### PR TITLE
Handle calling functions from global scope

### DIFF
--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -104,6 +104,30 @@ static zend_always_inline void php_parallel_exceptions_write(zend_object *except
     EG(fake_scope) = scope;
 }
 
+zend_object* php_parallel_exception_object(zend_class_entry *ce, const char *message, zend_long code, zend_string *file, zend_long line) {
+    zend_object *exception = zend_objects_new(ce);
+
+    object_properties_init(exception, ce);
+
+    if (message) {
+        zend_update_property_string(ce, exception, "message", sizeof("message")-1, message);
+    }
+
+    if (code) {
+        zend_update_property_long(ce, exception, "code", sizeof("code")-1, code);
+    }
+
+    if (file) {
+        zend_update_property_str(ce, exception, "file", sizeof("file")-1, file);
+    }
+
+    if (line) {
+        zend_update_property_long(ce, exception, "line", sizeof("line")-1, line);
+    }
+
+    return exception;
+}
+
 void php_parallel_exceptions_destroy(php_parallel_exception_t *ex) {
     PARALLEL_ZVAL_DTOR(&ex->class);
     PARALLEL_ZVAL_DTOR(&ex->file);

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -84,6 +84,7 @@ extern zend_class_entry* php_parallel_events_event_error_ce;
 
 typedef struct _php_parallel_exception_t php_parallel_exception_t;
 
+zend_object* php_parallel_exception_object(zend_class_entry *ce, const char *message, zend_long code, zend_string *file, zend_long line);
 void         php_parallel_exceptions_save(zval *saved, zend_object *exception);
 zend_object* php_parallel_exceptions_restore(zval *exception);
 void         php_parallel_exceptions_destroy(php_parallel_exception_t *ex);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -29,8 +29,7 @@ php_parallel_runtime_t* php_parallel_runtime_construct(zend_string *bootstrap) {
 
     object_init_ex(&rt, php_parallel_runtime_ce);
 
-    runtime = 
-        php_parallel_runtime_from(&rt);
+    runtime = php_parallel_runtime_from(&rt);
 
     php_parallel_scheduler_start(runtime, bootstrap);
 
@@ -76,7 +75,8 @@ PHP_METHOD(Parallel_Runtime, run)
         Z_PARAM_ARRAY(argv)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
+    if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED) ||
+        php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_DONE)) {
         php_parallel_exception_ex(
             php_parallel_runtime_error_closed_ce,
             "Runtime closed");

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -28,7 +28,7 @@ typedef struct _php_parallel_runtime_t {
     php_parallel_monitor_t          *monitor;
     zend_string                     *bootstrap;
     struct {
-        zend_atomic_bool                   *interrupt;
+        zend_atomic_bool            *interrupt;
     } child;
     struct {
         void                        *server;
@@ -36,6 +36,10 @@ typedef struct _php_parallel_runtime_t {
         char                       **argv;
     } parent;
     zend_llist                       schedule;
+    zend_bool                        crashed;
+    zend_string                     *missing;
+    zend_string                     *file;
+    uint32_t                         line;
     zend_object                      std;
 } php_parallel_runtime_t;
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -69,7 +69,7 @@ LONG WINAPI php_parallel_veh_handler(PEXCEPTION_POINTERS exceptionInfo) {
 struct sigaction php_parallel_old_sigsegv_action;
 
 static void php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context) {
-	// Only handle this SIGSEGV if this is a parallel thread
+    // Only handle this SIGSEGV if this is a parallel thread
     if (php_parallel_scheduler_context) {
         php_parallel_scheduler_context->crashed = 1;
 
@@ -193,6 +193,9 @@ static zend_always_inline php_parallel_runtime_t* php_parallel_scheduler_setup(p
 
 static zend_always_inline void php_parallel_scheduler_exit(php_parallel_runtime_t *runtime) {
     php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE);
+    // PHP_PARALLEL_CLOSED prevents the thread holding the \parallel\Runtime
+    // object from scheduling new tasks on this finished thread
+    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSED);
 
     php_request_shutdown(NULL);
 
@@ -311,13 +314,13 @@ static void php_parallel_scheduler_pull(zend_function *function) {
 
 #if PHP_VERSION_ID >= 80100
     if (function->op_array.num_dynamic_func_defs) {
-    	uint32_t it = 0;
+        uint32_t it = 0;
 
-    	while (it < function->op_array.num_dynamic_func_defs) {
-    	    php_parallel_scheduler_pull(
+        while (it < function->op_array.num_dynamic_func_defs) {
+            php_parallel_scheduler_pull(
                (zend_function*) function->op_array.dynamic_func_defs[it]);
             it++;
-    	}
+        }
     }
 #endif
 }
@@ -337,14 +340,14 @@ static void php_parallel_scheduler_clean(zend_function *function) {
 
 #if PHP_VERSION_ID >= 80100
     if (function->op_array.num_dynamic_func_defs) {
-    	uint32_t it = 0;
+        uint32_t it = 0;
 
-    	while (it < function->op_array.num_dynamic_func_defs) {
-    	    php_parallel_scheduler_clean(
+        while (it < function->op_array.num_dynamic_func_defs) {
+            php_parallel_scheduler_clean(
               (zend_function*) function->op_array.dynamic_func_defs[it]);
           pefree(function->op_array.dynamic_func_defs[it], 1);
           it++;
-    	}
+        }
         /* Free the dynamic_func_defs array itself */
         pefree(function->op_array.dynamic_func_defs, 1);
         function->op_array.dynamic_func_defs = NULL;
@@ -444,8 +447,8 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
             }
         } zend_catch {
             if (runtime->crashed) {
+                zend_object *exception = NULL;
                 if (future) {
-                    zend_object *exception = NULL;
                     char *message = NULL;
 
                     zend_clear_exception();
@@ -464,16 +467,23 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
                             "illegal instruction (segmentation fault) in task", 0, runtime->file, runtime->line);
                     }
 
+                    php_parallel_monitor_lock(future->monitor);
                     if (exception) {
                         php_parallel_exceptions_save(frame->return_value, exception);
-                        php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
                         OBJ_RELEASE(exception);
                     }
+                    php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY|PHP_PARALLEL_ERROR);
+                    php_parallel_monitor_unlock(future->monitor);
                 }
-                runtime->crashed = 0;
-                runtime->missing = NULL;
-                runtime->file = NULL;
-                runtime->line = 0;
+
+                // This runtime crashed, as such we can not give any guarantees
+                // anymore and it is best to shut down the thread as gracefuly
+                // as possible. By setting the `runtime->monitor` to
+                // `PHP_PARALLEL_KILLED` we make sure that this thread goes
+                // through shutdown and calls `pthread_ext()`
+                php_parallel_monitor_lock(runtime->monitor);
+                php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE|PHP_PARALLEL_KILLED);
+                php_parallel_monitor_unlock(runtime->monitor);
             } else if (future) {
                 php_parallel_monitor_lock(future->monitor);
                 if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -21,11 +21,53 @@
 #include "parallel.h"
 #include "../php_parallel.h"
 #include "zend_types.h"
+#include <signal.h>
 
 TSRM_TLS php_parallel_runtime_t* php_parallel_scheduler_context = NULL;
 TSRM_TLS php_parallel_future_t* php_parallel_scheduler_future = NULL;
 
 void (*zend_interrupt_handler)(zend_execute_data*) = NULL;
+
+struct sigaction php_parallel_old_sigsegv_action;
+
+static void php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context) {
+	// Only handle this SIGSEGV if this is a parallel thread
+    if (php_parallel_scheduler_context) {
+        php_parallel_scheduler_context->crashed = 1;
+
+        if (EG(current_execute_data)) {
+            if (EG(current_execute_data)->opline) {
+                const zend_op *opline = EG(current_execute_data)->opline;
+
+                php_parallel_scheduler_context->line = opline->lineno;
+                if (opline->opcode == ZEND_INIT_FCALL) {
+                    zval *name = RT_CONSTANT(opline, opline->op2);
+
+                    if (Z_TYPE_P(name) == IS_STRING) {
+                        if (!zend_hash_exists(EG(function_table), Z_STR_P(name))) {
+                            php_parallel_scheduler_context->missing = Z_STR_P(name);
+                        }
+                    }
+                }
+            }
+            if (EG(current_execute_data)->func && EG(current_execute_data)->func->op_array.filename) {
+                php_parallel_scheduler_context->file = EG(current_execute_data)->func->op_array.filename;
+            }
+        }
+        zend_bailout();
+    }
+
+    if (php_parallel_old_sigsegv_action.sa_flags & SA_SIGINFO) {
+        php_parallel_old_sigsegv_action.sa_sigaction(sig, info, context);
+    } else if (php_parallel_old_sigsegv_action.sa_handler == SIG_DFL) {
+        signal(sig, SIG_DFL);
+        raise(sig);
+    } else if (php_parallel_old_sigsegv_action.sa_handler == SIG_IGN) {
+        // ignore
+    } else {
+        php_parallel_old_sigsegv_action.sa_handler(sig);
+    }
+}
 
 static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void *rhs) {
     return lhs == rhs;
@@ -342,6 +384,11 @@ static zend_always_inline bool php_parallel_scheduler_pop(php_parallel_runtime_t
 static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_execute_data *frame) {
     php_parallel_future_t *future = php_parallel_scheduler_future;
 
+    runtime->crashed = 0;
+    runtime->missing = NULL;
+    runtime->file = NULL;
+    runtime->line = 0;
+
     zend_first_try {
         zend_try {
             zend_execute_ex(frame);
@@ -357,7 +404,38 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
                 }
             }
         } zend_catch {
-            if (future) {
+            if (runtime->crashed) {
+                if (future) {
+                    zend_object *exception = NULL;
+                    char *message = NULL;
+
+                    zend_clear_exception();
+
+                    if (runtime->missing) {
+                        spprintf(&message, 0,
+                            "Call to undefined function %s() in task, please provide the function via a bootstrap file",
+                            ZSTR_VAL(runtime->missing));
+                        exception = php_parallel_exception_object(
+                            php_parallel_runtime_error_illegal_instruction_ce,
+                            message, 0, runtime->file, runtime->line);
+                        efree(message);
+                    } else {
+                        exception = php_parallel_exception_object(
+                            php_parallel_runtime_error_illegal_instruction_ce,
+                            "illegal instruction (segmentation fault) in task", 0, runtime->file, runtime->line);
+                    }
+
+                    if (exception) {
+                        php_parallel_exceptions_save(frame->return_value, exception);
+                        php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+                        OBJ_RELEASE(exception);
+                    }
+                }
+                runtime->crashed = 0;
+                runtime->missing = NULL;
+                runtime->file = NULL;
+                runtime->line = 0;
+            } else if (future) {
                 php_parallel_monitor_lock(future->monitor);
                 if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
                     php_parallel_monitor_set(future->monitor, PHP_PARALLEL_KILLED);
@@ -366,7 +444,7 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
             }
         } zend_end_try();
 
-         if (frame->return_value  && !Z_ISUNDEF_P(frame->return_value)) {
+        if (frame->return_value  && !Z_ISUNDEF_P(frame->return_value)) {
             zval garbage = *frame->return_value;
 
             if (Z_OPT_REFCOUNTED(garbage)) {
@@ -719,8 +797,16 @@ static void php_parallel_scheduler_interrupt(zend_execute_data *execute_data) {
 
 PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER)
 {
+    struct sigaction sa;
+
     zend_interrupt_handler = zend_interrupt_function;
     zend_interrupt_function = php_parallel_scheduler_interrupt;
+
+    memset(&sa, 0, sizeof(struct sigaction));
+    sa.sa_sigaction = php_parallel_sigsegv_handler;
+    sa.sa_flags = SA_SIGINFO;
+
+    sigaction(SIGSEGV, &sa, &php_parallel_old_sigsegv_action);
 
     PHP_MINIT(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
 
@@ -729,6 +815,8 @@ PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER)
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SCHEDULER)
 {
+    sigaction(SIGSEGV, &php_parallel_old_sigsegv_action, NULL);
+
     zend_interrupt_function = zend_interrupt_handler;
 
     PHP_MSHUTDOWN(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -21,13 +21,51 @@
 #include "parallel.h"
 #include "../php_parallel.h"
 #include "zend_types.h"
-#include <signal.h>
+
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <signal.h>
+#endif
 
 TSRM_TLS php_parallel_runtime_t* php_parallel_scheduler_context = NULL;
 TSRM_TLS php_parallel_future_t* php_parallel_scheduler_future = NULL;
 
 void (*zend_interrupt_handler)(zend_execute_data*) = NULL;
 
+#ifdef _WIN32
+void *php_parallel_veh_handle = NULL;
+
+LONG WINAPI php_parallel_veh_handler(PEXCEPTION_POINTERS exceptionInfo) {
+    if (exceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+        if (php_parallel_scheduler_context) {
+            php_parallel_scheduler_context->crashed = 1;
+
+            if (EG(current_execute_data)) {
+                if (EG(current_execute_data)->opline) {
+                    const zend_op *opline = EG(current_execute_data)->opline;
+
+                    php_parallel_scheduler_context->line = opline->lineno;
+                    if (opline->opcode == ZEND_INIT_FCALL) {
+                        zval *name = RT_CONSTANT(opline, opline->op2);
+
+                        if (Z_TYPE_P(name) == IS_STRING) {
+                            if (!zend_hash_exists(EG(function_table), Z_STR_P(name))) {
+                                php_parallel_scheduler_context->missing = Z_STR_P(name);
+                            }
+                        }
+                    }
+                }
+                if (EG(current_execute_data)->func && EG(current_execute_data)->func->op_array.filename) {
+                    php_parallel_scheduler_context->file = EG(current_execute_data)->func->op_array.filename;
+                }
+            }
+            zend_bailout();
+        }
+    }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+#else
 struct sigaction php_parallel_old_sigsegv_action;
 
 static void php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context) {
@@ -68,6 +106,7 @@ static void php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context
         php_parallel_old_sigsegv_action.sa_handler(sig);
     }
 }
+#endif
 
 static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void *rhs) {
     return lhs == rhs;
@@ -797,16 +836,20 @@ static void php_parallel_scheduler_interrupt(zend_execute_data *execute_data) {
 
 PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER)
 {
-    struct sigaction sa;
-
     zend_interrupt_handler = zend_interrupt_function;
     zend_interrupt_function = php_parallel_scheduler_interrupt;
+
+#ifdef _WIN32
+    php_parallel_veh_handle = AddVectoredExceptionHandler(1, php_parallel_veh_handler);
+#else
+    struct sigaction sa;
 
     memset(&sa, 0, sizeof(struct sigaction));
     sa.sa_sigaction = php_parallel_sigsegv_handler;
     sa.sa_flags = SA_SIGINFO;
 
     sigaction(SIGSEGV, &sa, &php_parallel_old_sigsegv_action);
+#endif
 
     PHP_MINIT(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
 
@@ -815,7 +858,13 @@ PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER)
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SCHEDULER)
 {
+#ifdef _WIN32
+    if (php_parallel_veh_handle) {
+        RemoveVectoredExceptionHandler(php_parallel_veh_handle);
+    }
+#else
     sigaction(SIGSEGV, &php_parallel_old_sigsegv_action, NULL);
+#endif
 
     zend_interrupt_function = zend_interrupt_handler;
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -193,9 +193,6 @@ static zend_always_inline php_parallel_runtime_t* php_parallel_scheduler_setup(p
 
 static zend_always_inline void php_parallel_scheduler_exit(php_parallel_runtime_t *runtime) {
     php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE);
-    // PHP_PARALLEL_CLOSED prevents the thread holding the \parallel\Runtime
-    // object from scheduling new tasks on this finished thread
-    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSED);
 
     php_request_shutdown(NULL);
 

--- a/tests/base/073.phpt
+++ b/tests/base/073.phpt
@@ -1,0 +1,48 @@
+--TEST--
+parallel\Runtime::run() - closure calls undefined function in worker thread
+--DESCRIPTION--
+Fixes https://github.com/krakjoe/parallel/issues/317
+If you call a function that exists in the main thread's `EG(function_table)`
+from a `\parallel\Runtime`, this will compile just fine, as PHP is not aware
+of the execution in the other thread, but the execution will segfault. This
+test ensures that instead of segfaulting this throws an Exception to the
+caller that can be catched.
+--EXTENSIONS--
+parallel
+--SKIPIF--
+<?php
+if (ini_get("opcache.enable_cli")) {
+	die("skip opcache must not be loaded");
+}
+if (version_compare(PHP_VERSION, "8.2.0", "<")) {
+    die("skip php 8.1 is failing on its own gracefully");
+}
+?>
+--FILE--
+<?php
+function a()
+{
+	return "foo";
+}
+
+$runtime = new parallel\Runtime();
+try {
+	$future = $runtime->run(function () {
+		return a();
+	});
+	$future->value();
+} catch (parallel\Runtime\Error\IllegalInstruction $e) {
+	var_dump($e->getMessage());
+	var_dump($e->getFile());
+	var_dump($e->getLine());
+}
+$future = $runtime->run(function () {
+	return "done";
+});
+var_dump($future->value());
+?>
+--EXPECTF--
+string(%d) "Call to undefined function a() in task, please provide the function via a bootstrap file"
+string(%d) "%s073.php"
+int(10)
+string(4) "done"

--- a/tests/base/074.phpt
+++ b/tests/base/074.phpt
@@ -20,35 +20,31 @@ if (version_compare(PHP_VERSION, "8.2.0", "<")) {
 ?>
 --FILE--
 <?php
+
 function a()
 {
 	return "foo";
 }
 
-$runtime = new parallel\Runtime();
-try {
-	$future = $runtime->run(function () {
-		return a();
-	});
-	$future->value();
-} catch (\parallel\Runtime\Error\IllegalInstruction $e) {
-	var_dump($e->getMessage());
-	var_dump($e->getFile());
-	var_dump($e->getLine());
+$future[] = \parallel\run(function() { return a(); });
+$future[] = \parallel\run(function() { return a(); });
+$future[] = \parallel\run(function() { return a(); });
+$future[] = \parallel\run(function() { return a(); });
+$future[] = \parallel\run(function() { return a(); });
+$future[] = \parallel\run(function() { return a(); });
+
+foreach ($future as $v) {
+	try {
+		var_dump($v->value());
+	} catch (\parallel\Runtime\Error\IllegalInstruction $e) {
+		echo "done." . \PHP_EOL;
+	}
 }
-try {
-	$future = $runtime->run(function () {
-		return "done";
-	});
-	$future->value();
-} catch (\parallel\Runtime\Error\Closed $e) {
-	var_dump($e->getMessage());
-}
-echo "done";
 ?>
 --EXPECTF--
-string(%d) "Call to undefined function a() in task, please provide the function via a bootstrap file"
-string(%d) "%s073.php"
-int(10)
-string(%d) "Runtime closed"
-done
+done.
+done.
+done.
+done.
+done.
+done.


### PR DESCRIPTION
When calling a function from the global scope of the main thread in a task, `parallel` crashes depending on the PHP version and if you have  `OPcache` enabled or not (see #317).

Copying the `function_table` from the parent thread seems possible, but it is complex, error-prone, and, due to the highly dynamic nature of PHP, nearly impossible to perform with 100% accuracy. 

How does the crashing code look:
```php
<?php
function foo() { return "OK"; }
$future = \parallel\run(function(){ 
    return foo(); 
}); 
var_dump($future->value()); 
```

`parallel` does not copy functions from the main threads `function_table` to the task's thread. You need to make those functions available using a bootstrap file:

```php
<?php 
\parallel\bootstrap('bootstrap.php'); 
$future = \parallel\run(function(){ 
    return foo(); 
}); 
var_dump($future->value()); 

// bootstrap.php
<?php 
function foo() { return "OK"; }
```

This PR adds a `SIGSEGV` handler that catches this crash (and other segmentation faults) and raises an exception that get's thrown when the `$future->value()` function is called. Additionally this runtime get's shutdown, so for parallel managed runtimes through `\parallel\run()` you will not notice any difference (just in CPU cycles, as `parallel` has to create a new runtime if you schedule a new task), for runtimes created using `new \parallel\Runtime()` you will notice that after a crash you can't schedule a new task on that runtime anymore. When calling `$runtime->run()` it'll throw a `\parallel\Runtime\Error\Closed()` exception instead of scheduling the task to be run.

Fixes #317 