### PR TITLE
Update Windows CI workflow for PHP 8.4

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,8 @@ jobs:
           ts: ${{matrix.ts}}
       - name: Fetch dependencies
         run: |
-          curl -LO https://windows.php.net/downloads/pecl/deps/pthreads-2.11.0-vs16-${{matrix.arch}}.zip
-          7z x pthreads-2.11.0-vs16-${{matrix.arch}}.zip -o..\deps
+          curl -LO https://downloads.php.net/~windows/pecl/deps/pthreads-3.0.0-vs16-${{matrix.arch}}.zip
+          7z x pthreads-3.0.0-vs16-${{matrix.arch}}.zip -o..\deps
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
           arch: [x64]
           ts: [ts]
     if: success() || failure()
@@ -15,10 +15,10 @@ jobs:
     name: Windows, PHP v${{matrix.version}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.8
+        uses: php/setup-php-sdk@v0.9
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}
@@ -55,7 +55,7 @@ jobs:
           copy ..\deps\COPYING .install\COPYING.PTHREADS
           copy ..\deps\bin\* .install
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: parallel-${{matrix.version}}
           path: .install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
           arch: [x64]
           ts: [ts]
     if: success() || failure()
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: Windows, PHP v${{matrix.version}}
     steps:
       - name: Checkout


### PR DESCRIPTION
We also update to the latest actions:

* setup-php-sdk v9 is required for PHP 8.4 support
* actions/checkout v4 and actions/upload-artifact v4 are not deprecated

---

Not sure whether the uploaded artifacts still make sense. That might have been added since until recently DLLs have not been shown on https://pecl.php.net/package/parallel. On the other hand, these artifacts may be helpful for Windows users testing a bug fix or new feature. 