### PR TITLE
expand ci

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -5,12 +5,15 @@ jobs:
     strategy:
       matrix:
           version: ["8.0", "8.1", "8.2"]
+          debug: ["enable", "disable"]
+          opcache: ["enable", "disable"]
     runs-on: ubuntu-latest
+    name: Linux, PHP v${{matrix.version}}, ${{matrix.debug}}-debug, ${{matrix.opcache}}-opcache
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup PHP
-        run: docker-compose build php-${{matrix.version}}
+        run: docker-compose build --build-arg PHP_SRC_DEBUG=${{matrix.debug}} --build-arg PHP_SRC_OPCACHE=${{matrix.opcache}} php-${{matrix.version}}
       - name: Setup parallel
         run: docker-compose build parallel-${{matrix.version}}
       - name: Test parallel
@@ -25,6 +28,7 @@ jobs:
           arch: [x64]
           ts: [ts]
     runs-on: windows-latest
+    name: Windows, PHP v${{matrix.version}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,13 @@ x-aliases:
       tty: true
       volumes:
         - .:/opt/parallel
+      working_dir: /opt/parallel
   - &build
       context: .
       args:
         - PHP_SRC_TYPE
         - PHP_SRC_DEBUG
+        - PHP_SRC_OPCACHE
         - PHP_VERSION_MAJOR
         - PHP_VERSION_MINOR
         - PHP_VERSION_PATCH
@@ -33,12 +35,12 @@ services:
         UBUNTU_VERSION_MINOR: "04",
         PHP_SRC_TYPE:         dist,
         PHP_SRC_DEBUG:        enable,
+        PHP_SRC_OPCACHE:      disable,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    0,
         PHP_VERSION_PATCH:    23,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  php-dist-8.0.23,
     image:           php-dist-8.0.23:parallel,
     <<: *dev
@@ -54,7 +56,6 @@ services:
         PHP_VERSION_PATCH:    23,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  parallel-dist-8.0.23,
     image:           parallel-dist-8.0.23:latest,
     depends_on:      [php-8.0],
@@ -68,12 +69,12 @@ services:
         UBUNTU_VERSION_MINOR: "04",
         PHP_SRC_TYPE:         dist,
         PHP_SRC_DEBUG:        enable,
+        PHP_SRC_OPCACHE:      disable,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    1,
         PHP_VERSION_PATCH:    11,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  php-dist-8.1.11,
     image:           php-dist-8.1.11:parallel,
     <<: *dev
@@ -89,7 +90,6 @@ services:
         PHP_VERSION_PATCH:    11,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  parallel-dist-8.1.11,
     image:           parallel-dist-8.1.11:latest,
     depends_on:      [php-8.1],
@@ -103,13 +103,13 @@ services:
         UBUNTU_VERSION_MINOR: "04",
         PHP_SRC_TYPE:         git,
         PHP_SRC_DEBUG:        enable,
+        PHP_SRC_OPCACHE:      disable,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
         PHP_VERSION_PATCH:    0,
         PHP_VERSION_RC:       RC4,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  php-git-8.2.0,
     image:           php-git-8.2.0:parallel,
     <<: *dev
@@ -125,7 +125,6 @@ services:
         PHP_VERSION_PATCH:    0,
       }
     },
-    working_dir:     /opt/parallel,
     container_name:  parallel-git-8.2.0,
     image:           parallel-git-8.2.0:latest,
     depends_on:      [php-8.2],

--- a/docker/parallel.test
+++ b/docker/parallel.test
@@ -11,5 +11,6 @@ export REPORT_EXIT_STATUS=1
 
 php $PHP_RUN_TESTS                          \
     -P                                      \
+    -d opcache.jit_buffer_size=32M          \
     -g FAIL,XFAIL,XLEAK,SKIP,BORK,LEAK      \
     --show-diff

--- a/docker/php.dockerfile
+++ b/docker/php.dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:$UBUNTU_VERSION_MAJOR.$UBUNTU_VERSION_MINOR
 
 ARG PHP_SRC_TYPE
 ARG PHP_SRC_DEBUG
+ARG PHP_SRC_OPCACHE
 ARG PHP_VERSION_MAJOR
 ARG PHP_VERSION_MINOR
 ARG PHP_VERSION_PATCH
@@ -24,12 +25,13 @@ RUN /opt/bin/php.src $PHP_SRC_TYPE $PHP_VERSION_MAJOR $PHP_VERSION_MINOR $PHP_VE
 
 WORKDIR /opt/src/php-src
 
-RUN ./buildconf --force >/dev/null 2>/dev/null
+RUN ./buildconf --force
 
 RUN ./configure --disable-all \
                 --disable-cgi \
                 --disable-phpdbg \
                 --$PHP_SRC_DEBUG-debug \
+                --$PHP_SRC_OPCACHE-opcache \
                 --enable-zts \
                 --prefix=/opt \
                 --with-config-file-scan-dir=/etc/php.d \
@@ -44,6 +46,10 @@ RUN cp php.ini-development /etc/php.ini
 RUN mkdir -p /etc/php.d
 
 ENV PATH=/opt/bin:$PATH
+
+RUN test $PHP_SRC_OPCACHE = "disable" || \
+        echo "zend_extension=opcache.so" > /etc/php.d/opcache.ini && \
+        echo "opcache.enable_cli=1"     >> /etc/php.d/opcache.ini
 
 RUN php -v
 

--- a/docker/php.src
+++ b/docker/php.src
@@ -3,7 +3,7 @@
 case $1 in
     dist)
         wget https://www.php.net/distributions/php-$2.$3.$4.tar.gz \
-            -O /opt/src/php-$2.$3.$4$5.tar.gz > /dev/null
+            -O /opt/src/php-$2.$3.$4$5.tar.gz
         tar -C /opt/src -xf opt/src/php-$2.$3.$4$5.tar.gz
         ln -s /opt/src/php-$2.$3.$4$5 /opt/src/php-src
     ;;


### PR DESCRIPTION
This expands Linux CI to include release and debug (previously and by default only debug), and opcache (JIT) enabled builds (previously and by default disabled).