### PR TITLE
copy over functions from global function table

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -463,26 +463,7 @@ static zend_always_inline zend_object* php_parallel_copy_closure_persistent(zend
     return &copy->std;
 }
 
-static zend_always_inline void php_parallel_copy_closure_init_run_time_cache(zend_op_array *function) {
-    void *rtc;
 
-    function->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
-#if PHP_VERSION_ID >= 80200
-    rtc = emalloc(function->cache_size);
-
-    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
-#else
-    rtc = emalloc(sizeof(void*) + function->cache_size);
-
-    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
-
-    rtc = (char*)rtc + sizeof(void*);
-
-    ZEND_MAP_PTR_SET(function->run_time_cache, rtc);
-#endif
-
-    memset(rtc, 0, function->cache_size);
-}
 
 static zend_always_inline zend_object* php_parallel_copy_closure_thread(zend_object *source) {
     zend_closure_t *copy =
@@ -520,7 +501,7 @@ static zend_always_inline zend_object* php_parallel_copy_closure_thread(zend_obj
     ZEND_MAP_PTR_INIT(function->static_variables_ptr, &function->static_variables);
 #endif
 
-    php_parallel_copy_closure_init_run_time_cache(function);
+    php_parallel_copy_init_run_time_cache(function);
 
     if (Z_TYPE(copy->this_ptr) == IS_OBJECT) {
         PARALLEL_ZVAL_COPY(&copy->this_ptr, &copy->this_ptr, 0);
@@ -987,7 +968,7 @@ static void php_parallel_copy_zval_persistent(
 
 zend_function* php_parallel_copy_function(const zend_function *function, zend_bool persistent) {
     if (persistent) {
-        function =      	
+        function =
             php_parallel_cache_function(function);
 
         php_parallel_dependencies_store(function);

--- a/src/copy.h
+++ b/src/copy.h
@@ -83,6 +83,28 @@ typedef struct _php_parallel_copy_context_t {
 php_parallel_copy_context_t* php_parallel_copy_context_start(
     php_parallel_copy_direction_t direction,
     php_parallel_copy_context_t **previous);
+
+static zend_always_inline void php_parallel_copy_init_run_time_cache(zend_op_array *function) {
+    void *rtc;
+
+    function->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
+#if PHP_VERSION_ID >= 80200
+    rtc = emalloc(function->cache_size);
+
+    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
+#else
+    rtc = emalloc(sizeof(void*) + function->cache_size);
+
+    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
+
+    rtc = (char*)rtc + sizeof(void*);
+
+    ZEND_MAP_PTR_SET(function->run_time_cache, rtc);
+#endif
+
+    memset(rtc, 0, function->cache_size);
+}
+
 void* php_parallel_copy_context_find(php_parallel_copy_context_t *context, void *address);
 void php_parallel_copy_context_insert(php_parallel_copy_context_t *context, void *address, void *assigned);
 void php_parallel_copy_context_end(

--- a/src/dependencies.c
+++ b/src/dependencies.c
@@ -19,6 +19,7 @@
 #define HAVE_PARALLEL_DEPENDENCIES
 
 #include "parallel.h"
+#include "zend_extensions.h"
 
 static struct {
     pthread_mutex_t mutex;
@@ -72,7 +73,7 @@ static void php_parallel_dependencies_load_globals(const zend_function *function
 #if PHP_VERSION_ID >= 80100
     if (function->op_array.dynamic_func_defs) {
     	uint32_t it = 0, end = function->op_array.num_dynamic_func_defs;
-    	
+
     	while (it < end) {
     	    php_parallel_dependencies_load_globals(
     	    	(zend_function*) function->op_array.dynamic_func_defs[it]);
@@ -86,7 +87,6 @@ static void php_parallel_dependencies_load_globals(const zend_function *function
 
 
 void php_parallel_dependencies_store(const zend_function *function) { /* {{{ */
-#if PHP_VERSION_ID < 80100
     HashTable dependencies;
 
     pthread_mutex_lock(&PDM(mutex));
@@ -102,6 +102,7 @@ void php_parallel_dependencies_store(const zend_function *function) { /* {{{ */
                 *end = opline + function->op_array.last;
 
         while (opline < end) {
+#if PHP_VERSION_ID < 80100
             if (opline->opcode == ZEND_DECLARE_LAMBDA_FUNCTION) {
                 zend_string   *key;
                 zend_function *dependency;
@@ -121,6 +122,34 @@ void php_parallel_dependencies_store(const zend_function *function) { /* {{{ */
 
                 php_parallel_dependencies_store(dependency);
             }
+#endif
+            if (opline->opcode == ZEND_INIT_FCALL ||
+                opline->opcode == ZEND_INIT_FCALL_BY_NAME ||
+                opline->opcode == ZEND_INIT_NS_FCALL_BY_NAME) {
+                if (opline->op2_type == IS_CONST) {
+                    zval *name = RT_CONSTANT(opline, opline->op2);
+
+                    if (Z_TYPE_P(name) == IS_STRING) {
+                        zend_function *dependency =
+                            zend_hash_find_ptr(EG(function_table), Z_STR_P(name));
+
+                        if (dependency && dependency->type == ZEND_USER_FUNCTION) {
+                            dependency = php_parallel_copy_function(dependency, 1);
+
+                            if (dependencies.nNumUsed == 0) {
+                                zend_hash_init(&dependencies, 8, NULL, NULL, 1);
+                            }
+
+                            if (!zend_hash_exists(&dependencies, Z_STR_P(name))) {
+                                zend_hash_add_ptr(
+                                    &dependencies,
+                                    php_parallel_copy_string_interned(Z_STR_P(name)),
+                                    dependency);
+                            }
+                        }
+                    }
+                }
+            }
             opline++;
         }
     }
@@ -131,19 +160,15 @@ void php_parallel_dependencies_store(const zend_function *function) { /* {{{ */
         &dependencies, sizeof(HashTable));
 
     pthread_mutex_unlock(&PDM(mutex));
-#endif
 } /* }}} */
 
 void php_parallel_dependencies_load(const zend_function *function) { /* {{{ */
-#if PHP_VERSION_ID < 80100
     HashTable *dependencies;
     zend_string *key;
     zend_function *dependency;
-#endif
 
     php_parallel_dependencies_load_globals(function);
 
-#if PHP_VERSION_ID < 80100
     pthread_mutex_lock(&PDM(mutex));
     dependencies = zend_hash_index_find_ptr(
         &PDM(table), (zend_ulong) function->op_array.opcodes);
@@ -168,7 +193,6 @@ void php_parallel_dependencies_load(const zend_function *function) { /* {{{ */
             zend_hash_add_empty_element(&PDG(used), key);
         }
     } ZEND_HASH_FOREACH_END();
-#endif
 } /* }}} */
 
 static void php_parallel_dependencies_dtor(zval *zv) { /* {{{ */

--- a/src/dependencies.c
+++ b/src/dependencies.c
@@ -182,45 +182,75 @@ void php_parallel_dependencies_load(const zend_function *function) { /* {{{ */
 
     ZEND_HASH_FOREACH_STR_KEY_PTR(dependencies, key, dependency) {
         if (!zend_hash_exists(EG(function_table), key)) {
-            zend_op_array *used =
-                (zend_op_array*)
-                    php_parallel_copy_function(dependency, 0);
+            zend_op_array *used;
 
-            zend_hash_add_ptr(EG(function_table), key, used);
+            php_parallel_dependencies_load(dependency);
 
-            ZEND_MAP_PTR_NEW(used->run_time_cache);
-
-            zend_hash_add_empty_element(&PDG(used), key);
-        }
-    } ZEND_HASH_FOREACH_END();
-} /* }}} */
-
-static void php_parallel_dependencies_dtor(zval *zv) { /* {{{ */
-    zend_hash_destroy(Z_PTR_P(zv));
-    pefree(Z_PTR_P(zv), 1);
-} /* }}} */
-
-PHP_RINIT_FUNCTION(PARALLEL_DEPENDENCIES)
-{
-    zend_hash_init(&PDG(activated), 32, NULL, NULL, 0);
-    zend_hash_init(&PDG(used), 32, NULL, NULL, 0);
-
-    return SUCCESS;
-}
-
-PHP_RSHUTDOWN_FUNCTION(PARALLEL_DEPENDENCIES)
-{
-    zend_string *key;
-
-    zend_hash_destroy(&PDG(activated));
-    ZEND_HASH_FOREACH_STR_KEY(&PDG(used), key) {
-        zend_hash_del(EG(function_table), key);
-    } ZEND_HASH_FOREACH_END();
-    zend_hash_destroy(&PDG(used));
-
-    return SUCCESS;
-}
-
+                        used = (zend_op_array*) emalloc(sizeof(zend_op_array));
+                        memcpy(used, dependency, sizeof(zend_op_array));
+                        used->fn_flags &= ~ZEND_ACC_IMMUTABLE;
+                        
+                        if (used->static_variables) {
+                            used->static_variables = php_parallel_copy_hash_ctor(used->static_variables, 0);
+                        }
+            
+            #if PHP_VERSION_ID >= 80200
+                        ZEND_MAP_PTR_INIT(used->static_variables_ptr, used->static_variables);
+            #else
+                        ZEND_MAP_PTR_INIT(used->static_variables_ptr, &used->static_variables);
+            #endif
+            
+                        php_parallel_copy_init_run_time_cache(used);
+            
+                        zend_hash_add_ptr(EG(function_table), key, used);
+            
+                        zend_hash_add_empty_element(&PDG(used), key);
+                    }
+                } ZEND_HASH_FOREACH_END();
+            } /* }}} */
+            
+            static void php_parallel_dependencies_dtor(zval *zv) { /* {{{ */
+                zend_hash_destroy(Z_PTR_P(zv));
+                pefree(Z_PTR_P(zv), 1);
+            } /* }}} */
+            
+            PHP_RINIT_FUNCTION(PARALLEL_DEPENDENCIES)
+            {
+                zend_hash_init(&PDG(activated), 32, NULL, NULL, 0);
+                zend_hash_init(&PDG(used), 32, NULL, NULL, 0);
+            
+                return SUCCESS;
+            }
+            
+            PHP_RSHUTDOWN_FUNCTION(PARALLEL_DEPENDENCIES)
+            {
+                zend_string *key;
+            
+                zend_hash_destroy(&PDG(activated));
+                ZEND_HASH_FOREACH_STR_KEY(&PDG(used), key) {
+                    zend_function *f = zend_hash_find_ptr(EG(function_table), key);
+            
+                    if (f && f->type == ZEND_USER_FUNCTION) {
+                        f->op_array.opcodes = NULL;
+                        f->op_array.literals = NULL;
+                        f->op_array.vars = NULL;
+                        f->op_array.arg_info = NULL;
+                        f->op_array.try_catch_array = NULL;
+                        f->op_array.live_range = NULL;
+            #if PHP_VERSION_ID >= 80000
+                        f->op_array.attributes = NULL;
+            #endif
+            #if PHP_VERSION_ID >= 80100
+                        f->op_array.dynamic_func_defs = NULL;
+            #endif
+                    }
+            
+                    zend_hash_del(EG(function_table), key);
+                } ZEND_HASH_FOREACH_END();
+                zend_hash_destroy(&PDG(used));
+            
+                return SUCCESS;
+            }
 PHP_MINIT_FUNCTION(PARALLEL_DEPENDENCIES)
 {
     php_parallel_mutex_init(&PDM(mutex), 1);

--- a/tests/base/073.phpt
+++ b/tests/base/073.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Check function copying without opcache
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+    die('skip parallel not loaded');
+}
+if (ini_get("opcache.enable_cli")) {
+    die("skip opcache must not be loaded for this test");
+}
+?>
+--FILE--
+<?php
+function b() { echo "done."; }
+function a() { b(); }
+(new \parallel\Runtime)->run(function() { a(); });
+?>
+--EXPECT--
+done.

--- a/tests/base/074.phpt
+++ b/tests/base/074.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check function copying with opcache disabled
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+    die('skip parallel not loaded');
+}
+?>
+--INI--
+opcache.enable=0
+opcache.enable_cli=0
+--FILE--
+<?php
+function b() { echo "done."; }
+function a() { b(); }
+(new \parallel\Runtime)->run(function() { a(); });
+?>
+--EXPECT--
+done.

--- a/tests/base/075.phpt
+++ b/tests/base/075.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check function copying with opcache enabled
+--EXTENSIONS--
+opcache
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+    die('skip parallel not loaded');
+}
+?>
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+--FILE--
+<?php
+function b() { echo "done."; }
+function a() { b(); }
+(new \parallel\Runtime)->run(function() { a(); });
+?>
+--EXPECT--
+done.

--- a/tests/base/076.phpt
+++ b/tests/base/076.phpt
@@ -1,0 +1,30 @@
+--TEST--
+parallel: static variables in functions are isolated
+--FILE--
+<?php
+function b() {
+	static $i = 0;
+	$i++;
+	sleep(1);
+	return $i;
+}
+
+function a() {
+    return b();
+}
+
+$futures[] = \parallel\run(function() { return a(); });
+$futures[] = \parallel\run(function() { return a(); });
+$futures[] = \parallel\run(function() { return a(); });
+$futures[] = \parallel\run(function() { return a(); });
+
+foreach ($futures as $future) {
+	echo "Done: ".$future->value().PHP_EOL;
+}
+?>
+--EXPECT--
+Done: 1
+Done: 1
+Done: 1
+Done: 1
+


### PR DESCRIPTION
This PR aims to handle cases nicer where you call a function from the global function table in your runtime and it currently segfaults:

```php
<?php
function a() {
    return;
};
\parallel\run(function () { a(); });
```

This compiles, because the function `a()` is known at compile time, but PHP has no idea about the threading things we do, so it is not aware that in the scope of the runtime the function `a()` is not available. As we do not copy over the function itself, PHP when executing the closure will segfault on a `NULL` pointer in:

```
Process 2943 stopped
* thread #4, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000010081fcfc php`ZEND_INIT_FCALL_SPEC_CONST_HANDLER(execute_data=0x0000000102a13020) at zend_vm_execute.h:3842:9
   3839			fname = (zval*)RT_CONSTANT(opline, opline->op2);
   3840			func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(fname));
   3841			ZEND_ASSERT(func != NULL && "Function existence must be checked at compile time");
-> 3842			fbc = Z_FUNC_P(func);
   3843			if (EXPECTED(fbc->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&fbc->op_array))) {
   3844				init_func_run_time_cache(&fbc->op_array);
   3845			}
(lldb) bt
* thread #4, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000010081fcfc php`ZEND_INIT_FCALL_SPEC_CONST_HANDLER(execute_data=0x0000000102a13020) at zend_vm_execute.h:3842:9
    frame #1: 0x00000001007be7e0 php`execute_ex(ex=0x0000000102a13020) at zend_vm_execute.h:57007:7
    frame #2: 0x00000001017494e8 parallel.so`php_parallel_scheduler_run(runtime=0x000000010185e140, frame=0x0000000102a13020) at scheduler.c:332:13
    frame #3: 0x0000000101748924 parallel.so`php_parallel_thread(arg=0x000000010185e140) at scheduler.c:506:9
    frame #4: 0x000000018c5baf94 libsystem_pthread.dylib`_pthread_start + 136
(lldb) p func
(zval *) NULL
```

# TODO's

## OPcache
I am aware that in some cases the pointer we get from
```
func = zend_hash_find_known_hash(EG(function_table), Z_STR_P(fname));
```
is a pointer into a SHM segment from the OPcache itself. In that case we might not need to copy over the function because OPcache handled that for us. Problem so far is my limited understanding and it sometimes works, but sometimes not. Once I figured that out, I'll update this PR

## `static` variables
```php
<?php
function b() {
	static $i = 0;
	$i++;
	sleep(1);
	return $i;
}

function a() {
    return b();
}

$futures[] = \parallel\run(function() { return a(); });
$futures[] = \parallel\run(function() { return a(); });
$futures[] = \parallel\run(function() { return a(); });
$futures[] = \parallel\run(function() { return a(); });

foreach ($futures as $future) {
	echo "Done: ".$future->value().PHP_EOL;
}
```

Outputs `Done: 4` four times, where it should be `Done: 1` for each ...

Fixes #317 