### PR TITLE
Update INSTALL.md to require php 8

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 Requirements
 ============
 
-  * PHP 7.2+
+  * PHP 8.0
   * ZTS
   * <pthread.h>
 


### PR DESCRIPTION
I see about a month ago you dropped support for php 7. INSTALL.md seems to have been forgotten.