### PR TITLE
Fix/update Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,20 +53,20 @@ jobs:
         run: nmake test TESTS="--show-diff tests"
       - name: package
         run: |
-          md ..\install
-          copy LICENSE ..\install
-          copy README.md ..\install
+          md win-install
+          copy LICENSE win-install
+          copy README.md win-install
           if exist x64 (
             if exist x64\Release (set prefix=x64\Release) else set prefix=x64\Release_TS
           ) else (
             if exist Release (set prefix=Release) else set prefix=Release_TS
           )
-          copy %prefix%\php_parallel.dll ..\install
-          copy %prefix%\php_parallel.pdb ..\install
-          copy ..\deps\COPYING ..\install\COPYING.PTHREADS
-          copy ..\deps\bin\* ..\install
+          copy %prefix%\php_parallel.dll win-install
+          copy %prefix%\php_parallel.pdb win-install
+          copy ..\deps\COPYING win-install\COPYING.PTHREADS
+          copy ..\deps\bin\* win-install
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: parallel-${{matrix.version}}
-          path: ..\install
+          path: win-install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,20 +52,20 @@ jobs:
         run: nmake test TESTS="--show-diff tests"
       - name: package
         run: |
-          md .install
-          copy LICENSE .install
-          copy README.md .install
+          md ..\install
+          copy LICENSE ..\install
+          copy README.md ..\install
           if exist x64 (
             if exist x64\Release (set prefix=x64\Release) else set prefix=x64\Release_TS
           ) else (
             if exist Release (set prefix=Release) else set prefix=Release_TS
           )
-          copy %prefix%\php_parallel.dll .install
-          copy %prefix%\php_parallel.pdb .install
-          copy ..\deps\COPYING .install\COPYING.PTHREADS
-          copy ..\deps\bin\* .install
+          copy %prefix%\php_parallel.dll ..\install
+          copy %prefix%\php_parallel.pdb ..\install
+          copy ..\deps\COPYING ..\install\COPYING.PTHREADS
+          copy ..\deps\bin\* ..\install
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: parallel-${{matrix.version}}
-          path: .install
+          path: ..\install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,11 +28,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup PHP
         id: setup-php
-        uses: php/setup-php-sdk@v0.9
+        uses: php/setup-php-sdk@v0.10
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
+          cache: true
       - name: Fetch dependencies
         run: |
           curl -LO https://downloads.php.net/~windows/pecl/deps/pthreads-3.0.0-vs16-${{matrix.arch}}.zip


### PR DESCRIPTION
This should fix the build artifact upload which is broken as of 10e43f1eaf8c698a0758d428a4d19e1f17b0df2f (sorry, my bad). It should also use the caches of this repository to speed up the setup of the PHP SDK.
