### PR TITLE
Fix GH-205: segmentation fault when creating a sync class

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -86,7 +86,7 @@ void php_parallel_sync_release(php_parallel_sync_t *sync) {
 static zend_object* php_parallel_sync_object_create(zend_class_entry *ce) {
     php_parallel_sync_object_t *object =
         (php_parallel_sync_object_t*)
-            ecalloc(1, sizeof(php_parallel_sync_t) + zend_object_properties_size(ce));
+            ecalloc(1, sizeof(php_parallel_sync_object_t) + zend_object_properties_size(ce));
 
     zend_object_std_init(&object->std, ce);
 

--- a/tests/sync/006.phpt
+++ b/tests/sync/006.phpt
@@ -1,0 +1,17 @@
+--TEST--
+GH-205 (segmentation fault when creating a sync class)
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+$a = [];
+
+for($i = 0; $i < 100; $i++){
+	$a[] = new \parallel\Sync(false);
+}
+?>
+--EXPECT--


### PR DESCRIPTION
We need to allocate sufficient memory for the desired object.