### PR TITLE
Emphasize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ Hello World
 $runtime = new \parallel\Runtime();
 
 $future = $runtime->run(function(){
-    for ($i = 0; $i < 500; $i++)
-        echo "*";
-
+	for ($i = 0; $i < 500; $i++) {
+		usleep(rand(1, 1000));
+		echo "*";
+	}
     return "easy";
 });
 
 for ($i = 0; $i < 500; $i++) {
-    echo ".";
+	usleep(rand(1, 1000));
+	echo ".";
 }
 
 printf("\nUsing \\parallel\\Runtime is %s\n", $future->value());


### PR DESCRIPTION
On a fast processor the example did mostly result in "." followed by
"*". Adding a random delay makes it explicit the echo's are executed in
parallel. This minimizes the the probability of the scheduler causing the example appearing to execute in serial. 