### PR TITLE
Add building of windows binaries to GitHub releases

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -40,4 +40,5 @@ jobs:
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
           ts: ${{ matrix.ts }}
-          args: --enable-parallel
+          args: --with-parallel
+          libs: pthreads

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,10 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Fetch dependencies
-        run: |
-          curl -LO https://downloads.php.net/~windows/pecl/deps/pthreads-3.0.0-vs16-${{matrix.arch}}.zip
-          7z x pthreads-3.0.0-vs16-${{matrix.arch}}.zip -- -o..\deps
       - name: Build the extension
         uses: php/php-windows-builder/extension@v1
         with:

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,43 @@
+name: Publish Windows Releases
+on:
+  pull_request: null
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  get-extension-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.extension-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get the extension matrix
+        id: extension-matrix
+        uses: php/php-windows-builder/extension-matrix@v1
+        with:
+          php-version-list: '8.0, 8.1, 8.2, 8.3, 8.4'
+          arch-list: 'x64, x86'
+          ts-list: 'ts'
+  build:
+    needs: get-extension-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJson(needs.get-extension-matrix.outputs.matrix)}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Fetch dependencies
+        run: |
+          curl -LO https://downloads.php.net/~windows/pecl/deps/pthreads-3.0.0-vs16-${{matrix.arch}}.zip
+          7z x pthreads-3.0.0-vs16-${{matrix.arch}}.zip -- -o..\deps
+      - name: Build the extension
+        uses: php/php-windows-builder/extension@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+          arch: ${{ matrix.arch }}
+          ts: ${{ matrix.ts }}
+          args: --enable-parallel

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,6 +1,5 @@
 name: Publish Windows Releases
 on:
-  pull_request: null
   release:
     types: [published]
 
@@ -38,3 +37,13 @@ jobs:
           ts: ${{ matrix.ts }}
           args: --with-parallel
           libs: pthreads
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'release' }}
+    steps:
+      - name: Upload artifact to the release
+        uses: php/php-windows-builder/release@v1
+        with:
+          release: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will add making Windows releases and magically add them to the GitHub release for https://github.com/php/pie to find them. Once this PR is merged and working, we should fully support pie