### PR TITLE
Make parallel compile with upcoming PHP 8.4

### DIFF
--- a/src/poll.c
+++ b/src/poll.c
@@ -20,7 +20,11 @@
 
 #include "parallel.h"
 
+#if PHP_VERSION_ID >= 80400
+#include "ext/random/php_random.h"
+#else
 #include "ext/standard/php_mt_rand.h"
+#endif
 
 typedef struct _php_parallel_events_poll_t {
     struct timeval stop;


### PR DESCRIPTION
Hey there 👋 

this PR makes `ext-parallel` compile with the upcoming PHP 8.4.

Kind regards
Florian

Fixes #286