### PR TITLE
add PHP 8.5 to CI

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -24,7 +24,7 @@ jobs:
   vanilla:
     strategy:
       matrix:
-          version: ["8.1", "8.2", "8.3", "8.4"]
+          version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     if: success() || failure()
     runs-on: ubuntu-latest
     needs: auth
@@ -37,7 +37,7 @@ jobs:
   opcache:
     strategy:
       matrix:
-          version: ["8.1", "8.2", "8.3", "8.4"]
+          version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     if: success() || failure()
     runs-on: ubuntu-latest
     needs: auth
@@ -50,7 +50,7 @@ jobs:
   jit:
     strategy:
       matrix:
-          version: ["8.1", "8.2", "8.3", "8.4"]
+          version: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     if: success() || failure()
     runs-on: ubuntu-latest
     needs: auth

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           - major: 8
             minor: 5
             patch: 0
-            rc: RC1
+            rc: RC2
         src:
           - dist
         flags:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
         php:
           - major: 8
             minor: 0
-            patch: 30 
+            patch: 30
             rc: ''
           - major: 8
             minor: 1
@@ -33,6 +33,10 @@ jobs:
             minor: 4
             patch: 1
             rc: ''
+          - major: 8
+            minor: 5
+            patch: 0
+            rc: RC1
         src:
           - dist
         flags:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
   vanilla:
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
           build: ["gcov", "release"]
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
   opcache:
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
           build: ["gcov", "release"]
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
   jit:
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
           build: ["gcov", "release"]
     if: success() || failure()
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,7 +17,7 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
           arch: [x64]
           ts: [ts]
     if: success() || failure()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,10 +17,9 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-          version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+          version: ["8.0", "8.1", "8.2", "8.3", "8.4"]
           arch: [x64]
           ts: [ts]
-    continue-on-error: ${{ matrix.version == '8.5' }}
     if: success() || failure()
     runs-on: windows-2022
     name: Windows, PHP v${{matrix.version}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,7 @@ jobs:
           version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
           arch: [x64]
           ts: [ts]
+    continue-on-error: ${{ matrix.version == '8.5' }}
     if: success() || failure()
     runs-on: windows-2022
     name: Windows, PHP v${{matrix.version}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -643,11 +643,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  php-dbg-8.5,
-    image:           ghcr.io/krakjoe/php-dbg-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/php-dbg-8.5:8.5.0RC2,
     profiles:        [php-8.5,dbg],
     <<: [*dev, *parallel]
   }
@@ -660,11 +660,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  php-gcov-8.5,
-    image:           ghcr.io/krakjoe/php-gcov-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/php-gcov-8.5:8.5.0RC2,
     profiles:        [php-8.5,gcov],
     <<: [*dev, *parallel]
   }
@@ -677,11 +677,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  php-asan-8.5,
-    image:           ghcr.io/krakjoe/php-asan-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/php-asan-8.5:8.5.0RC2,
     profiles:        [php-8.5,asan],
     <<: [*dev, *parallel]
   }
@@ -694,11 +694,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  php-release-8.5,
-    image:           ghcr.io/krakjoe/php-release-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/php-release-8.5:8.5.0RC2,
     profiles:        [php-8.5,release],
     <<: [*dev, *parallel]
   }
@@ -711,11 +711,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  parallel-dbg-8.5,
-    image:           ghcr.io/krakjoe/parallel-dbg-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/parallel-dbg-8.5:8.5.0RC2,
     profiles:        [parallel-8.5,dbg],
     <<: [*dev, *parallel]
   }
@@ -728,11 +728,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  parallel-gcov-8.5,
-    image:           ghcr.io/krakjoe/parallel-gcov-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/parallel-gcov-8.5:8.5.0RC2,
     profiles:        [parallel-8.5,gcov],
     <<: [*dev, *parallel]
   }
@@ -745,11 +745,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  parallel-asan-8.5,
-    image:           ghcr.io/krakjoe/parallel-asan-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/parallel-asan-8.5:8.5.0RC2,
     profiles:        [parallel-8.5,asan],
     <<: [*dev, *parallel]
   }
@@ -762,11 +762,11 @@ services:
         PHP_VERSION_MAJOR:    8,
         PHP_VERSION_MINOR:    5,
         PHP_VERSION_PATCH:    0,
-        PHP_VERSION_RC:       rc1,
+        PHP_VERSION_RC:       rc2,
       }
     },
     container_name:  parallel-release-8.5,
