### PR TITLE
Crash less and allow more cyclomatic refs

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -370,11 +370,12 @@ zend_function* php_parallel_cache_closure(const zend_function *source, zend_func
         memcpy(closure, cache, sizeof(zend_op_array));
     }
 
-    if (closure->op_array.static_variables) {
+    if (source->op_array.static_variables) {
         HashTable *statics =
             ZEND_MAP_PTR_GET(
                 source->op_array.static_variables_ptr);
 
+        if (statics) {
         closure->op_array.static_variables =
             php_parallel_copy_hash_ctor(statics, 1);
 
@@ -387,7 +388,21 @@ zend_function* php_parallel_cache_closure(const zend_function *source, zend_func
             closure->op_array.static_variables_ptr,
             &closure->op_array.static_variables);
 #endif
+        }
     }
+
+#if PHP_VERSION_ID >= 80100
+    if (source->op_array.num_dynamic_func_defs) {
+        uint32_t it = 0;
+        closure->op_array.dynamic_func_defs = php_parallel_cache_copy_mem(
+            source->op_array.dynamic_func_defs,
+            sizeof(zend_op_array*) * source->op_array.num_dynamic_func_defs);
+        while (it < source->op_array.num_dynamic_func_defs) {
+            closure->op_array.dynamic_func_defs[it] = (zend_op_array*) php_parallel_cache_closure((zend_function*) source->op_array.dynamic_func_defs[it], NULL);
+            it++;
+        }
+    }
+#endif
 
     return closure;
 } /* }}} */

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -33,6 +33,8 @@ static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void
 static void php_parallel_schedule_free_function(zend_function *function) {
     if (function->op_array.static_variables) {
         php_parallel_copy_hash_dtor(function->op_array.static_variables, 1);
+        ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
+        function->op_array.static_variables = NULL;
     }
 
 #if PHP_VERSION_ID >= 80100
@@ -245,6 +247,8 @@ static void php_parallel_scheduler_clean(zend_function *function) {
 
         if (!(GC_FLAGS(statics) & IS_ARRAY_IMMUTABLE)) {
             zend_array_destroy(statics);
+            ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
+            function->op_array.static_variables = NULL;
         }
     }
 
@@ -254,8 +258,9 @@ static void php_parallel_scheduler_clean(zend_function *function) {
 
     	while (it < function->op_array.num_dynamic_func_defs) {
     	    php_parallel_scheduler_clean(
-               (zend_function*) function->op_array.dynamic_func_defs[it]);
-            it++;
+              (zend_function*) function->op_array.dynamic_func_defs[it]);
+          pefree(function->op_array.dynamic_func_defs[it],1);
+          it++;
     	}
     }
 #endif

--- a/tests/base/045.phpt
+++ b/tests/base/045.phpt
@@ -28,6 +28,3 @@ bool(true)
 bool(true)
 --XLEAK--
 The interrupt we use for cancellation is not treated in a thread safe way in core
-
-
-

--- a/tests/base/068.phpt
+++ b/tests/base/068.phpt
@@ -20,5 +20,5 @@ array(1) {
   ["self"]=>
   *RECURSION*
 }
---XFAIL--
+--XLEAK--
 REASON: no cyclic reference collector implemented yet

--- a/tests/base/069.phpt
+++ b/tests/base/069.phpt
@@ -24,5 +24,5 @@ object(Foo)#2 (1) {
   ["foo"]=>
   *RECURSION*
 }
---XFAIL--
+--XLEAK--
 REASON: no cyclic reference collector implemented yet

