### PR TITLE
fix memleak / crashes

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -218,7 +218,11 @@ static void php_parallel_scheduler_pull(zend_function *function) {
         }
     }
 
+#if PHP_VERSION_ID < 80200
     ZEND_MAP_PTR_NEW(function->op_array.run_time_cache);
+#else
+    ZEND_MAP_PTR_INIT(function->op_array.run_time_cache, NULL);
+#endif
 
 #if PHP_VERSION_ID >= 80100
     if (function->op_array.num_dynamic_func_defs) {


### PR DESCRIPTION
Should fix #316 

I need to understand this a bit more. The [hint](https://github.com/krakjoe/parallel/issues/316#issuecomment-2417278746) from @arnaud-lb works from PHP 8.2, 8.3 and 8.4-rc but fails in PHP 8.1. 
Switching from `ZEND_MAP_PTR_NEW` to `ZEND_MAP_PTR_INIT(function->op_array.run_time_cache, NULL)` makes PHP 8.0 and 8.1 segfault in the tests