### PR TITLE
windows: remove unneeded lib checks

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -9,9 +9,7 @@ if (PHP_PARALLEL != 'no') {
 
 		if(CHECK_HEADER_ADD_INCLUDE("pthread.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname) &&    
 			CHECK_HEADER_ADD_INCLUDE("sched.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname) &&
-			CHECK_LIB("pthreadVC2.lib", "parallel", PHP_PARALLEL) &&
-			CHECK_LIB("ws2_32.lib", "parallel", PHP_PARALLEL) &&
-			CHECK_LIB("Iphlpapi.lib", "parallel", PHP_PARALLEL)) {
+			CHECK_LIB("pthreadVC2.lib", "parallel", PHP_PARALLEL)) {
 			EXTENSION("parallel", "php_parallel.c", PHP_PARALLEL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname);
 			ADD_SOURCES(
 				configure_module_dirname + "/src",


### PR DESCRIPTION
ws2_32 (Winsock2) and Iphlpapi (IP helper API) appear not to be needed here due to the lack of anything socket or internet related.