### PR TITLE
Adopt pthread4w 3 for windows config.w32

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -2,24 +2,59 @@
 ARG_WITH('parallel', 'parallel support', 'no');
 
 if (PHP_PARALLEL != 'no') {
-	if (PHP_ZTS == "no") {
-		WARNING("Parallel extension requires ZTS build of PHP on windows");
-	} else if (PHP_VERSION < 8) {
-		WARNING("Parallel requires PHP8.0+");
-	} else {
-		AC_DEFINE('HAVE_PARALLEL', 1, 'parallel support enabled');
-
-		if(CHECK_HEADER_ADD_INCLUDE("pthread.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname) &&    
-			CHECK_HEADER_ADD_INCLUDE("sched.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname) &&
-			CHECK_LIB("pthreadVC2.lib", "parallel", PHP_PARALLEL)) {
-			EXTENSION("parallel", "php_parallel.c", PHP_PARALLEL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname);
-			ADD_SOURCES(
-				configure_module_dirname + "/src",
-				"exceptions.c copy.c check.c dependencies.c cache.c monitor.c parallel.c runtime.c scheduler.c future.c channel.c link.c handlers.c events.c poll.c loop.c event.c input.c sync.c",
-				"parallel"
-			);
-		} else {
-			WARNING("parallel not enabled; pthread libraries and headers not found");
+	do {
+		// check if zts enabled
+		if (PHP_ZTS == "no") {
+			WARNING("Parallel extension requires ZTS build of PHP on windows");
+			break;
 		}
-	}
+
+		// check if PHP 8+
+		if (PHP_VERSION < 8) {
+			WARNING("Parallel requires PHP8.0+");
+			break;
+		}
+
+		// check headers
+		if (
+			!CHECK_HEADER_ADD_INCLUDE("pthread.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname) ||
+			!CHECK_HEADER_ADD_INCLUDE("sched.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname)
+		) {
+			WARNING("parallel not enabled; pthread headers not found");
+			break;
+		}
+
+		// check libraries
+		var libNames = [
+			'libpthreadVC',
+			'libpthreadGC',
+			'pthreadVC'
+		];
+		var libName = null;
+		for (var i in libNames) {
+			var l = libNames[i] + '3.lib';
+			if (CHECK_LIB(l)) {
+				libName = l;
+				break;
+			}
+			l = libNames[i] + '2.lib';
+			if (CHECK_LIB(l)) {
+				libName = l;
+				break;
+			}
+		}
+		if (libName == null) {
+			WARNING("parallel not enabled; pthread libraries not found");
+			break;
+		}
+
+		// register extension
+		AC_DEFINE('HAVE_PARALLEL', 1, 'parallel support enabled');
+		EXTENSION("parallel", "php_parallel.c", PHP_PARALLEL_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname);
+		ADD_SOURCES(
+			configure_module_dirname + "/src",
+			"exceptions.c copy.c check.c dependencies.c cache.c monitor.c parallel.c runtime.c scheduler.c future.c channel.c link.c handlers.c events.c poll.c loop.c event.c input.c sync.c",
+			"parallel"
+		);
+	} while (false);
 }

--- a/config.w32
+++ b/config.w32
@@ -2,17 +2,17 @@
 ARG_WITH('parallel', 'parallel support', 'no');
 
 if (PHP_PARALLEL != 'no') {
-	do {
+	(function () {
 		// check if zts enabled
 		if (PHP_ZTS == "no") {
 			WARNING("Parallel extension requires ZTS build of PHP on windows");
-			break;
+			return;
 		}
 
 		// check if PHP 8+
 		if (PHP_VERSION < 8) {
 			WARNING("Parallel requires PHP8.0+");
-			break;
+			return;
 		}
 
 		// check headers
@@ -21,7 +21,7 @@ if (PHP_PARALLEL != 'no') {
 			!CHECK_HEADER_ADD_INCLUDE("sched.h", "CFLAGS_PARALLEL", PHP_PARALLEL + ";" + configure_module_dirname)
 		) {
 			WARNING("parallel not enabled; pthread headers not found");
-			break;
+			return;
 		}
 
 		// check libraries
@@ -45,7 +45,7 @@ if (PHP_PARALLEL != 'no') {
 		}
 		if (libName == null) {
 			WARNING("parallel not enabled; pthread libraries not found");
-			break;
+			return;
 		}
 
 		// register extension
@@ -56,5 +56,5 @@ if (PHP_PARALLEL != 'no') {
 			"exceptions.c copy.c check.c dependencies.c cache.c monitor.c parallel.c runtime.c scheduler.c future.c channel.c link.c handlers.c events.c poll.c loop.c event.c input.c sync.c",
 			"parallel"
 		);
-	} while (false);
+	})();
 }


### PR DESCRIPTION
default library is libpthreadVC3.lib, this may trig a `LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library` warning at building, but this will make parallel donot need pthreadXXX.dll