### PR TITLE
Add a reference to `argc` and `argv` to child threads

### DIFF
--- a/src/runtime.c
+++ b/src/runtime.c
@@ -128,6 +128,8 @@ zend_object* php_parallel_runtime_create(zend_class_entry *type) {
     php_parallel_scheduler_init(runtime);
 
     runtime->parent.server = SG(server_context);
+    runtime->parent.argc = SG(request_info).argc;
+    runtime->parent.argv = SG(request_info).argv;
 
     return &runtime->std;
 }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -32,6 +32,8 @@ typedef struct _php_parallel_runtime_t {
     } child;
     struct {
         void                        *server;
+        int                          argc;
+        char                       **argv;
     } parent;
     zend_llist                       schedule;
     zend_object                      std;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -86,6 +86,8 @@ static zend_always_inline php_parallel_runtime_t* php_parallel_scheduler_setup(p
     TSRMLS_CACHE_UPDATE();
 
     SG(server_context) = runtime->parent.server;
+    SG(request_info).argc = runtime->parent.argc;
+    SG(request_info).argv = runtime->parent.argv;
 
     runtime->child.interrupt = &EG(vm_interrupt);
 

--- a/tests/base/070.phpt
+++ b/tests/base/070.phpt
@@ -1,0 +1,18 @@
+--TEST--
+SAPI globals
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	die("skip parallel not loaded");
+}
+?>
+--FILE--
+<?php
+var_dump($_SERVER['argc']);
+\parallel\run(function(){
+    var_dump($_SERVER['argc']);
+});
+?>
+--EXPECT--
+int(1)
+int(1)


### PR DESCRIPTION
This allows `dd-trace-php` to group threads together because for a CLI SAPI the script name (derived from argv[0]) is used as the service name which profiles get grouped by. This is less intrusive than #307 and should not trigger #341 again