### PR TITLE
Update PHP 8.2.0RC5 to 8.2.19

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ["8.0", "8.1"]
+          version: ["8.0", "8.1", "8.2"]
           arch: [x64]
           ts: [ts]
     if: success() || failure()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,11 +255,11 @@ services:
         PHP_SRC_TYPE:         git,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  php-dbg-8.2,
-    image:           ghcr.io/krakjoe/php-dbg-8.2:8.2.0,
+    image:           ghcr.io/krakjoe/php-dbg-8.2:8.2.19,
     profiles:        [php-8.2,dbg],
     <<: [*dev, *parallel]
   }
@@ -271,11 +271,11 @@ services:
         PHP_SRC_GCOV:         enable,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  php-gcov-8.2,
-    image:           ghcr.io/krakjoe/php-gcov-8.2:8.2.0,
+    image:           ghcr.io/krakjoe/php-gcov-8.2:8.2.19,
     profiles:        [php-8.2,gcov],
     <<: [*dev, *parallel]
   }
@@ -287,11 +287,11 @@ services:
         PHP_SRC_TYPE:         git,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  php-asan-8.2,
-    image:           ghcr.io/krakjoe/php-asan-8.2:8.2.0,
+    image:           ghcr.io/krakjoe/php-asan-8.2:8.2.19,
     profiles:        [php-8.2,asan],
     <<: [*dev, *parallel]
   }
@@ -303,11 +303,11 @@ services:
         PHP_SRC_TYPE:         git,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  php-release-8.2,
-    image:           ghcr.io/krakjoe/php-release-8.2:8.2.0,
+    image:           ghcr.io/krakjoe/php-release-8.2:8.2.19,
     profiles:        [php-8.2,release],
     <<: [*dev, *parallel]
   }
@@ -319,7 +319,7 @@ services:
         PHP_SRC_TYPE:         dbg,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  parallel-dbg-8.2,
@@ -335,7 +335,7 @@ services:
         PHP_SRC_GCOV:         enable,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  parallel-gcov-8.2,
@@ -351,7 +351,7 @@ services:
         PHP_SRC_TYPE:         asan,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  parallel-asan-8.2,
@@ -367,7 +367,7 @@ services:
         PHP_SRC_TYPE:         release,
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    2,
-        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_PATCH:    19,
       }
     },
     container_name:  parallel-release-8.2,


### PR DESCRIPTION
This PR bumps PHP 8.2.0RC5 to 8.2.19 on GitHub workflow, nothing else.