### PR TITLE
Fix memory leak in nested closure handling

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -394,7 +394,10 @@ zend_function* php_parallel_cache_closure(const zend_function *source, zend_func
 #if PHP_VERSION_ID >= 80100
     if (source->op_array.num_dynamic_func_defs) {
         uint32_t it = 0;
-        closure->op_array.dynamic_func_defs = php_parallel_cache_copy_mem(
+        /* Use regular persistent memory for dynamic_func_defs array, not cache pool */
+        closure->op_array.dynamic_func_defs = pemalloc(
+            sizeof(zend_op_array*) * source->op_array.num_dynamic_func_defs, 1);
+        memcpy(closure->op_array.dynamic_func_defs,
             source->op_array.dynamic_func_defs,
             sizeof(zend_op_array*) * source->op_array.num_dynamic_func_defs);
         while (it < source->op_array.num_dynamic_func_defs) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -258,9 +258,12 @@ static void php_parallel_scheduler_clean(zend_function *function) {
     	while (it < function->op_array.num_dynamic_func_defs) {
     	    php_parallel_scheduler_clean(
               (zend_function*) function->op_array.dynamic_func_defs[it]);
-          pefree(function->op_array.dynamic_func_defs[it],1);
+          pefree(function->op_array.dynamic_func_defs[it], 1);
           it++;
     	}
+        /* Free the dynamic_func_defs array itself */
+        pefree(function->op_array.dynamic_func_defs, 1);
+        function->op_array.dynamic_func_defs = NULL;
     }
 #endif
 }


### PR DESCRIPTION
This PR fixes a memory leak that caused the cache to exhaust when running closures with nested functions (dynamic function definitions).

When scheduling closures containing nested functions, `php_parallel_cache_closure()` was allocating memory from the cache pool for the `dynamic_func_defs` array. This memory was never properly freed, causing the cache to fill up and eventually trigger a `realloc()` that could lead to segfaults in case the OS decided to move the entire allocation to a different address.

fixes #345 