### PR TITLE
Add support for ZEND_ACC_NOT_SERIALIZABLE flag

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -383,8 +383,12 @@ PHP_MINIT_FUNCTION(PARALLEL_CHANNEL)
     php_parallel_channel_ce->create_object = php_parallel_channel_create;
     php_parallel_channel_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_channel_ce->serialize = zend_class_serialize_deny;
-    php_parallel_channel_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_channel_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_channel_ce->serialize = zend_class_serialize_deny;
+        php_parallel_channel_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     zend_declare_class_constant_long(php_parallel_channel_ce, ZEND_STRL("Infinite"), -1);
 

--- a/src/events.c
+++ b/src/events.c
@@ -270,8 +270,12 @@ PHP_MINIT_FUNCTION(PARALLEL_EVENTS)
     php_parallel_events_ce->get_iterator  = php_parallel_events_loop_create;
     php_parallel_events_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_events_ce->serialize = zend_class_serialize_deny;
-    php_parallel_events_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_events_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_events_ce->serialize = zend_class_serialize_deny;
+        php_parallel_events_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     zend_class_implements(php_parallel_events_ce, 1, zend_ce_countable);
 

--- a/src/future.c
+++ b/src/future.c
@@ -299,8 +299,12 @@ PHP_MINIT_FUNCTION(PARALLEL_FUTURE)
     php_parallel_future_ce->create_object = php_parallel_future_create;
     php_parallel_future_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_future_ce->serialize = zend_class_serialize_deny;
-    php_parallel_future_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_future_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_future_ce->serialize = zend_class_serialize_deny;
+        php_parallel_future_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     php_parallel_future_string_runtime = zend_string_init_interned(ZEND_STRL("runtime"), 1);
 

--- a/src/input.c
+++ b/src/input.c
@@ -195,8 +195,12 @@ PHP_MINIT_FUNCTION(PARALLEL_EVENTS_INPUT)
     php_parallel_events_input_ce->create_object = php_parallel_events_input_create;
     php_parallel_events_input_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_events_input_ce->serialize = zend_class_serialize_deny;
-    php_parallel_events_input_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_events_input_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_events_input_ce->serialize = zend_class_serialize_deny;
+        php_parallel_events_input_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     return SUCCESS;
 }

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -158,8 +158,12 @@ PHP_MINIT_FUNCTION(PARALLEL_RUNTIME)
     php_parallel_runtime_ce->create_object = php_parallel_runtime_create;
     php_parallel_runtime_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_runtime_ce->serialize = zend_class_serialize_deny;
-    php_parallel_runtime_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_runtime_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_runtime_ce->serialize = zend_class_serialize_deny;
+        php_parallel_runtime_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     PHP_MINIT(PARALLEL_FUTURE)(INIT_FUNC_ARGS_PASSTHRU);
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -312,8 +312,12 @@ PHP_MINIT_FUNCTION(PARALLEL_SYNC)
     php_parallel_sync_ce->create_object = php_parallel_sync_object_create;
     php_parallel_sync_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    php_parallel_sync_ce->serialize = zend_class_serialize_deny;
-    php_parallel_sync_ce->unserialize = zend_class_unserialize_deny;
+    #ifdef ZEND_ACC_NOT_SERIALIZABLE
+        php_parallel_sync_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+    #else
+        php_parallel_sync_ce->serialize = zend_class_serialize_deny;
+        php_parallel_sync_ce->unserialize = zend_class_unserialize_deny;
+    #endif
 
     php_parallel_sync_string_value = zend_string_init_interned(ZEND_STRL("value"), 1);
 


### PR DESCRIPTION
This PR adds support for `ZEND_ACC_NOT_SERIALIZABLE` that was introduced by [php/php-src@814a932](https://github.com/php/php-src/commit/814a9327348b63ac15008c873f210e798d19fa26).

From Nikita's commit:

> This prevents serialization and unserialization of a class and its
> children in a way that does not depend on the zend_class_serialize_deny
> and zend_class_unserialize_deny handlers that will be going away
> in PHP 9 together with the Serializable interface.