### PR TITLE
Fix crash with opcache

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -241,7 +241,7 @@ static zend_always_inline zend_bool php_parallel_scheduler_pop(php_parallel_runt
         &el->frame->func->op_array,
         head->frame->return_value);
 
-    Z_PTR(el->frame->This) = Z_PTR(head->frame->This);
+    php_parallel_scheduler_future = Z_PTR(head->frame->This);
 
     zend_llist_del_element(
         &runtime->schedule,
@@ -252,9 +252,7 @@ static zend_always_inline zend_bool php_parallel_scheduler_pop(php_parallel_runt
 }
 
 static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_execute_data *frame) {
-    php_parallel_future_t *future = 
-        php_parallel_scheduler_future = 
-            (php_parallel_future_t*) Z_PTR(frame->This);
+    php_parallel_future_t *future = php_parallel_scheduler_future;
 
     zend_first_try {
         zend_try {


### PR DESCRIPTION
I'll removed attaching `parallel\Future` to `execute_data->This`, because PHP taking `zend_class_entry` from there while autoloading (via `zend_get_called_scope`).

This fixes issues: #109, #110, #119, #124, #132 but only with opcache enabled, also i recommend use it with PR #130.