### PR TITLE
fix refcounts to make `develop` stable

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -188,6 +188,8 @@ static zend_always_inline HashTable* php_parallel_copy_hash_persistent_inline(
             context, source, ht);
     }
 
+    // see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
+    // TODO: needs fixing
     GC_SET_REFCOUNT(ht, 2);
     GC_SET_PERSISTENT_TYPE(ht, GC_ARRAY);
     GC_ADD_FLAGS(ht, IS_ARRAY_IMMUTABLE);
@@ -374,6 +376,8 @@ HashTable *php_parallel_copy_hash_persistent(HashTable *source,
 }
 
 void php_parallel_copy_hash_dtor(HashTable *table, zend_bool persistent) {
+    // see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
+    // TODO: needs fixing
     if (GC_DELREF(table) == (persistent ? 1 : 0)) {
         if (!persistent) {
             GC_REMOVE_FROM_BUFFER(table);

--- a/src/copy.c
+++ b/src/copy.c
@@ -188,7 +188,7 @@ static zend_always_inline HashTable* php_parallel_copy_hash_persistent_inline(
             context, source, ht);
     }
 
-    GC_SET_REFCOUNT(ht, 1);
+    GC_SET_REFCOUNT(ht, 2);
     GC_SET_PERSISTENT_TYPE(ht, GC_ARRAY);
     GC_ADD_FLAGS(ht, IS_ARRAY_IMMUTABLE);
 
@@ -374,7 +374,7 @@ HashTable *php_parallel_copy_hash_persistent(HashTable *source,
 }
 
 void php_parallel_copy_hash_dtor(HashTable *table, zend_bool persistent) {
-    if (GC_DELREF(table) == 0) {
+    if (GC_DELREF(table) == (persistent ? 1 : 0)) {
         if (!persistent) {
             GC_REMOVE_FROM_BUFFER(table);
             GC_TYPE_INFO(table) =

--- a/tests/functional/008.phpt
+++ b/tests/functional/008.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Check array literal copying into threads
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+$run = function() {
+    $a = [];
+    for ($i = 0; $i < 100000; $i++) {
+        $b = &$a[$i];
+    }
+    return 0;
+};
+
+for ($i = 0; $i < 10; $i++) {
+    $futures[$i] = \parallel\run($run, []);
+}
+
+for ($i = 0; $i < 10; $i++) {
+    var_dump($futures[$i]->value());
+}
+?>
+--EXPECT--
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)
+int(0)


### PR DESCRIPTION
Based on @arnaud-lb's [comment](https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880) I decided to revert the refcounts for array. This is not in line with the rest that happens there, but it makes `develop` stable again. Once I do fully understand what is going on, I'll cleanup things 