### PR TITLE
Include php_random.h for PHP 8.2+

### DIFF
--- a/src/poll.c
+++ b/src/poll.c
@@ -20,7 +20,7 @@
 
 #include "parallel.h"
 
-#if PHP_VERSION_ID >= 80400
+#if PHP_VERSION_ID >= 80200
 #include "ext/random/php_random.h"
 #else
 #include "ext/standard/php_mt_rand.h"


### PR DESCRIPTION
ext/random was introduced in PHP 8.2 and starting with that version the new php_random.h is the recommended header. PHP 8.4 just removed the compatibility include.

see krakjoe/parallel#287