-    image:           ghcr.io/krakjoe/parallel-release-8.5:8.5.0RC1,
+    image:           ghcr.io/krakjoe/parallel-release-8.5:8.5.0RC2,
     profiles:        [parallel-8.5,release],
     <<: [*dev, *parallel]
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -630,6 +630,143 @@ services:
     },
     container_name:  parallel-release-8.4,
     image:           ghcr.io/krakjoe/parallel-release-8.4:8.4.1,
-    profiles:        [parallel-8.3,release],
+    profiles:        [parallel-8.4,release],
+    <<: [*dev, *parallel]
+  }
+
+  # PHP-8.5
+  "php-dbg-8.5": {
+    build: {        <<: *build,
+      dockerfile:    docker/php.dockerfile,
+      args: {       <<: [*ubuntu, *php],
+        PHP_SRC_TYPE:         git,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  php-dbg-8.5,
+    image:           ghcr.io/krakjoe/php-dbg-8.5:8.5.0RC1,
+    profiles:        [php-8.5,dbg],
+    <<: [*dev, *parallel]
+  }
+  "php-gcov-8.5": {
+    build: {        <<: *build,
+      dockerfile:    docker/php.dockerfile,
+      args: {       <<: [*ubuntu, *php],
+        PHP_SRC_TYPE:         git,
+        PHP_SRC_GCOV:         enable,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  php-gcov-8.5,
+    image:           ghcr.io/krakjoe/php-gcov-8.5:8.5.0RC1,
+    profiles:        [php-8.5,gcov],
+    <<: [*dev, *parallel]
+  }
+  "php-asan-8.5": {
+    build: {        <<: *build,
+      dockerfile:    docker/php.dockerfile,
+      args: {       <<: [*ubuntu, *php],
+        PHP_SRC_ASAN:         enable,
+        PHP_SRC_TYPE:         git,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  php-asan-8.5,
+    image:           ghcr.io/krakjoe/php-asan-8.5:8.5.0RC1,
+    profiles:        [php-8.5,asan],
+    <<: [*dev, *parallel]
+  }
+  "php-release-8.5": {
+    build: {           <<: *build,
+      dockerfile: docker/php.dockerfile,
+      args: { <<: [*ubuntu, *php],
+        PHP_SRC_DEBUG:        disable,
+        PHP_SRC_TYPE:         git,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  php-release-8.5,
+    image:           ghcr.io/krakjoe/php-release-8.5:8.5.0RC1,
+    profiles:        [php-8.5,release],
+    <<: [*dev, *parallel]
+  }
+  # parallel + PHP-8.5
+  "parallel-dbg-8.5": {
+    build: { <<: *build,
+      dockerfile: docker/parallel.dockerfile,
+      args: {        <<: *php,
+        PHP_SRC_TYPE:         dbg,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  parallel-dbg-8.5,
+    image:           ghcr.io/krakjoe/parallel-dbg-8.5:8.5.0RC1,
+    profiles:        [parallel-8.5,dbg],
+    <<: [*dev, *parallel]
+  }
+  "parallel-gcov-8.5": {
+    build: { <<: *build,
+      dockerfile: docker/parallel.dockerfile,
+      args: {        <<: *php,
+        PHP_SRC_TYPE:         gcov,
+        PHP_SRC_GCOV:         enable,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  parallel-gcov-8.5,
+    image:           ghcr.io/krakjoe/parallel-gcov-8.5:8.5.0RC1,
+    profiles:        [parallel-8.5,gcov],
+    <<: [*dev, *parallel]
+  }
+  "parallel-asan-8.5": {
+    build: {        <<: *build,
+      dockerfile:    docker/parallel.dockerfile,
+      args: {       <<: *php,
+        PHP_SRC_ASAN:         enable,
+        PHP_SRC_TYPE:         asan,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  parallel-asan-8.5,
+    image:           ghcr.io/krakjoe/parallel-asan-8.5:8.5.0RC1,
+    profiles:        [parallel-8.5,asan],
+    <<: [*dev, *parallel]
+  }
+  "parallel-release-8.5": {
+    build: {        <<: *build,
+      dockerfile:    docker/parallel.dockerfile,
+      args: {       <<: *php,
+        PHP_SRC_DEBUG:        disable,
+        PHP_SRC_TYPE:         release,
+        PHP_VERSION_MAJOR:    8,
+        PHP_VERSION_MINOR:    5,
+        PHP_VERSION_PATCH:    0,
+        PHP_VERSION_RC:       rc1,
+      }
+    },
+    container_name:  parallel-release-8.5,
+    image:           ghcr.io/krakjoe/parallel-release-8.5:8.5.0RC1,
+    profiles:        [parallel-8.5,release],
     <<: [*dev, *parallel]
   }

--- a/docker/php.dockerfile
+++ b/docker/php.dockerfile
@@ -20,7 +20,8 @@ RUN mkdir -p /opt/src
 RUN mkdir -p /opt/bin
 RUN mkdir -p /opt/etc
 
-ADD docker/php.src /opt/bin
+ADD --chmod=755 docker/php.src /opt/bin
+ADD --chmod=755 docker/php.opcache.sh /opt/bin
 
 RUN /opt/bin/php.src $PHP_SRC_TYPE $PHP_VERSION_MAJOR $PHP_VERSION_MINOR $PHP_VERSION_PATCH $PHP_VERSION_RC
 
@@ -50,7 +51,7 @@ RUN mkdir -p /opt/etc/php.d
 
 ENV PATH=/opt/bin:$PATH
 
-RUN echo "zend_extension=opcache.so" > /opt/etc/php.d/opcache.ini
+RUN /opt/bin/php.opcache.sh $PHP_VERSION_MAJOR $PHP_VERSION_MINOR
 
 RUN php -v
 

--- a/docker/php.opcache.sh
+++ b/docker/php.opcache.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script to conditionally configure opcache based on PHP version
+# In PHP 8.5+, opcache is built-in and doesn't need to be loaded as an extension
+
+PHP_VERSION_MAJOR=$1
+PHP_VERSION_MINOR=$2
+
+# Compare version: if PHP < 8.5, load opcache as extension
+if [ "$PHP_VERSION_MAJOR" -lt 8 ] || ([ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]); then
+    echo "PHP ${PHP_VERSION_MAJOR}.${PHP_VERSION_MINOR}: Loading opcache as zend_extension"
+    echo "zend_extension=opcache.so" > /opt/etc/php.d/opcache.ini
+else
+    echo "PHP ${PHP_VERSION_MAJOR}.${PHP_VERSION_MINOR}: Opcache is built-in, not loading as extension"
+    # Create empty file to avoid any issues with missing config
+    touch /opt/etc/php.d/opcache.ini
+fi

--- a/docker/php.src
+++ b/docker/php.src
@@ -2,9 +2,17 @@
 
 case $1 in
     dist)
-        wget https://www.php.net/distributions/php-$2.$3.$4$5.tar.gz \
-            -O /opt/src/php-$2.$3.$4$5.tar.gz
-        tar -C /opt/src -xf opt/src/php-$2.$3.$4$5.tar.gz
+        if [[ $5 == RC* ]]; then
+            # RC releases may be hosted at different locations (e.g., downloads.php.net/~edorian/)
+            wget https://downloads.php.net/~edorian/php-$2.$3.$4$5.tar.gz \
+                -O /opt/src/php-$2.$3.$4$5.tar.gz
+            tar -C /opt/src -xf /opt/src/php-$2.$3.$4$5.tar.gz
+        else
+            # Stable releases are in the distributions folder
+            wget https://www.php.net/distributions/php-$2.$3.$4$5.tar.gz \
+                -O /opt/src/php-$2.$3.$4$5.tar.gz
+            tar -C /opt/src -xf /opt/src/php-$2.$3.$4$5.tar.gz
+        fi
         ln -s /opt/src/php-$2.$3.$4$5 /opt/src/php-src
     ;;
     git)

--- a/tests/base/063.phpt
+++ b/tests/base/063.phpt
@@ -24,9 +24,9 @@ $ch = Channel::make("sv", 3);
 
 for ($i=0;$i<3;$i++){
 	$sarr[$i]->run(function() use($ch) {
-		$functions = array("addslashes", "chunk_split", "metaphone", "strip_tags", "md5", "sha1", "strtoupper", "strtolower", "strrev", "strlen", "soundex", "ord");
+		$functions = array("addslashes", "chunk_split", "metaphone", "strip_tags", "md5", "sha1", "strtoupper", "strtolower", "strrev", "strlen", "soundex");
 		$string = "the quick brown fox jumps over the lazy dog";
-		
+
 		for ($i = 0; $i < 4000; $i++) {
 			foreach ($functions as $function) {
 				call_user_func_array($function, array($string));


### PR DESCRIPTION
This PR:
- adds the creation of PHP 8.5.0RC2 containers
- adds the PHP 8.5 runs to CI

Windows PHP 8.5 builds are not yet available