### PR TITLE
Make `request_info` from SAPI globals accessible in threads

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -128,6 +128,7 @@ zend_object* php_parallel_runtime_create(zend_class_entry *type) {
     php_parallel_scheduler_init(runtime);
 
     runtime->parent.server = SG(server_context);
+    runtime->parent.request_info = &SG(request_info);
 
     return &runtime->std;
 }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -15,6 +15,8 @@
   | Author: krakjoe                                                      |
   +----------------------------------------------------------------------+
  */
+#include "SAPI.h"
+
 #ifndef HAVE_PARALLEL_RUNTIME_H
 #define HAVE_PARALLEL_RUNTIME_H
 
@@ -32,6 +34,7 @@ typedef struct _php_parallel_runtime_t {
     } child;
     struct {
         void                        *server;
+        sapi_request_info           *request_info;
     } parent;
     zend_llist                       schedule;
     zend_object                      std;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -83,6 +83,7 @@ static zend_always_inline php_parallel_runtime_t* php_parallel_scheduler_setup(p
     TSRMLS_CACHE_UPDATE();
 
     SG(server_context) = runtime->parent.server;
+    SG(request_info)   = *runtime->parent.request_info;
 
     runtime->child.interrupt = &EG(vm_interrupt);
 

--- a/tests/base/070.phpt
+++ b/tests/base/070.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SAPI globals
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	die("skip parallel not loaded");
+}
+?>
+--FILE--
+<?php
+var_dump($_SERVER['argc']);
+\parallel\run(function(){
+    var_dump($_SERVER['argc']);
+});
+?>
+--EXPECT--
+int(1)
+int(1)


### PR DESCRIPTION
This PR aims to make the `request_info` from the SAPI globals accessible from the spawned threads. So far the `request_info`(accessed via `SG(request_info)` is a `NULL`-pointer which means that extensions do not have any information about the initial request that started this process.