### PR TITLE
Refactor: Replace deprecated Zend types with standard C99 types

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -123,7 +123,7 @@ static zend_always_inline void php_parallel_cache_type(zend_type *type) { /* {{{
 
 
 /* {{{ */
-static zend_op_array* php_parallel_cache_create(const zend_function *source, zend_bool statics) {
+static zend_op_array* php_parallel_cache_create(const zend_function *source, bool statics) {
     zend_op_array *cached = php_parallel_cache_copy_mem((void*) source, sizeof(zend_op_array));
 
     cached->fn_flags |= ZEND_ACC_IMMUTABLE;
@@ -333,7 +333,7 @@ _php_parallel_cached_function_return:
 } /* }}} */
 
 /* {{{ */
-static zend_always_inline zend_function* php_parallel_cache_function_ex(const zend_function *source, zend_bool statics) {
+static zend_always_inline zend_function* php_parallel_cache_function_ex(const zend_function *source, bool statics) {
     zend_op_array *cached;
     
     pthread_mutex_lock(&PCG(mutex));

--- a/src/channel.c
+++ b/src/channel.c
@@ -31,7 +31,7 @@ php_parallel_channels_t php_parallel_channels = {NULL, 0};
 zend_class_entry *php_parallel_channel_ce;
 zend_object_handlers php_parallel_channel_handlers;
 
-static zend_always_inline void php_parallel_channels_make_ex(php_parallel_channel_t *channel, zend_string *name, zend_bool buffered, zend_long capacity) {
+static zend_always_inline void php_parallel_channels_make_ex(php_parallel_channel_t *channel, zend_string *name, bool buffered, zend_long capacity) {
     channel->link = php_parallel_link_init(name, buffered, capacity);
 
     zend_hash_add_ptr(
@@ -40,7 +40,7 @@ static zend_always_inline void php_parallel_channels_make_ex(php_parallel_channe
         php_parallel_link_copy(channel->link));
 }
 
-static zend_always_inline void php_parallel_channels_make(zval *return_value, zend_string *name, zend_bool buffered, zend_long capacity) {
+static zend_always_inline void php_parallel_channels_make(zval *return_value, zend_string *name, bool buffered, zend_long capacity) {
     object_init_ex(return_value, php_parallel_channel_ce);
 
     php_parallel_channels_make_ex(
@@ -96,7 +96,7 @@ PHP_METHOD(Parallel_Channel, __construct)
 {
     php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
     zend_long capacity = -1;
-    zend_bool buffered = 0;
+    bool buffered = 0;
     zend_string *name = NULL;
 
     if (ZEND_NUM_ARGS()) {
@@ -134,7 +134,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(Parallel_Channel, make)
 {
     zend_string *name = NULL;
-    zend_bool    buffered = 0;
+    bool    buffered = 0;
     zend_long    capacity = -1;
 
     if (ZEND_NUM_ARGS() == 1) {

--- a/src/check.c
+++ b/src/check.c
@@ -35,17 +35,17 @@ TSRM_TLS struct {
 
 typedef struct _php_parallel_check_task_t {
     zend_function *function;
-    zend_bool      returns;
+    bool      returns;
 } php_parallel_check_task_t;
 
 typedef struct _php_parallel_check_function_t {
     zend_function *function;
     zend_uchar     instruction;
-    zend_bool      valid;
+    bool      valid;
 } php_parallel_check_function_t;
 
 typedef struct _php_parallel_check_type_t {
-    zend_bool valid;
+    bool valid;
 } php_parallel_check_type_t;
 
 typedef enum {
@@ -80,7 +80,7 @@ static zend_always_inline const char* php_parallel_check_opcode_name(zend_uchar 
     }
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_type(zend_type type) { /* {{{ */
+static zend_always_inline bool php_parallel_check_type(zend_type type) { /* {{{ */
     zend_string      *name;
     zend_type        *single;
     zend_class_entry *class;
@@ -153,7 +153,7 @@ static zend_always_inline zend_bool php_parallel_check_type(zend_type type) { /*
     return check.valid;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_arginfo(const zend_function *function) { /* {{{ */
+static zend_always_inline bool php_parallel_check_arginfo(const zend_function *function) { /* {{{ */
     zend_arg_info *it, *end;
     int argc = 1;
 
@@ -212,7 +212,7 @@ static zend_always_inline zend_bool php_parallel_check_arginfo(const zend_functi
     return 1;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_statics(const zend_function *function, zend_string **errn, zval **errz) { /* {{{ */
+static zend_always_inline bool php_parallel_check_statics(const zend_function *function, zend_string **errn, zval **errz) { /* {{{ */
     HashTable *statics;
     zval *value, *error;
     zend_string *name;
@@ -241,7 +241,7 @@ static zend_always_inline zend_bool php_parallel_check_statics(const zend_functi
     return 1;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_argv(zval *args, uint32_t *argc, zval **error) { /* {{{ */
+static zend_always_inline bool php_parallel_check_argv(zval *args, uint32_t *argc, zval **error) { /* {{{ */
     zval *arg;
 
     if (*argc == 0) {
@@ -259,7 +259,7 @@ static zend_always_inline zend_bool php_parallel_check_argv(zval *args, uint32_t
     return 1;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_use(zend_execute_data *execute_data, const zend_function *function, zend_op *bind) { /* {{{ */
+static zend_always_inline bool php_parallel_check_use(zend_execute_data *execute_data, const zend_function *function, zend_op *bind) { /* {{{ */
     zend_op *opline, *end;
 
     if (EX(func)->type != ZEND_USER_FUNCTION) {
@@ -283,7 +283,7 @@ static zend_always_inline zend_bool php_parallel_check_use(zend_execute_data *ex
     return 0;
 } /* }}} */
 
-zend_bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, zend_bool *returns) { /* {{{ */
+bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, bool *returns) { /* {{{ */
     php_parallel_check_task_t check, *checked;
     zend_op *it, *end;
 
@@ -436,7 +436,7 @@ zend_bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_
     return 1;
 } /* }}} */
 
-zend_bool php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro) { /* {{{ */
+bool php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro) { /* {{{ */
     php_parallel_check_function_t check, *checked;
     zend_op *it, *end;
 
@@ -499,7 +499,7 @@ _php_parallel_checked_function_return:
     return check.valid;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_closure(zend_closure_t *closure) { /* {{{ */
+static zend_always_inline bool php_parallel_check_closure(zend_closure_t *closure) { /* {{{ */
     return php_parallel_check_statics(&closure->func, NULL, NULL) &&
            php_parallel_check_function(&closure->func, NULL, NULL);
 } /* }}} */
@@ -660,7 +660,7 @@ static php_parallel_check_class_result_t php_parallel_check_class(zend_class_ent
     return php_parallel_check_class_inline(ce);
 }
 
-static zend_always_inline zend_bool php_parallel_check_object(zend_object *object, zval **error) { /* {{{ */
+static zend_always_inline bool php_parallel_check_object(zend_object *object, zval **error) { /* {{{ */
     if (instanceof_function(object->ce, php_parallel_channel_ce) ||
         instanceof_function(object->ce, php_parallel_sync_ce)) {
         return 1;
@@ -724,7 +724,7 @@ static zend_always_inline zend_bool php_parallel_check_object(zend_object *objec
     return 1;
 } /* }}} */
 
-static zend_always_inline zend_bool php_parallel_check_resource(zval *zv) { /* {{{ */
+static zend_always_inline bool php_parallel_check_resource(zval *zv) { /* {{{ */
     zend_resource *resource = Z_RES_P(zv);
 
     if (resource->type == php_file_le_stream() ||
@@ -735,7 +735,7 @@ static zend_always_inline zend_bool php_parallel_check_resource(zval *zv) { /* {
     return 0;
 } /* }}} */
 
-zend_bool php_parallel_check_zval(zval *zv, zval **error) { /* {{{ */
+bool php_parallel_check_zval(zval *zv, zval **error) { /* {{{ */
     switch (Z_TYPE_P(zv)) {
         case IS_OBJECT:
             if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {

--- a/src/check.h
+++ b/src/check.h
@@ -18,9 +18,9 @@
 #ifndef HAVE_PARALLEL_CHECK_H
 #define HAVE_PARALLEL_CHECK_H
 
-zend_bool      php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, zend_bool *returns);
-zend_bool      php_parallel_check_zval(zval *zv, zval **error);
-zend_bool      php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro);
+bool      php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, bool *returns);
+bool      php_parallel_check_zval(zval *zv, zval **error);
+bool      php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro);
 
 #define PARALLEL_ZVAL_CHECK php_parallel_check_zval
 #define PARALLEL_ZVAL_CHECK_CLOSURES php_parallel_check_zval_closures
@@ -28,7 +28,7 @@ zend_bool      php_parallel_check_function(const zend_function *function, zend_f
 #define PARALLEL_ZVAL_CHECK_CLOSURE(zv) \
     (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ce_closure)
 
-static zend_always_inline zend_bool php_parallel_check_zval_closures(zval *zv) { /* {{{ */
+static zend_always_inline bool php_parallel_check_zval_closures(zval *zv) { /* {{{ */
     if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {
         return 1;
     }

--- a/src/copy.c
+++ b/src/copy.c
@@ -51,7 +51,7 @@ static void php_parallel_copy_string_free(zval *zv) {
     free(Z_PTR_P(zv));
 }
 
-static zend_always_inline zend_string* php_parallel_copy_string_ex(zend_string *source, zend_bool persistent) {
+static zend_always_inline zend_string* php_parallel_copy_string_ex(zend_string *source, bool persistent) {
     zend_string *dest = zend_string_alloc(ZSTR_LEN(source), persistent);
 
     memcpy(ZSTR_VAL(dest),
@@ -89,7 +89,7 @@ zend_string* php_parallel_copy_string_interned(zend_string *source) {
     return dest;
 }
 
-static zend_always_inline void php_parallel_copy_string_dtor(zend_string *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_string_dtor(zend_string *source, bool persistent) {
     if (ZSTR_IS_INTERNED(source)) {
         return;
     }
@@ -99,7 +99,7 @@ static zend_always_inline void php_parallel_copy_string_dtor(zend_string *source
     }
 }
 
-static zend_always_inline zend_string* php_parallel_copy_string_ctor(zend_string *source, zend_bool persistent) {
+static zend_always_inline zend_string* php_parallel_copy_string_ctor(zend_string *source, bool persistent) {
     if (ZSTR_IS_INTERNED(source)) {
         return php_parallel_copy_string_interned(source);
     }
@@ -107,7 +107,7 @@ static zend_always_inline zend_string* php_parallel_copy_string_ctor(zend_string
     return php_parallel_copy_string_ex(source, persistent);
 }
 
-zend_string* php_parallel_copy_string(zend_string *source, zend_bool persistent) {
+zend_string* php_parallel_copy_string(zend_string *source, bool persistent) {
     return php_parallel_copy_string_ctor(source, persistent);
 }
 
@@ -151,7 +151,7 @@ zend_class_entry* php_parallel_copy_scope(zend_class_entry *class) {
     return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong) class, scope);
 }
 
-static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, zend_bool persistent) {
+static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, bool persistent) {
 #ifndef _WIN32
     if (source->type == php_file_le_stream() ||
         source->type == php_file_le_pstream()) {
@@ -357,7 +357,7 @@ static zend_string* php_parallel_copy_string_persistent(zend_string *string) {
     return php_parallel_copy_string_ctor(string, 1);
 }
 
-HashTable *php_parallel_copy_hash_ctor(HashTable *source, zend_bool persistent) {
+HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent) {
     if (persistent) {
         return php_parallel_copy_hash_persistent_inline(
                 source,
@@ -375,7 +375,7 @@ HashTable *php_parallel_copy_hash_persistent(HashTable *source,
                 php_parallel_copy_memory_func);
 }
 
-void php_parallel_copy_hash_dtor(HashTable *table, zend_bool persistent) {
+void php_parallel_copy_hash_dtor(HashTable *table, bool persistent) {
     // see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
     // TODO: needs fixing
     if (GC_DELREF(table) == (persistent ? 1 : 0)) {
@@ -531,7 +531,7 @@ static zend_always_inline zend_object* php_parallel_copy_closure_thread(zend_obj
     return &copy->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_closure_ctor(zend_object *source, zend_bool persistent) {
+static zend_always_inline zend_object* php_parallel_copy_closure_ctor(zend_object *source, bool persistent) {
     if (persistent) {
         return php_parallel_copy_closure_persistent(source);
     }
@@ -539,7 +539,7 @@ static zend_always_inline zend_object* php_parallel_copy_closure_ctor(zend_objec
     return php_parallel_copy_closure_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_closure_dtor(zend_object *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_closure_dtor(zend_object *source, bool persistent) {
     zend_closure_t *closure;
 
     if (!persistent) {
@@ -584,14 +584,14 @@ static zend_always_inline zend_reference* php_parallel_copy_reference_thread(zen
     return reference;
 }
 
-static zend_always_inline zend_reference* php_parallel_copy_reference_ctor(zend_reference *source, zend_bool persistent) {
+static zend_always_inline zend_reference* php_parallel_copy_reference_ctor(zend_reference *source, bool persistent) {
     if (persistent) {
         return php_parallel_copy_reference_persistent(source);
     }
     return php_parallel_copy_reference_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_reference_dtor(zend_reference *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_reference_dtor(zend_reference *source, bool persistent) {
     if (GC_DELREF(source) == 0) {
         PARALLEL_ZVAL_DTOR(
             &source->val);
@@ -637,14 +637,14 @@ static zend_always_inline zend_object* php_parallel_copy_channel_thread(zend_obj
     return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_channel_ctor(zend_object *source, zend_bool persistent) {
+static zend_always_inline zend_object* php_parallel_copy_channel_ctor(zend_object *source, bool persistent) {
     if (persistent) {
         return php_parallel_copy_channel_persistent(source);
     }
     return php_parallel_copy_channel_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_channel_dtor(zend_object *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_channel_dtor(zend_object *source, bool persistent) {
     php_parallel_channel_t *channel = php_parallel_channel_fetch(source);
 
     if (!persistent) {
@@ -696,14 +696,14 @@ static zend_always_inline zend_object* php_parallel_copy_sync_thread(zend_object
     return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_sync_ctor(zend_object *source, zend_bool persistent) {
+static zend_always_inline zend_object* php_parallel_copy_sync_ctor(zend_object *source, bool persistent) {
     if (persistent) {
         return php_parallel_copy_sync_persistent(source);
     }
     return php_parallel_copy_sync_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_sync_dtor(zend_object *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_sync_dtor(zend_object *source, bool persistent) {
     php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source);
 
     if (!persistent) {
@@ -831,7 +831,7 @@ static zend_always_inline zend_object* php_parallel_copy_object_thread(zend_obje
     return dest;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_object_ctor(zend_object *source, zend_bool persistent) {
+static zend_always_inline zend_object* php_parallel_copy_object_ctor(zend_object *source, bool persistent) {
     if (source->ce == zend_ce_closure) {
         return php_parallel_copy_closure_ctor(source, persistent);
     }
@@ -851,7 +851,7 @@ static zend_always_inline zend_object* php_parallel_copy_object_ctor(zend_object
     return php_parallel_copy_object_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source, zend_bool persistent) {
+static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source, bool persistent) {
     if (source->ce == zend_ce_closure) {
         php_parallel_copy_closure_dtor(source, persistent);
         return;
@@ -891,7 +891,7 @@ static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source
     }
 }
 
-void php_parallel_copy_zval_ctor(zval *dest, zval *source, zend_bool persistent) {
+void php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent) {
     switch (Z_TYPE_P(source)) {
         case IS_NULL:
         case IS_TRUE:
@@ -985,7 +985,7 @@ static void php_parallel_copy_zval_persistent(
     }
 }
 
-zend_function* php_parallel_copy_function(const zend_function *function, zend_bool persistent) {
+zend_function* php_parallel_copy_function(const zend_function *function, bool persistent) {
     if (persistent) {
         function =      	
             php_parallel_cache_function(function);

--- a/src/copy.h
+++ b/src/copy.h
@@ -46,7 +46,7 @@ typedef struct _zend_closure_t {
     zif_handler       orig_internal_handler;
 } zend_closure_t;
 
-static zend_always_inline void* php_parallel_copy_mem(void *source, size_t size, zend_bool persistent) {
+static zend_always_inline void* php_parallel_copy_mem(void *source, size_t size, bool persistent) {
     void *destination = (void*) pemalloc(PARALLEL_PLATFORM_ALIGNED(size), persistent);
 
     memcpy(destination, source, size);
@@ -54,17 +54,17 @@ static zend_always_inline void* php_parallel_copy_mem(void *source, size_t size,
     return destination;
 }
 
-zend_function* php_parallel_copy_function(const zend_function *function, zend_bool persistent);
+zend_function* php_parallel_copy_function(const zend_function *function, bool persistent);
 
 zend_string*   php_parallel_copy_string_interned(zend_string *source);
-zend_string*   php_parallel_copy_string(zend_string *source, zend_bool persistent);
+zend_string*   php_parallel_copy_string(zend_string *source, bool persistent);
 
-HashTable *php_parallel_copy_hash_ctor(HashTable *source, zend_bool persistent);
-void php_parallel_copy_hash_dtor(HashTable *table, zend_bool persistent);
+HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent);
+void php_parallel_copy_hash_dtor(HashTable *table, bool persistent);
 
 HashTable *php_parallel_copy_hash_persistent(HashTable *source, zend_string* (*)(zend_string*), void* (*)(void *, zend_long));
 
-void           php_parallel_copy_zval_ctor(zval *dest, zval *source, zend_bool persistent);
+void           php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent);
 void           php_parallel_copy_zval_dtor(zval *zv);
 
 zend_class_entry* php_parallel_copy_scope(zend_class_entry *);

--- a/src/events.c
+++ b/src/events.c
@@ -46,7 +46,7 @@ static zend_object* php_parallel_events_create(zend_class_entry *type) {
     return &events->std;
 }
 
-static zend_always_inline zend_bool php_parallel_events_add(php_parallel_events_t *events, zend_string *name, zval *object, zend_string **key) {
+static zend_always_inline bool php_parallel_events_add(php_parallel_events_t *events, zend_string *name, zval *object, zend_string **key) {
     if(instanceof_function(Z_OBJCE_P(object), php_parallel_channel_ce)) {
         php_parallel_channel_t *channel =
             (php_parallel_channel_t*)
@@ -68,7 +68,7 @@ static zend_always_inline zend_bool php_parallel_events_add(php_parallel_events_
     return 1;
 }
 
-static zend_always_inline zend_bool php_parallel_events_remove(php_parallel_events_t *events, zend_string *name) {
+static zend_always_inline bool php_parallel_events_remove(php_parallel_events_t *events, zend_string *name) {
     return zend_hash_del(&events->targets, name) == SUCCESS;
 }
 
@@ -207,7 +207,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(Parallel_Events, setBlocking)
 {
     php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zend_bool blocking;
+    bool blocking;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
         Z_PARAM_BOOL(blocking)

--- a/src/events.h
+++ b/src/events.h
@@ -22,7 +22,7 @@ typedef struct _php_parallel_events_t {
     zval        input;
     HashTable   targets;
     zend_long   timeout;
-    zend_bool   blocking;
+    bool   blocking;
     zval        blocker;
     zend_object std;
 } php_parallel_events_t;
@@ -35,9 +35,9 @@ typedef enum {
 typedef struct _php_parallel_events_state_t {
     php_parallel_events_type_t type;
     zend_string *name;
-    zend_bool readable;
-    zend_bool writable;
-    zend_bool closed;
+    bool readable;
+    bool writable;
+    bool closed;
     zend_object *object;
 } php_parallel_events_state_t;
 

--- a/src/future.c
+++ b/src/future.c
@@ -25,11 +25,11 @@ zend_object_handlers php_parallel_future_handlers;
 
 zend_string *php_parallel_future_string_runtime;
 
-zend_bool php_parallel_future_lock(php_parallel_future_t *future) {
+bool php_parallel_future_lock(php_parallel_future_t *future) {
     return php_parallel_monitor_lock(future->monitor);
 }
 
-zend_bool php_parallel_future_readable(php_parallel_future_t *future) {
+bool php_parallel_future_readable(php_parallel_future_t *future) {
     return php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY);
 }
 
@@ -70,7 +70,7 @@ void php_parallel_future_value(php_parallel_future_t *future, zval *return_value
     php_parallel_monitor_unlock(future->monitor);
 }
 
-zend_bool php_parallel_future_unlock(php_parallel_future_t *future) {
+bool php_parallel_future_unlock(php_parallel_future_t *future) {
     return php_parallel_monitor_unlock(future->monitor);
 }
 

--- a/src/future.h
+++ b/src/future.h
@@ -48,10 +48,10 @@ static zend_always_inline php_parallel_future_t* php_parallel_future_construct(z
 zend_object* php_parallel_future_create(zend_class_entry *);
 void         php_parallel_future_destroy(zend_object *);
 
-zend_bool    php_parallel_future_lock(php_parallel_future_t *future);
-zend_bool    php_parallel_future_readable(php_parallel_future_t *future);
+bool    php_parallel_future_lock(php_parallel_future_t *future);
+bool    php_parallel_future_readable(php_parallel_future_t *future);
 void         php_parallel_future_value(php_parallel_future_t *future, zval *value);
-zend_bool    php_parallel_future_unlock(php_parallel_future_t *future);
+bool    php_parallel_future_unlock(php_parallel_future_t *future);
 
 PHP_MINIT_FUNCTION(PARALLEL_FUTURE);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_FUTURE);

--- a/src/input.c
+++ b/src/input.c
@@ -153,7 +153,7 @@ zval* php_parallel_events_input_find(zval *zv, zend_string *target) {
     return zend_hash_find(&input->table, target);
 }
 
-zend_bool php_parallel_events_input_exists(zval *zv, zend_string *target) {
+bool php_parallel_events_input_exists(zval *zv, zend_string *target) {
     php_parallel_events_input_t *input;
 
     if (Z_TYPE_P(zv) != IS_OBJECT) {
@@ -165,7 +165,7 @@ zend_bool php_parallel_events_input_exists(zval *zv, zend_string *target) {
     return zend_hash_exists(&input->table, target);
 }
 
-zend_bool php_parallel_events_input_remove(zval *zv, zend_string *target) {
+bool php_parallel_events_input_remove(zval *zv, zend_string *target) {
     php_parallel_events_input_t *input;
 
     if (Z_TYPE_P(zv) != IS_OBJECT) {

--- a/src/input.h
+++ b/src/input.h
@@ -20,9 +20,9 @@
 
 extern zend_class_entry* php_parallel_events_input_ce;
 
-zend_bool php_parallel_events_input_exists(zval *zv, zend_string *target);
+bool php_parallel_events_input_exists(zval *zv, zend_string *target);
 zval*     php_parallel_events_input_find(zval *input, zend_string *target);
-zend_bool php_parallel_events_input_remove(zval *input, zend_string *target);
+bool php_parallel_events_input_remove(zval *input, zend_string *target);
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS_INPUT);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_INPUT);

--- a/src/link.c
+++ b/src/link.c
@@ -120,7 +120,7 @@ static zend_always_inline void php_parallel_link_cond_destroy(php_parallel_link_
     pthread_cond_destroy(&condition->w);
 }
 
-php_parallel_link_t* php_parallel_link_init(zend_string *name, zend_bool buffered, zend_long capacity) {
+php_parallel_link_t* php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity) {
     php_parallel_link_t *link = pecalloc(1, sizeof(php_parallel_link_t), 1);
 
     if (php_parallel_link_mutex_init(&link->m) != SUCCESS) {
@@ -171,7 +171,7 @@ php_parallel_link_t* php_parallel_link_copy(php_parallel_link_t *link) {
     return link;
 }
 
-static zend_always_inline zend_bool php_parallel_link_send_unbuffered(php_parallel_link_t *link, zval *value) {
+static zend_always_inline bool php_parallel_link_send_unbuffered(php_parallel_link_t *link, zval *value) {
     pthread_mutex_lock(&link->m.w);
     pthread_mutex_lock(&link->m.m);
 
@@ -206,7 +206,7 @@ static zend_always_inline zend_bool php_parallel_link_send_unbuffered(php_parall
     return 1;
 }
 
-static zend_always_inline zend_bool php_parallel_link_send_buffered(php_parallel_link_t *link, zval *value) {
+static zend_always_inline bool php_parallel_link_send_buffered(php_parallel_link_t *link, zval *value) {
     zval sent;
 
     pthread_mutex_lock(&link->m.m);
@@ -236,7 +236,7 @@ static zend_always_inline zend_bool php_parallel_link_send_buffered(php_parallel
     return 1;
 }
 
-zend_bool php_parallel_link_send(php_parallel_link_t *link, zval *value) {
+bool php_parallel_link_send(php_parallel_link_t *link, zval *value) {
     if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
         return php_parallel_link_send_unbuffered(link, value);
     } else {
@@ -244,7 +244,7 @@ zend_bool php_parallel_link_send(php_parallel_link_t *link, zval *value) {
     }
 }
 
-static zend_always_inline zend_bool php_parallel_link_recv_unbuffered(php_parallel_link_t *link, zval *value) {
+static zend_always_inline bool php_parallel_link_recv_unbuffered(php_parallel_link_t *link, zval *value) {
     pthread_mutex_lock(&link->m.r);
     pthread_mutex_lock(&link->m.m);
 
@@ -278,7 +278,7 @@ static zend_always_inline int php_parallel_link_queue_delete(void *lhs, void *rh
     return lhs == rhs;
 }
 
-static zend_always_inline zend_bool php_parallel_link_recv_buffered(php_parallel_link_t *link, zval *value) {
+static zend_always_inline bool php_parallel_link_recv_buffered(php_parallel_link_t *link, zval *value) {
     zval *head;
 
     pthread_mutex_lock(&link->m.m);
@@ -310,7 +310,7 @@ static zend_always_inline zend_bool php_parallel_link_recv_buffered(php_parallel
     return 1;
 }
 
-zend_bool php_parallel_link_recv(php_parallel_link_t *link, zval *value) {
+bool php_parallel_link_recv(php_parallel_link_t *link, zval *value) {
     if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
         return php_parallel_link_recv_unbuffered(link, value);
     } else {
@@ -318,7 +318,7 @@ zend_bool php_parallel_link_recv(php_parallel_link_t *link, zval *value) {
     }
 }
 
-zend_bool php_parallel_link_close(php_parallel_link_t *link) {
+bool php_parallel_link_close(php_parallel_link_t *link) {
     pthread_mutex_lock(&link->m.m);
 
     if (link->s.c) {
@@ -334,7 +334,7 @@ zend_bool php_parallel_link_close(php_parallel_link_t *link) {
     return 1;
 }
 
-zend_bool php_parallel_link_closed(php_parallel_link_t *link) {
+bool php_parallel_link_closed(php_parallel_link_t *link) {
     return link->s.c;
 }
 
@@ -342,11 +342,11 @@ zend_string* php_parallel_link_name(php_parallel_link_t *link) {
     return link->name;
 }
 
-zend_bool php_parallel_link_lock(php_parallel_link_t *link) {
+bool php_parallel_link_lock(php_parallel_link_t *link) {
     return pthread_mutex_lock(&link->m.m) == SUCCESS;
 }
 
-zend_bool php_parallel_link_writable(php_parallel_link_t *link) {
+bool php_parallel_link_writable(php_parallel_link_t *link) {
     switch (link->type) {
         case PHP_PARALLEL_LINK_UNBUFFERED:
             return link->s.r > 0;
@@ -358,7 +358,7 @@ zend_bool php_parallel_link_writable(php_parallel_link_t *link) {
     return 0;
 }
 
-zend_bool php_parallel_link_readable(php_parallel_link_t *link) {
+bool php_parallel_link_readable(php_parallel_link_t *link) {
     switch (link->type) {
         case PHP_PARALLEL_LINK_UNBUFFERED:
             return link->s.w > 0;
@@ -411,7 +411,7 @@ void php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug) {
     }
 }
 
-zend_bool php_parallel_link_unlock(php_parallel_link_t *link) {
+bool php_parallel_link_unlock(php_parallel_link_t *link) {
     return pthread_mutex_unlock(&link->m.m) == SUCCESS;
 }
 

--- a/src/link.h
+++ b/src/link.h
@@ -20,19 +20,19 @@
 
 typedef struct _php_parallel_link_t php_parallel_link_t;
 
-php_parallel_link_t* php_parallel_link_init(zend_string *name, zend_bool buffered, zend_long capacity);
+php_parallel_link_t* php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity);
 zend_string*         php_parallel_link_name(php_parallel_link_t *link);
 php_parallel_link_t* php_parallel_link_copy(php_parallel_link_t *link);
-zend_bool            php_parallel_link_send(php_parallel_link_t *link, zval *value);
-zend_bool            php_parallel_link_recv(php_parallel_link_t *link, zval *value);
-zend_bool            php_parallel_link_close(php_parallel_link_t *link);
-zend_bool            php_parallel_link_closed(php_parallel_link_t *link);
+bool            php_parallel_link_send(php_parallel_link_t *link, zval *value);
+bool            php_parallel_link_recv(php_parallel_link_t *link, zval *value);
+bool            php_parallel_link_close(php_parallel_link_t *link);
+bool            php_parallel_link_closed(php_parallel_link_t *link);
 void                 php_parallel_link_destroy(php_parallel_link_t *link);
 
-zend_bool            php_parallel_link_lock(php_parallel_link_t *link);
-zend_bool            php_parallel_link_writable(php_parallel_link_t *link);
-zend_bool            php_parallel_link_readable(php_parallel_link_t *link);
-zend_bool            php_parallel_link_unlock(php_parallel_link_t *link);
+bool            php_parallel_link_lock(php_parallel_link_t *link);
+bool            php_parallel_link_writable(php_parallel_link_t *link);
+bool            php_parallel_link_readable(php_parallel_link_t *link);
+bool            php_parallel_link_unlock(php_parallel_link_t *link);
 
 void                 php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug);
 

--- a/src/loop.c
+++ b/src/loop.c
@@ -75,7 +75,7 @@ const zend_object_iterator_funcs php_parallel_events_loop_functions = {
     .get_current_key    = NULL,
 };
 
-static zend_always_inline zend_bool php_parallel_events_loop_check(zval *zv) {
+static zend_always_inline bool php_parallel_events_loop_check(zval *zv) {
     php_parallel_events_t *events = php_parallel_events_from(zv);
 
     if (events->blocking) {

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -67,9 +67,9 @@ typedef union _php_parallel_platform_align_test {
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 0) \
     ZEND_PARSE_PARAMETERS_END()
 
-static zend_always_inline zend_bool php_parallel_mutex_init(pthread_mutex_t *mutex, zend_bool recursive) {
+static zend_always_inline bool php_parallel_mutex_init(pthread_mutex_t *mutex, bool recursive) {
     if (recursive) {
-        zend_bool result = 0;
+        bool result = 0;
         pthread_mutexattr_t attributes;
 
         pthread_mutexattr_init(&attributes);
@@ -93,7 +93,7 @@ static zend_always_inline void php_parallel_mutex_destroy(pthread_mutex_t *mutex
     pthread_mutex_destroy(mutex);
 }
 
-static zend_always_inline zend_bool php_parallel_cond_init(pthread_cond_t *cond) {
+static zend_always_inline bool php_parallel_cond_init(pthread_cond_t *cond) {
     return (pthread_cond_init(cond, NULL) == SUCCESS);
 }
 

--- a/src/poll.c
+++ b/src/poll.c
@@ -87,7 +87,7 @@ static zend_always_inline void php_parallel_events_poll_end(php_parallel_events_
     php_parallel_events_poll_free(poll);
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_timeout(php_parallel_events_poll_t *poll, php_parallel_events_t *events) {
+static zend_always_inline bool php_parallel_events_poll_timeout(php_parallel_events_poll_t *poll, php_parallel_events_t *events) {
     struct timeval now;
 
     if (events->timeout > -1 && gettimeofday(&now, NULL) == SUCCESS) {
@@ -103,7 +103,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_timeout(php_paralle
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_random(php_parallel_events_t *events, zend_string **name, zend_object **object) {
+static zend_always_inline bool php_parallel_events_poll_random(php_parallel_events_t *events, zend_string **name, zend_object **object) {
     uint32_t  size = events->targets.nNumUsed;
     zend_long random =
         php_mt_rand_range(0, (zend_long) size - 1);
@@ -124,7 +124,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_random(php_parallel
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_begin_link(
+static zend_always_inline bool php_parallel_events_poll_begin_link(
                                         php_parallel_events_t *events,
                                         php_parallel_events_state_t *state,
                                         zend_string *name,
@@ -156,7 +156,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_begin_link(
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_begin_future(
+static zend_always_inline bool php_parallel_events_poll_begin_future(
                             php_parallel_events_t *events,
                             php_parallel_events_state_t *state,
                             zend_string *name,
@@ -180,7 +180,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_begin_future(
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_begin(php_parallel_events_t *events, php_parallel_events_state_t *state) {
+static zend_always_inline bool php_parallel_events_poll_begin(php_parallel_events_t *events, php_parallel_events_state_t *state) {
     zend_string *name;
     zend_object *object;
 
@@ -199,7 +199,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_begin(php_parallel_
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_link(
+static zend_always_inline bool php_parallel_events_poll_link(
                             php_parallel_events_t *events,
                             php_parallel_events_state_t *state,
                             zval *retval) {
@@ -258,7 +258,7 @@ static zend_always_inline zend_bool php_parallel_events_poll_link(
     return 0;
 }
 
-static zend_always_inline zend_bool php_parallel_events_poll_future(
+static zend_always_inline bool php_parallel_events_poll_future(
                             php_parallel_events_t *events,
                             php_parallel_events_state_t *state,
                             zval *retval) {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -19,7 +19,7 @@
 #define HAVE_PARALLEL_RUNTIME_H
 
 #if PHP_VERSION_ID < 80200
-# define zend_atomic_bool zend_bool
+# define zend_atomic_bool bool
 # define zend_atomic_bool_store(dest, value) (*(dest) = value)
 #endif
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -179,12 +179,12 @@ static zend_always_inline void php_parallel_scheduler_add(
     }
 }
 
-static zend_always_inline zend_bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime) {
+static zend_always_inline bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime) {
     return !zend_llist_count(&runtime->schedule);
 }
 
-zend_bool php_parallel_scheduler_busy(php_parallel_runtime_t *runtime) {
-    zend_bool busy = 1;
+bool php_parallel_scheduler_busy(php_parallel_runtime_t *runtime) {
+    bool busy = 1;
 
     php_parallel_monitor_lock(runtime->monitor);
     if (php_parallel_scheduler_empty(runtime)) {
@@ -270,7 +270,7 @@ static void php_parallel_scheduler_clean(zend_function *function) {
 #endif
 }
 
-static zend_always_inline zend_bool php_parallel_scheduler_pop(php_parallel_runtime_t *runtime, php_parallel_schedule_el_t *el) {
+static zend_always_inline bool php_parallel_scheduler_pop(php_parallel_runtime_t *runtime, php_parallel_schedule_el_t *el) {
     php_parallel_schedule_el_t *head;
     zend_class_entry *scope = NULL;
     zend_function    *function = NULL;
@@ -590,7 +590,7 @@ void php_parallel_scheduler_stop(php_parallel_runtime_t *runtime) {
 void php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value) {
     zend_execute_data      *caller = EG(current_execute_data)->prev_execute_data;
     const zend_function    *function = zend_get_closure_method_def(Z_OBJ_P(closure));
-    zend_bool               returns = 0;
+    bool               returns = 0;
     php_parallel_future_t  *future = NULL;
 
     php_parallel_monitor_lock(runtime->monitor);
@@ -610,7 +610,7 @@ void php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure,
     php_parallel_monitor_unlock(runtime->monitor);
 }
 
-void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, zend_bool kill) {
+void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill) {
     php_parallel_monitor_lock(runtime->monitor);
 
     if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
@@ -638,7 +638,7 @@ void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, zend_bool kill
     pthread_join(runtime->thread, NULL);
 }
 
-zend_bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
+bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
     size_t in, out = 0;
 
     php_parallel_monitor_lock(future->runtime->monitor);
@@ -655,7 +655,7 @@ zend_bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
     php_parallel_monitor_unlock(future->runtime->monitor);
 
     if (in == out) {
-        zend_bool cancelled = 0;
+        bool cancelled = 0;
 
         php_parallel_monitor_lock(future->monitor);
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -26,11 +26,11 @@ void               php_parallel_scheduler_init(php_parallel_runtime_t *runtime);
 void               php_parallel_scheduler_start(php_parallel_runtime_t *runtime, zend_string *bootstrap);
 void               php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value);
 void               php_parallel_scheduler_stop(php_parallel_runtime_t *runtime);
-void               php_parallel_scheduler_join(php_parallel_runtime_t *runtime, zend_bool kill);
-zend_bool          php_parallel_scheduler_busy(php_parallel_runtime_t *runtime);
+void               php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill);
+bool          php_parallel_scheduler_busy(php_parallel_runtime_t *runtime);
 void               php_parallel_scheduler_destroy(php_parallel_runtime_t *runtime);
 
-zend_bool          php_parallel_scheduler_cancel(php_parallel_future_t *future);
+bool          php_parallel_scheduler_cancel(php_parallel_future_t *future);
 
 PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SCHEDULER);

--- a/src/sync.c
+++ b/src/sync.c
@@ -266,7 +266,7 @@ PHP_METHOD(Parallel_Sync, notify)
 {
     php_parallel_sync_object_t *object =
         php_parallel_sync_object_from(getThis());
-    zend_bool all = 0;
+    bool all = 0;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL


### PR DESCRIPTION
According to the [`php/main.php`](https://github.com/php/php-src/blob/c27368c9392c46047c20d86f536753c29e73b8a0/main/php.h#L418-L422), `zend_bool` should not be used anymore in favour of `bool`:

```c
/* the following typedefs are deprecated and will be removed in PHP
 * 9.0; use the standard C99 types instead */
typedef bool zend_bool;
typedef intptr_t zend_intptr_t;
typedef uintptr_t zend_uintptr_t;
```