--- a/tests/base/071.phpt
+++ b/tests/base/071.phpt
@@ -1,0 +1,51 @@
+--TEST--
+parallel recursion in arrays in the closure
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+  die("skip parallel not loaded");
+}
+if (!version_compare(PHP_VERSION, "8.1", ">=")) {
+    die("skip php 8.1 required");
+}
+?>
+--FILE--
+<?php
+function transformChunk($n)
+{
+  $fibonacci = function ($n) use (&$fibonacci) {
+    if ($n == 0) {
+      return 0;
+    }
+    if ($n == 1) {
+      return 1;
+    }
+    return $fibonacci($n - 1) + $fibonacci($n - 2);
+  };
+  return $fibonacci($n);
+}
+
+$runtime = new \parallel\Runtime();
+$future = $runtime->run(
+  transformChunk(...),
+  [
+    10
+  ]
+);
+var_dump($future->value());
+
+$runtime = new \parallel\Runtime();
+$future = $runtime->run(
+  transformChunk(...),
+  [
+    10
+  ]
+);
+var_dump($future->value());
+
+?>
+--EXPECT--
+int(55)
+int(55)
+--XFAIL--
+heap-use-after-free

--- a/tests/base/071.phpt
+++ b/tests/base/071.phpt
@@ -47,5 +47,5 @@ var_dump($future->value());
 --EXPECT--
 int(55)
 int(55)
---XLEAK--
+--XFAIL--
 REASON: no cyclic reference collector implemented yet

--- a/tests/base/072-bootstrap.php
+++ b/tests/base/072-bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+function transformChunk($n)
+{
+  $fibonacci = function ($n) use (&$fibonacci) {
+    if ($n == 0) {
+      return 0;
+    }
+    if ($n == 1) {
+      return 1;
+    }
+    return $fibonacci($n - 1) + $fibonacci($n - 2);
+  };
+  return $fibonacci($n);
+}

--- a/tests/base/072.phpt
+++ b/tests/base/072.phpt
@@ -11,32 +11,23 @@ if (!version_compare(PHP_VERSION, "8.1", ">=")) {
 ?>
 --FILE--
 <?php
-function transformChunk($n)
-{
-  $fibonacci = function ($n) use (&$fibonacci) {
-    if ($n == 0) {
-      return 0;
-    }
-    if ($n == 1) {
-      return 1;
-    }
-    return $fibonacci($n - 1) + $fibonacci($n - 2);
-  };
-  return $fibonacci($n);
-}
 
-$runtime = new \parallel\Runtime();
+$app = function ($n) {
+  return transformChunk($n);
+};
+
+$runtime = new \parallel\Runtime(__DIR__.'/072-bootstrap.php');
 $future = $runtime->run(
-  transformChunk(...),
+  $app,
   [
     10
   ]
 );
 var_dump($future->value());
 
-$runtime = new \parallel\Runtime();
+$runtime = new \parallel\Runtime(__DIR__.'/072-bootstrap.php');
 $future = $runtime->run(
-  transformChunk(...),
+  $app,
   [
     10
   ]

--- a/tests/base/072.phpt
+++ b/tests/base/072.phpt
@@ -38,5 +38,5 @@ var_dump($future->value());
 --EXPECT--
 int(55)
 int(55)
---XLEAK--
+--XFAIL--
 REASON: no cyclic reference collector implemented yet


### PR DESCRIPTION
This PR fixes the usage of self referencing closures:
```php
  $fibonacci = function ($n) use (&$fibonacci) {
    if ($n == 0) {
      return 0;
    }
    if ($n == 1) {
      return 1;
    }
    return $fibonacci($n - 1) + $fibonacci($n - 2);
  };
```
This should also fix some segfaults and/or `zend_mm_heap corrupted` panics.

Granted, the tests I've added ([base/071](https://github.com/krakjoe/parallel/blob/4df8e7de69878fe51087d7e60e5f91d35d825f34/tests/base/071.phpt) and [base/072](https://github.com/krakjoe/parallel/blob/4df8e7de69878fe51087d7e60e5f91d35d825f34/tests/base/072.phpt)) surface a memory leak, but not much and it does not crash anymore. To be clear: the memory leak was there since way before this PR, this PR just makes sure we do not crash anymore, so overall we are less bad then before 😉 🎉 