### PR TITLE
fix compile issue with PHP 8.2 and 8.3 on 32 bit hardware

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -244,7 +244,9 @@ static zend_op_array* php_parallel_cache_create(const zend_function *source, zen
                 case ZEND_FAST_CALL:
                     opline->op1.jmp_addr = &opcodes[opline->op1.jmp_addr - source->op_array.opcodes];
                 break;
+#if PHP_VERSION_ID < 80200
                 case ZEND_JMPZNZ:
+#endif
                 case ZEND_JMPZ:
                 case ZEND_JMPNZ:
                 case ZEND_JMPZ_EX:


### PR DESCRIPTION
In PHP 8.2 the `JMPZNZ` opcode was removed with https://github.com/php/php-src/pull/7857

fixes #283