### PR TITLE
HAVE_BUILTIN_ATOMIC conflict with fpm/config.m4 

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -33,7 +33,7 @@ if test "$PHP_PARALLEL" != "no"; then
     return (__atomic_add_fetch(&variable, 1, __ATOMIC_SEQ_CST)) ? 1 : 0;
   ]])], [
     AC_MSG_RESULT([yes])
-    AC_DEFINE(HAVE_BUILTIN_ATOMIC, 1, [Define to 1 if supports __atomic_add_fetch()])
+    AC_DEFINE(HAVE_BUILTIN_ATOMIC_CPP11, 1, [Define to 1 if supports __atomic_add_fetch()])
   ], [
     AC_MSG_RESULT([no])
   ])

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -87,7 +87,7 @@ static zend_always_inline void php_parallel_cond_destroy(pthread_cond_t *cond) {
 static zend_always_inline void php_parallel_atomic_addref(uint32_t *refcount) {
 #ifdef _WIN32
     InterlockedAdd(refcount, 1);
-#elif defined(HAVE_BUILTIN_ATOMIC)
+#elif defined(HAVE_BUILTIN_ATOMIC_CPP11)
     __atomic_add_fetch(refcount, 1, __ATOMIC_SEQ_CST);
 #else
     __sync_add_and_fetch(refcount, 1);
@@ -97,7 +97,7 @@ static zend_always_inline void php_parallel_atomic_addref(uint32_t *refcount) {
 static zend_always_inline uint32_t php_parallel_atomic_delref(uint32_t *refcount) {
 #ifdef _WIN32
     return InterlockedAdd(refcount, -1);
-#elif defined(HAVE_BUILTIN_ATOMIC)
+#elif defined(HAVE_BUILTIN_ATOMIC_CPP11)
     return __atomic_sub_fetch(refcount, 1, __ATOMIC_SEQ_CST);
 #else
     return __sync_sub_and_fetch(refcount, 1);


### PR DESCRIPTION
In file sapi/fpm/config.m4, using old __sync_ series to define HAVE_BUILTIN_ATOMIC