### PR TITLE
fix #112: broken type hinting with opcache

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -106,11 +106,14 @@ zend_string* php_parallel_copy_string(zend_string *source, zend_bool persistent)
 }
 
 zend_class_entry* php_parallel_copy_scope(zend_class_entry *class) {
-    zend_class_entry *scope;
+    zend_class_entry *scope, *exists_ce;
 
 #ifdef ZEND_ACC_IMMUTABLE
     if (class->ce_flags & ZEND_ACC_IMMUTABLE) {
-        return class;
+        exists_ce = zend_lookup_class_ex(class->name, NULL, ZEND_FETCH_CLASS_NO_AUTOLOAD);
+        if (exists_ce) {
+            return class;
+        }
     }
 #endif
 

--- a/tests/base/062.bootstrap.inc
+++ b/tests/base/062.bootstrap.inc
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types = 1);
+
+class EnvWrap
+{
+    private EnvDto $env;
+
+    public function __construct($env)
+    {
+        $this->env = $env;
+    }
+
+    public function getEnv(): EnvDto
+    {
+        return $this->env;
+    }
+}
+
+spl_autoload_register(static function ($fcqn) {
+    if ('EnvDto' === $fcqn) {
+        require sprintf('%s/062.immutable.inc', __DIR__);
+    }
+});

--- a/tests/base/062.immutable.inc
+++ b/tests/base/062.immutable.inc
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+class EnvDto
+{
+    private string $name;
+
+    public function __construct($name)
+    {
+        $this->name      = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/base/062.phpt
+++ b/tests/base/062.phpt
@@ -5,6 +5,9 @@ parallel immutable class load
 if (!extension_loaded('parallel')) {
 	die("skip parallel not loaded");
 }
+if (!version_compare(PHP_VERSION, "7.4", ">=")) {
+    die("skip php 7.4 required");
+}
 ?>
 --FILE--
 <?php

--- a/tests/base/062.phpt
+++ b/tests/base/062.phpt
@@ -1,0 +1,26 @@
+--TEST--
+parallel immutable class load
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	die("skip parallel not loaded");
+}
+?>
+--FILE--
+<?php
+declare(strict_types = 1);
+
+use parallel\Runtime;
+
+$bootstrapFile = sprintf('%s/062.bootstrap.inc', __DIR__);
+include_once $bootstrapFile;
+
+$rt = new Runtime($bootstrapFile);
+$params = new EnvWrap(new EnvDto('ok'));
+
+$rt->run(static function (EnvWrap $params) {
+    echo $params->getEnv()->getName();
+}, [$params]);
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
Opcache optimizer marks some classes `ZEND_ACC_IMMUTABLE` (see [UPGRADING.INTERNALS [139:151]](https://github.com/php/php-src/blob/PHP-7.4.4/UPGRADING.INTERNALS#L139-L151)) in [zend_persist.c [709:715]](https://github.com/php/php-src/blob/e2b5f18896ca4169859c8ca058a9926aad6e3763/ext/opcache/zend_persist.c#L709-L715) and they are not in process memory.

This problem appears in `zend_check_type` [zend_execute.c [1033]](https://github.com/php/php-src/blob/e2b5f18896ca4169859c8ca058a9926aad6e3763/Zend/zend_execute.c#L1033) because `zend_fetch_class` with `ZEND_FETCH_CLASS_NO_AUTOLOAD` on immutable class returns NULL. `CG(class_table)` does not contain record for the required FCQN.

Three solution to solve this issue:
 - check if `zend_fetch_class` w/o autoload returns NULL and call `zend_fetch_class` with autoload. (this PR)
 - use preload functionality of opcache and `opcache_compile_file` for all missed in process memory immutable classes. (but there is an additional problem: opcache uses separate shared memory for all threads and `opcache_compile_file` everytime will be triggered for each thread bootstrap)
 - or completely delete the lines with `#ifdef ZEND_ACC_IMMUTABLE` in [copy.c ](https://github.com/krakjoe/parallel/pull/130/commits/169efdf58e0b40e8cafd2a4ff9ef286568a55d6f#diff-70f7ceeb39f0a1d58bdc83bfd1dd25d1R111-R118)