### PR TITLE
Add function to expose parallel worker threads

### DIFF
--- a/php_parallel.h
+++ b/php_parallel.h
@@ -30,5 +30,12 @@ extern zend_module_entry parallel_module_entry;
 ZEND_TSRMLS_CACHE_EXTERN()
 # endif
 
-#endif	/* PHP_PARALLEL_H */
+#if _WIN32
+# define PARALLEL_API __declspec(dllexport)
+#else
+# define PARALLEL_API __attribute__ ((visibility("default")))
+#endif
 
+PARALLEL_API zend_bool php_parallel_is_parallel_worker_thread(void);
+
+#endif	/* PHP_PARALLEL_H */

--- a/php_parallel.h
+++ b/php_parallel.h
@@ -36,6 +36,6 @@ ZEND_TSRMLS_CACHE_EXTERN()
 # define PARALLEL_API __attribute__ ((visibility("default")))
 #endif
 
-PARALLEL_API zend_bool php_parallel_is_parallel_worker_thread(void);
+PARALLEL_API bool php_parallel_is_parallel_worker_thread(void);
 
 #endif	/* PHP_PARALLEL_H */

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -180,7 +180,7 @@ static zend_always_inline void php_parallel_scheduler_add(
     }
 }
 
-static zend_always_inline zend_bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime) {
+static zend_always_inline bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime) {
     return !zend_llist_count(&runtime->schedule);
 }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -684,7 +684,7 @@ zend_bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
     }
 }
 
-PARALLEL_API zend_bool php_parallel_is_parallel_worker_thread(void) {
+PARALLEL_API bool php_parallel_is_parallel_worker_thread(void) {
     return php_parallel_scheduler_context != NULL;
 }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -19,6 +19,7 @@
 #define HAVE_PARALLEL_SCHEDULER
 
 #include "parallel.h"
+#include "../php_parallel.h"
 #include "zend_types.h"
 
 TSRM_TLS php_parallel_runtime_t* php_parallel_scheduler_context = NULL;
@@ -681,6 +682,10 @@ zend_bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
 
         return 1;
     }
+}
+
+PARALLEL_API zend_bool php_parallel_is_parallel_worker_thread(void) {
+    return php_parallel_scheduler_context != NULL;
 }
 
 static void php_parallel_scheduler_interrupt(zend_execute_data *execute_data) {


### PR DESCRIPTION
This adds a public function `php_parallel_is_parallel_worker_thread()` that other extensions can use to query if the current thread is a parallel worker or not.