### PR TITLE
Cleanup code formatting and docs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: ForIndentation
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 120
+AccessModifierOffset: -4
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCompound: true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,27 @@
+# https://editorconfig.org/
+
 root = true
 
 [*]
-charset = utf-8
-indent_style = tab
-insert_final_newline = true
 trim_trailing_whitespace = true
-indent_size = 4
+insert_final_newline     = true
+end_of_line              = lf
+charset                  = utf-8
+tab_width                = 4
+indent_size              = 4
+indent_style             = tab
 
-[*.php]
-block_comment_start = /*
-block_comment = *
-block_comment_end = */
+[*.{dtd,html,inc,php,phpt,rng,wsdl,xml,xsd,xsl}]
+indent_style             = space
 
-[{*Makefile,.gitmodules}]
-indent_style = tab
+[*.{ac,m4,sh,yml}]
+indent_size              = 2
+indent_style             = space
+
+[*.md]
+indent_style             = space
+max_line_length          = 80
+
+[COMMIT_EDITMSG]
+indent_style             = space
+max_line_length          = 80

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,28 @@
+name: Clang-Format Check
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - master
+      - develop
+      - release
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format
+
+    - name: Run clang-format
+      run: |
+        # Find all C files and run clang-format check
+        # -dry-run outputs violations without changing files
+        # -Werror makes warnings (violations) exit with non-zero status
+        find src -name '*.c' -o -name '*.h' | xargs clang-format -style=file --dry-run --Werror

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,0 +1,4 @@
+fmt:
+	find src \( -name '*.c' -o -name '*.h' \) -print0 | xargs -0 clang-format -i -style=file
+
+format: fmt

--- a/config.m4
+++ b/config.m4
@@ -69,4 +69,6 @@ if test "$PHP_PARALLEL" != "no"; then
   if test "$PHP_PARALLEL_GCOV" != "no"; then
     PHP_SUBST(EXTRA_CFLAGS)
   fi
+
+  PHP_ADD_MAKEFILE_FRAGMENT
 fi

--- a/php_parallel.h
+++ b/php_parallel.h
@@ -19,6 +19,7 @@
 #ifndef PHP_PARALLEL_H
 # define PHP_PARALLEL_H
 
+#include "php.h"
 extern zend_module_entry parallel_module_entry;
 # define phpext_parallel_ptr &parallel_module_entry
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -106,7 +106,7 @@ static zend_always_inline void php_parallel_cache_type(zend_type *type) { /* {{{
         if (ZEND_TYPE_USES_ARENA(*type)) {
             ZEND_TYPE_FULL_MASK(*type) &= ~_ZEND_TYPE_ARENA_BIT;
         }
- 
+
         ZEND_TYPE_SET_PTR(*type, list);
     }
 
@@ -144,13 +144,13 @@ static zend_op_array* php_parallel_cache_create(const zend_function *source, boo
 #if PHP_VERSION_ID >= 80100
     if (cached->num_dynamic_func_defs) {
     	uint32_t it = 0;
-    	
+
     	cached->dynamic_func_defs = php_parallel_cache_copy_mem(
     	                                cached->dynamic_func_defs,
     	                                sizeof(zend_op_array*) * cached->num_dynamic_func_defs);
-    	
+
     	while (it < cached->num_dynamic_func_defs) {
-    	    cached->dynamic_func_defs[it] = 
+    	    cached->dynamic_func_defs[it] =
                 (zend_op_array*) php_parallel_cache_create(
     	            (zend_function*) cached->dynamic_func_defs[it], statics);
             it++;
@@ -158,6 +158,10 @@ static zend_op_array* php_parallel_cache_create(const zend_function *source, boo
     }
 #endif
 
+    // This path is taken when OPcache is enabled and active, and the `source`
+    // zend_function's opcodes are already handled and stored in OPcache's
+    // Shared Memory (SHM). OPcache sets `op_array->refcount`to `NULL` for such
+    // persistent `op_array`'s.
     if (!cached->refcount) {
         goto _php_parallel_cached_function_return;
     }
@@ -291,7 +295,7 @@ static zend_op_array* php_parallel_cache_create(const zend_function *source, boo
                 info->name =
                     php_parallel_copy_string_interned(it->name);
             }
-            
+
             php_parallel_cache_type(&info->type);
 
             info++;
@@ -335,7 +339,7 @@ _php_parallel_cached_function_return:
 /* {{{ */
 static zend_always_inline zend_function* php_parallel_cache_function_ex(const zend_function *source, bool statics) {
     zend_op_array *cached;
-    
+
     pthread_mutex_lock(&PCG(mutex));
 
     if ((cached = zend_hash_index_find_ptr(&PCG(table), (zend_ulong) source->op_array.opcodes))) {
@@ -346,7 +350,7 @@ static zend_always_inline zend_function* php_parallel_cache_function_ex(const ze
 
     zend_hash_index_add_ptr(
         &PCG(table),
-        (zend_ulong) source->op_array.opcodes, 
+        (zend_ulong) source->op_array.opcodes,
         cached);
 
 _php_parallel_cached_function_return:

--- a/src/cache.c
+++ b/src/cache.c
@@ -21,427 +21,396 @@
 #include "parallel.h"
 
 static struct {
-    pthread_mutex_t mutex;
-    HashTable       table;
-    struct {
-        size_t      size;
-        size_t      used;
-        void       *mem;
-        void       *block;
-    } memory;
+	pthread_mutex_t mutex;
+	HashTable       table;
+	struct {
+		size_t size;
+		size_t used;
+		void  *mem;
+		void  *block;
+	} memory;
 } php_parallel_cache_globals = {PTHREAD_MUTEX_INITIALIZER};
 
 #define PCG(e) php_parallel_cache_globals.e
 #define PCM(e) PCG(memory).e
 
-#define PARALLEL_CACHE_CHUNK \
-    PARALLEL_PLATFORM_ALIGNED((1024 * 1024) * 8)
+#define PARALLEL_CACHE_CHUNK PARALLEL_PLATFORM_ALIGNED((1024 * 1024) * 8)
 
 /* {{{ */
-static zend_always_inline void* php_parallel_cache_alloc(size_t size) {
-    void *mem;
-    size_t aligned =
-        PARALLEL_PLATFORM_ALIGNED(size);
+static zend_always_inline void *php_parallel_cache_alloc(size_t size)
+{
+	void  *mem;
+	size_t aligned = PARALLEL_PLATFORM_ALIGNED(size);
 
-    ZEND_ASSERT(size < PARALLEL_CACHE_CHUNK);
+	ZEND_ASSERT(size < PARALLEL_CACHE_CHUNK);
 
-    if ((PCM(used) + aligned) >= PCM(size)) {
-        PCM(size) = PARALLEL_PLATFORM_ALIGNED(
-            PCM(size) + PARALLEL_CACHE_CHUNK);
-        PCM(mem) = (void*) realloc(PCM(mem), PCM(size));
+	if ((PCM(used) + aligned) >= PCM(size)) {
+		PCM(size) = PARALLEL_PLATFORM_ALIGNED(PCM(size) + PARALLEL_CACHE_CHUNK);
+		PCM(mem) = realloc(PCM(mem), PCM(size));
 
-        if (!PCM(mem)) {
-            /* out of memory */
-            return NULL;
-        }
+		if (!PCM(mem)) {
+			/* out of memory */
+			return NULL;
+		}
 
-        PCM(block) = (void*)(((char*)PCM(mem)) + PCM(used));
-    }
+		PCM(block) = (void *)(((char *)PCM(mem)) + PCM(used));
+	}
 
-    mem = PCM(block);
-    PCM(block) =
-        (void*)(((char*)PCM(block)) + aligned);
-    PCM(used) += aligned;
+	mem = PCM(block);
+	PCM(block) = (void *)(((char *)PCM(block)) + aligned);
+	PCM(used) += aligned;
 
-    return mem;
+	return mem;
 }
 
-static zend_always_inline void* php_parallel_cache_copy_mem(void *source, zend_long size) {
-    void *destination =
-        php_parallel_cache_alloc(size);
+static zend_always_inline void *php_parallel_cache_copy_mem(void *source, zend_long size)
+{
+	void *destination = php_parallel_cache_alloc(size);
 
-    memcpy(destination, source, size);
+	memcpy(destination, source, size);
 
-    return destination;
+	return destination;
 } /* }}} */
 
-static zend_always_inline HashTable* php_parallel_cache_statics(HashTable *statics) { /* {{{ */
-    HashTable *cached = zend_hash_index_find_ptr(&PCG(table), (zend_ulong) statics);
+static zend_always_inline HashTable *php_parallel_cache_statics(HashTable *statics)
+{ /* {{{ */
+	HashTable *cached = zend_hash_index_find_ptr(&PCG(table), (zend_ulong)statics);
 
-    if (cached) {
-        return cached;
-    }
+	if (cached) {
+		return cached;
+	}
 
-    cached = php_parallel_copy_hash_persistent(
-                statics,
-                php_parallel_copy_string_interned,
-                php_parallel_cache_copy_mem);
+	cached = php_parallel_copy_hash_persistent(statics, php_parallel_copy_string_interned, php_parallel_cache_copy_mem);
 
-    return zend_hash_index_update_ptr(&PCG(table), (zend_ulong) statics, cached);
+	return zend_hash_index_update_ptr(&PCG(table), (zend_ulong)statics, cached);
 } /* }}} */
 
-static zend_always_inline void php_parallel_cache_type(zend_type *type) { /* {{{ */
-    zend_type *single;
+static zend_always_inline void php_parallel_cache_type(zend_type *type)
+{ /* {{{ */
+	zend_type *single;
 
-    if (!ZEND_TYPE_IS_SET(*type)) {
-        return;
-    }
+	if (!ZEND_TYPE_IS_SET(*type)) {
+		return;
+	}
 
-    if (ZEND_TYPE_HAS_LIST(*type)) {
-        zend_type_list *list = ZEND_TYPE_LIST(*type);
+	if (ZEND_TYPE_HAS_LIST(*type)) {
+		zend_type_list *list = ZEND_TYPE_LIST(*type);
 
-        list = php_parallel_cache_copy_mem(
-            	list, ZEND_TYPE_LIST_SIZE(list->num_types));
+		list = php_parallel_cache_copy_mem(list, ZEND_TYPE_LIST_SIZE(list->num_types));
 
-        if (ZEND_TYPE_USES_ARENA(*type)) {
-            ZEND_TYPE_FULL_MASK(*type) &= ~_ZEND_TYPE_ARENA_BIT;
-        }
+		if (ZEND_TYPE_USES_ARENA(*type)) {
+			ZEND_TYPE_FULL_MASK(*type) &= ~_ZEND_TYPE_ARENA_BIT;
+		}
 
-        ZEND_TYPE_SET_PTR(*type, list);
-    }
+		ZEND_TYPE_SET_PTR(*type, list);
+	}
 
-    ZEND_TYPE_FOREACH(*type, single) {
-        if (ZEND_TYPE_HAS_NAME(*single)) {
-            zend_string *name = ZEND_TYPE_NAME(*single);
+	ZEND_TYPE_FOREACH(*type, single)
+	{
+		if (ZEND_TYPE_HAS_NAME(*single)) {
+			zend_string *name = ZEND_TYPE_NAME(*single);
 
-            ZEND_TYPE_SET_PTR(
-                *single,
-                php_parallel_copy_string_interned(name));
-        }
-    } ZEND_TYPE_FOREACH_END();
+			ZEND_TYPE_SET_PTR(*single, php_parallel_copy_string_interned(name));
+		}
+	}
+	ZEND_TYPE_FOREACH_END();
 } /* }}} */
-
 
 /* {{{ */
-static zend_op_array* php_parallel_cache_create(const zend_function *source, bool statics) {
-    zend_op_array *cached = php_parallel_cache_copy_mem((void*) source, sizeof(zend_op_array));
+static zend_op_array *php_parallel_cache_create(const zend_function *source, bool statics)
+{
+	zend_op_array *cached = php_parallel_cache_copy_mem((void *)source, sizeof(zend_op_array));
 
-    cached->fn_flags |= ZEND_ACC_IMMUTABLE;
+	cached->fn_flags |= ZEND_ACC_IMMUTABLE;
 
-    if (statics && cached->static_variables) {
-        cached->static_variables =
-            php_parallel_cache_statics(cached->static_variables);
-    }
+	if (statics && cached->static_variables) {
+		cached->static_variables = php_parallel_cache_statics(cached->static_variables);
+	}
 
 #if PHP_VERSION_ID >= 80200
-    ZEND_MAP_PTR_INIT(cached->static_variables_ptr, cached->static_variables);
+	ZEND_MAP_PTR_INIT(cached->static_variables_ptr, cached->static_variables);
 #else
-    ZEND_MAP_PTR_INIT(cached->static_variables_ptr, &cached->static_variables);
+	ZEND_MAP_PTR_INIT(cached->static_variables_ptr, &cached->static_variables);
 #endif
 
-    ZEND_MAP_PTR_INIT(cached->run_time_cache, NULL);
+	ZEND_MAP_PTR_INIT(cached->run_time_cache, NULL);
 
 #if PHP_VERSION_ID >= 80100
-    if (cached->num_dynamic_func_defs) {
-    	uint32_t it = 0;
+	if (cached->num_dynamic_func_defs) {
+		uint32_t it = 0;
 
-    	cached->dynamic_func_defs = php_parallel_cache_copy_mem(
-    	                                cached->dynamic_func_defs,
-    	                                sizeof(zend_op_array*) * cached->num_dynamic_func_defs);
+		cached->dynamic_func_defs = php_parallel_cache_copy_mem(
+		    cached->dynamic_func_defs, sizeof(zend_op_array *) * cached->num_dynamic_func_defs);
 
-    	while (it < cached->num_dynamic_func_defs) {
-    	    cached->dynamic_func_defs[it] =
-                (zend_op_array*) php_parallel_cache_create(
-    	            (zend_function*) cached->dynamic_func_defs[it], statics);
-            it++;
-    	}
-    }
+		while (it < cached->num_dynamic_func_defs) {
+			cached->dynamic_func_defs[it] =
+			    php_parallel_cache_create((zend_function *)cached->dynamic_func_defs[it], statics);
+			it++;
+		}
+	}
 #endif
 
-    // This path is taken when OPcache is enabled and active, and the `source`
-    // zend_function's opcodes are already handled and stored in OPcache's
-    // Shared Memory (SHM). OPcache sets `op_array->refcount`to `NULL` for such
-    // persistent `op_array`'s.
-    if (!cached->refcount) {
-        goto _php_parallel_cached_function_return;
-    }
+	// This path is taken when OPcache is enabled and active, and the `source`
+	// zend_function's opcodes are already handled and stored in OPcache's
+	// Shared Memory (SHM). OPcache sets `op_array->refcount`to `NULL` for such
+	// persistent `op_array`'s.
+	if (!cached->refcount) {
+		goto _php_parallel_cached_function_return;
+	}
 
-    cached->refcount  = NULL;
+	cached->refcount = NULL;
 
-    if (cached->last_literal) {
-        zval     *literal = cached->literals,
-                 *end     = literal + cached->last_literal;
-        zval     *slot    = php_parallel_cache_copy_mem(
-                                    cached->literals,
-                                        sizeof(zval) * cached->last_literal);
+	if (cached->last_literal) {
+		zval *literal = cached->literals;
+		zval *end = literal + cached->last_literal;
+		zval *slot = php_parallel_cache_copy_mem(cached->literals, sizeof(zval) * cached->last_literal);
 
-        cached->literals = slot;
+		cached->literals = slot;
 
-        while (literal < end) {
-            if (Z_TYPE_P(literal) == IS_ARRAY) {
-                ZVAL_ARR(slot,
-                    php_parallel_copy_hash_persistent(
-                        Z_ARRVAL_P(literal),
-                        php_parallel_copy_string_interned,
-                        php_parallel_cache_copy_mem));
-            } else if (Z_TYPE_P(literal) == IS_STRING) {
-                ZVAL_STR(slot,
-                    php_parallel_copy_string_interned(Z_STR_P(literal)));
-            }
+		while (literal < end) {
+			if (Z_TYPE_P(literal) == IS_ARRAY) {
+				ZVAL_ARR(slot, php_parallel_copy_hash_persistent(Z_ARRVAL_P(literal), php_parallel_copy_string_interned,
+				                                                 php_parallel_cache_copy_mem));
+			} else if (Z_TYPE_P(literal) == IS_STRING) {
+				ZVAL_STR(slot, php_parallel_copy_string_interned(Z_STR_P(literal)));
+			}
 
-	        Z_TYPE_FLAGS_P(slot) &= ~(IS_TYPE_REFCOUNTED|IS_TYPE_COLLECTABLE);
-            literal++;
-            slot++;
-        }
-    }
+			Z_TYPE_FLAGS_P(slot) &= ~(IS_TYPE_REFCOUNTED | IS_TYPE_COLLECTABLE);
+			literal++;
+			slot++;
+		}
+	}
 
-    if (cached->last_var) {
-        zend_string **vars = cached->vars;
-        uint32_t      it = 0,
-                      end = cached->last_var;
-        zend_string **heap = php_parallel_cache_alloc(cached->last_var * sizeof(zend_string*));
+	if (cached->last_var) {
+		zend_string **vars = cached->vars;
+		uint32_t      it = 0;
+		uint32_t      end = cached->last_var;
+		zend_string **heap = php_parallel_cache_alloc(cached->last_var * sizeof(zend_string *));
 
-        while (it < end) {
-            heap[it] =
-                php_parallel_copy_string_interned(vars[it]);
-            it++;
-        }
-        cached->vars = heap;
-    }
+		while (it < end) {
+			heap[it] = php_parallel_copy_string_interned(vars[it]);
+			it++;
+		}
+		cached->vars = heap;
+	}
 
-    if (cached->last) {
-        zend_op *opcodes = php_parallel_cache_copy_mem(cached->opcodes, sizeof(zend_op) * cached->last);
-        zend_op *opline  = opcodes,
-                *end     = opline + cached->last;
+	if (cached->last) {
+		zend_op *opcodes = php_parallel_cache_copy_mem(cached->opcodes, sizeof(zend_op) * cached->last);
+		zend_op *opline = opcodes;
+		zend_op *end = opline + cached->last;
 
-        while (opline < end) {
-            if (opline->op1_type == IS_CONST) {
+		while (opline < end) {
+			if (opline->op1_type == IS_CONST) {
 #if ZEND_USE_ABS_CONST_ADDR
-                opline->op1.zv = (zval*)((char*)opline->op1.zv + ((char*)cached->literals - (char*)source->op_array.literals));
+				opline->op1.zv =
+				    (zval *)((char *)opline->op1.zv + ((char *)cached->literals - (char *)source->op_array.literals));
 #else
-                opline->op1.constant =
-                    (char*)(cached->literals +
-                            ((zval*)((char*)(source->op_array.opcodes + (opline - opcodes)) +
-                            (int32_t)opline->op1.constant) - source->op_array.literals)) -
-                            (char*)opline;
+				opline->op1.constant =
+				    (char *)(cached->literals + ((zval *)((char *)(source->op_array.opcodes + (opline - opcodes)) +
+				                                          (int32_t)opline->op1.constant) -
+				                                 source->op_array.literals)) -
+				    (char *)opline;
 #endif
-                if (opline->opcode == ZEND_SEND_VAL
-                 || opline->opcode == ZEND_SEND_VAL_EX
-                 || opline->opcode == ZEND_QM_ASSIGN) {
-                    zend_vm_set_opcode_handler_ex(opline, 0, 0, 0);
-                }
-            }
-            if (opline->op2_type == IS_CONST) {
+				if (opline->opcode == ZEND_SEND_VAL || opline->opcode == ZEND_SEND_VAL_EX ||
+				    opline->opcode == ZEND_QM_ASSIGN) {
+					zend_vm_set_opcode_handler_ex(opline, 0, 0, 0);
+				}
+			}
+			if (opline->op2_type == IS_CONST) {
 #if ZEND_USE_ABS_CONST_ADDR
-                opline->op2.zv = (zval*)((char*)opline->op2.zv + ((char*)cached->literals - (char*)source->op_array.literals));
+				opline->op2.zv =
+				    (zval *)((char *)opline->op2.zv + ((char *)cached->literals - (char *)source->op_array.literals));
 #else
-                opline->op2.constant =
-                    (char*)(cached->literals +
-                            ((zval*)((char*)(source->op_array.opcodes + (opline - opcodes)) +
-                            (int32_t)opline->op2.constant) - source->op_array.literals)) -
-                            (char*)opline;
+				opline->op2.constant =
+				    (char *)(cached->literals + ((zval *)((char *)(source->op_array.opcodes + (opline - opcodes)) +
+				                                          (int32_t)opline->op2.constant) -
+				                                 source->op_array.literals)) -
+				    (char *)opline;
 #endif
-            }
+			}
 #if ZEND_USE_ABS_JMP_ADDR
-            switch (opline->opcode) {
-                case ZEND_JMP:
-                case ZEND_FAST_CALL:
-                    opline->op1.jmp_addr = &opcodes[opline->op1.jmp_addr - source->op_array.opcodes];
-                break;
+			switch (opline->opcode) {
+			case ZEND_JMP:
+			case ZEND_FAST_CALL:
+				opline->op1.jmp_addr = &opcodes[opline->op1.jmp_addr - source->op_array.opcodes];
+				break;
 #if PHP_VERSION_ID < 80200
-                case ZEND_JMPZNZ:
+			case ZEND_JMPZNZ:
 #endif
-                case ZEND_JMPZ:
-                case ZEND_JMPNZ:
-                case ZEND_JMPZ_EX:
-                case ZEND_JMPNZ_EX:
-                case ZEND_JMP_SET:
-                case ZEND_COALESCE:
-                case ZEND_FE_RESET_R:
-                case ZEND_FE_RESET_RW:
-                case ZEND_ASSERT_CHECK:
-                    opline->op2.jmp_addr = &opcodes[opline->op2.jmp_addr - source->op_array.opcodes];
-                    break;
+			case ZEND_JMPZ:
+			case ZEND_JMPNZ:
+			case ZEND_JMPZ_EX:
+			case ZEND_JMPNZ_EX:
+			case ZEND_JMP_SET:
+			case ZEND_COALESCE:
+			case ZEND_FE_RESET_R:
+			case ZEND_FE_RESET_RW:
+			case ZEND_ASSERT_CHECK:
+				opline->op2.jmp_addr = &opcodes[opline->op2.jmp_addr - source->op_array.opcodes];
+				break;
 
-                case ZEND_CATCH:
-                    if (!(opline->extended_value & ZEND_LAST_CATCH)) {
-                        opline->op2.jmp_addr = &opcodes[opline->op2.jmp_addr - source->op_array.opcodes];
-                    }
-                    break;
-            }
+			case ZEND_CATCH:
+				if (!(opline->extended_value & ZEND_LAST_CATCH)) {
+					opline->op2.jmp_addr = &opcodes[opline->op2.jmp_addr - source->op_array.opcodes];
+				}
+				break;
+			}
 #endif
 
-            opline++;
-        }
-        cached->opcodes = opcodes;
-    }
+			opline++;
+		}
+		cached->opcodes = opcodes;
+	}
 
-    if (cached->arg_info) {
-        zend_arg_info *it    = cached->arg_info,
-                      *end   = it + cached->num_args,
-                      *info;
+	if (cached->arg_info) {
+		zend_arg_info *it = cached->arg_info;
+		zend_arg_info *end = it + cached->num_args;
+		zend_arg_info *info;
 
-        if (cached->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-            it--;
-        }
-        if (cached->fn_flags & ZEND_ACC_VARIADIC) {
-            end++;
-        }
+		if (cached->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+			it--;
+		}
+		if (cached->fn_flags & ZEND_ACC_VARIADIC) {
+			end++;
+		}
 
-        cached->arg_info = info = php_parallel_cache_copy_mem(it, (end - it) * sizeof(zend_arg_info));
+		cached->arg_info = info = php_parallel_cache_copy_mem(it, (end - it) * sizeof(zend_arg_info));
 
-         while (it < end) {
-            if (info->name) {
-                info->name =
-                    php_parallel_copy_string_interned(it->name);
-            }
+		while (it < end) {
+			if (info->name) {
+				info->name = php_parallel_copy_string_interned(it->name);
+			}
 
-            php_parallel_cache_type(&info->type);
+			php_parallel_cache_type(&info->type);
 
-            info++;
-            it++;
-        }
-        if (cached->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-            cached->arg_info++;
-        }
-    }
+			info++;
+			it++;
+		}
+		if (cached->fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+			cached->arg_info++;
+		}
+	}
 
-    if (cached->try_catch_array) {
-        cached->try_catch_array =
-            php_parallel_cache_copy_mem(
-                cached->try_catch_array,
-                    sizeof(zend_try_catch_element) * cached->last_try_catch);
-    }
+	if (cached->try_catch_array) {
+		cached->try_catch_array = php_parallel_cache_copy_mem(cached->try_catch_array,
+		                                                      sizeof(zend_try_catch_element) * cached->last_try_catch);
+	}
 
-    if (cached->live_range) {
-        cached->live_range =
-            php_parallel_cache_copy_mem(
-                cached->live_range,
-                sizeof(zend_live_range) * cached->last_live_range);
-    }
+	if (cached->live_range) {
+		cached->live_range =
+		    php_parallel_cache_copy_mem(cached->live_range, sizeof(zend_live_range) * cached->last_live_range);
+	}
 
-    if (cached->function_name)
-        cached->function_name =
-            php_parallel_copy_string_interned(cached->function_name);
+	if (cached->function_name) {
+		cached->function_name = php_parallel_copy_string_interned(cached->function_name);
+	}
 
-    if (cached->filename)
-        cached->filename =
-            php_parallel_copy_string_interned(cached->filename);
+	if (cached->filename) {
+		cached->filename = php_parallel_copy_string_interned(cached->filename);
+	}
 
-    if (cached->doc_comment)
-        cached->doc_comment =
-            php_parallel_copy_string_interned(cached->doc_comment);
+	if (cached->doc_comment) {
+		cached->doc_comment = php_parallel_copy_string_interned(cached->doc_comment);
+	}
 
 _php_parallel_cached_function_return:
-    return cached;
+	return cached;
 } /* }}} */
 
 /* {{{ */
-static zend_always_inline zend_function* php_parallel_cache_function_ex(const zend_function *source, bool statics) {
-    zend_op_array *cached;
+static zend_always_inline zend_function *php_parallel_cache_function_ex(const zend_function *source, bool statics)
+{
+	zend_op_array *cached;
 
-    pthread_mutex_lock(&PCG(mutex));
+	pthread_mutex_lock(&PCG(mutex));
 
-    if ((cached = zend_hash_index_find_ptr(&PCG(table), (zend_ulong) source->op_array.opcodes))) {
-        goto _php_parallel_cached_function_return;
-    }
+	if ((cached = zend_hash_index_find_ptr(&PCG(table), (zend_ulong)source->op_array.opcodes))) {
+		goto _php_parallel_cached_function_return;
+	}
 
-    cached = php_parallel_cache_create(source, statics);
+	cached = php_parallel_cache_create(source, statics);
 
-    zend_hash_index_add_ptr(
-        &PCG(table),
-        (zend_ulong) source->op_array.opcodes,
-        cached);
+	zend_hash_index_add_ptr(&PCG(table), (zend_ulong)source->op_array.opcodes, cached);
 
 _php_parallel_cached_function_return:
-    pthread_mutex_unlock(&PCG(mutex));
+	pthread_mutex_unlock(&PCG(mutex));
 
-    return (zend_function*) cached;
+	return (zend_function *)cached;
 } /* }}} */
 
-zend_function* php_parallel_cache_closure(const zend_function *source, zend_function *closure) { /* {{{ */
-    zend_op_array *cache;
+zend_function *php_parallel_cache_closure(const zend_function *source, zend_function *closure)
+{ /* {{{ */
+	zend_op_array *cache;
 
-    cache =
-        (zend_op_array*)
-            php_parallel_cache_function_ex(
-                (zend_function*) source, 0);
+	cache = (zend_op_array *)php_parallel_cache_function_ex((zend_function *)source, 0);
 
-    if (!closure) {
-        closure = php_parallel_copy_mem(
-            cache, sizeof(zend_op_array), 1);
-    } else {
-        memcpy(closure, cache, sizeof(zend_op_array));
-    }
+	if (!closure) {
+		closure = php_parallel_copy_mem(cache, sizeof(zend_op_array), 1);
+	} else {
+		memcpy(closure, cache, sizeof(zend_op_array));
+	}
 
-    if (source->op_array.static_variables) {
-        HashTable *statics =
-            ZEND_MAP_PTR_GET(
-                source->op_array.static_variables_ptr);
+	if (source->op_array.static_variables) {
+		HashTable *statics = ZEND_MAP_PTR_GET(source->op_array.static_variables_ptr);
 
-        if (statics) {
-        closure->op_array.static_variables =
-            php_parallel_copy_hash_ctor(statics, 1);
+		if (statics) {
+			closure->op_array.static_variables = php_parallel_copy_hash_ctor(statics, 1);
 
 #if PHP_VERSION_ID >= 80200
-        ZEND_MAP_PTR_INIT(
-            closure->op_array.static_variables_ptr,
-            closure->op_array.static_variables);
+			ZEND_MAP_PTR_INIT(closure->op_array.static_variables_ptr, closure->op_array.static_variables);
 #else
-        ZEND_MAP_PTR_INIT(
-            closure->op_array.static_variables_ptr,
-            &closure->op_array.static_variables);
+			ZEND_MAP_PTR_INIT(closure->op_array.static_variables_ptr, &closure->op_array.static_variables);
 #endif
-        }
-    }
+		}
+	}
 
 #if PHP_VERSION_ID >= 80100
-    if (source->op_array.num_dynamic_func_defs) {
-        uint32_t it = 0;
-        /* Use regular persistent memory for dynamic_func_defs array, not cache pool */
-        closure->op_array.dynamic_func_defs = pemalloc(
-            sizeof(zend_op_array*) * source->op_array.num_dynamic_func_defs, 1);
-        memcpy(closure->op_array.dynamic_func_defs,
-            source->op_array.dynamic_func_defs,
-            sizeof(zend_op_array*) * source->op_array.num_dynamic_func_defs);
-        while (it < source->op_array.num_dynamic_func_defs) {
-            closure->op_array.dynamic_func_defs[it] = (zend_op_array*) php_parallel_cache_closure((zend_function*) source->op_array.dynamic_func_defs[it], NULL);
-            it++;
-        }
-    }
+	if (source->op_array.num_dynamic_func_defs) {
+		uint32_t it = 0;
+		/* Use regular persistent memory for dynamic_func_defs array, not cache pool */
+		closure->op_array.dynamic_func_defs =
+		    pemalloc(sizeof(zend_op_array *) * source->op_array.num_dynamic_func_defs, 1);
+		memcpy(closure->op_array.dynamic_func_defs, source->op_array.dynamic_func_defs,
+		       sizeof(zend_op_array *) * source->op_array.num_dynamic_func_defs);
+		while (it < source->op_array.num_dynamic_func_defs) {
+			closure->op_array.dynamic_func_defs[it] = (zend_op_array *)php_parallel_cache_closure(
+			    (zend_function *)source->op_array.dynamic_func_defs[it], NULL);
+			it++;
+		}
+	}
 #endif
 
-    return closure;
+	return closure;
 } /* }}} */
 
-zend_function* php_parallel_cache_function(const zend_function *source) { /* {{{ */
-    return php_parallel_cache_function_ex(source, 1);
+zend_function *php_parallel_cache_function(const zend_function *source)
+{ /* {{{ */
+	return php_parallel_cache_function_ex(source, 1);
 } /* }}} */
 
 /* {{{ */
 PHP_MINIT_FUNCTION(PARALLEL_CACHE)
 {
-    zend_hash_init(&PCG(table), 32, NULL, NULL, 1);
+	zend_hash_init(&PCG(table), 32, NULL, NULL, 1);
 
-    PCM(size) = PARALLEL_CACHE_CHUNK;
-    PCM(mem) =
-        PCM(block) =
-            malloc(PCM(size));
+	PCM(size) = PARALLEL_CACHE_CHUNK;
+	PCM(mem) = PCM(block) = malloc(PCM(size));
 
-    if (!PCM(mem)) {
-        /* out of memory */
-    }
+	if (!PCM(mem)) {
+		/* out of memory */
+	}
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_CACHE)
 {
-    zend_hash_destroy(&PCG(table));
+	zend_hash_destroy(&PCG(table));
 
-    if (PCM(mem))
-        free(PCM(mem));
+	if (PCM(mem)) {
+		free(PCM(mem));
+	}
 
-    return SUCCESS;
+	return SUCCESS;
 } /* }}} */
 #endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -19,22 +19,22 @@
 #define HAVE_PARALLEL_CACHE_H
 
 /*
-* parallel is intended to be used with opcache, and whether it is loaded or
-* not, this function shall return a permanently allocated (immutable)
-* copy of the source function, with no reference count and immutable statics.
-*/
-zend_function* php_parallel_cache_function(const zend_function *source);
+ * parallel is intended to be used with opcache, and whether it is loaded or
+ * not, this function shall return a permanently allocated (immutable)
+ * copy of the source function, with no reference count and immutable statics.
+ */
+zend_function *php_parallel_cache_function(const zend_function *source);
 
 /*
-* parallel must be able to buffer closures in persistent (but not permanent)
-* memory for transfer to different contexts.
-*
-* this function shall return an (immutable) copy of the source closure,
-* with no reference count, and immutable statics as they are
-* at the time of the call.
-* If destination is null it will be allocated for return value.
-*/
-zend_function* php_parallel_cache_closure(const zend_function *source, zend_function *destination);
+ * parallel must be able to buffer closures in persistent (but not permanent)
+ * memory for transfer to different contexts.
+ *
+ * this function shall return an (immutable) copy of the source closure,
+ * with no reference count, and immutable statics as they are
+ * at the time of the call.
+ * If destination is null it will be allocated for return value.
+ */
+zend_function *php_parallel_cache_closure(const zend_function *source, zend_function *destination);
 
 PHP_MINIT_FUNCTION(PARALLEL_CACHE);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_CACHE);

--- a/src/channel.c
+++ b/src/channel.c
@@ -21,213 +21,191 @@
 #include "parallel.h"
 
 typedef struct _php_parallel_channels_t {
-    php_parallel_monitor_t *monitor;
-    zend_ulong              idc;
-    HashTable links;
+	php_parallel_monitor_t *monitor;
+	zend_ulong              idc;
+	HashTable               links;
 } php_parallel_channels_t;
 
-php_parallel_channels_t php_parallel_channels = {NULL, 0};
+php_parallel_channels_t        php_parallel_channels = {NULL, 0};
 
-zend_class_entry *php_parallel_channel_ce;
-zend_object_handlers php_parallel_channel_handlers;
+zend_class_entry              *php_parallel_channel_ce;
+zend_object_handlers           php_parallel_channel_handlers;
 
-static zend_always_inline void php_parallel_channels_make_ex(php_parallel_channel_t *channel, zend_string *name, bool buffered, zend_long capacity) {
-    channel->link = php_parallel_link_init(name, buffered, capacity);
+static zend_always_inline void php_parallel_channels_make_ex(php_parallel_channel_t *channel, zend_string *name,
+                                                             bool buffered, zend_long capacity)
+{
+	channel->link = php_parallel_link_init(name, buffered, capacity);
 
-    zend_hash_add_ptr(
-        &php_parallel_channels.links,
-        php_parallel_link_name(channel->link),
-        php_parallel_link_copy(channel->link));
+	zend_hash_add_ptr(&php_parallel_channels.links, php_parallel_link_name(channel->link),
+	                  php_parallel_link_copy(channel->link));
 }
 
-static zend_always_inline void php_parallel_channels_make(zval *return_value, zend_string *name, bool buffered, zend_long capacity) {
-    object_init_ex(return_value, php_parallel_channel_ce);
+static zend_always_inline void php_parallel_channels_make(zval *return_value, zend_string *name, bool buffered,
+                                                          zend_long capacity)
+{
+	object_init_ex(return_value, php_parallel_channel_ce);
 
-    php_parallel_channels_make_ex(
-        php_parallel_channel_from(return_value),
-        name,
-        buffered,
-        capacity);
+	php_parallel_channels_make_ex(php_parallel_channel_from(return_value), name, buffered, capacity);
 }
 
-static zend_always_inline void php_parallel_channels_open(zval *return_value, php_parallel_link_t *link) {
-    php_parallel_channel_t *channel;
+static zend_always_inline void php_parallel_channels_open(zval *return_value, php_parallel_link_t *link)
+{
+	php_parallel_channel_t *channel;
 
-    object_init_ex(return_value, php_parallel_channel_ce);
+	object_init_ex(return_value, php_parallel_channel_ce);
 
-    channel = php_parallel_channel_from(return_value);
-    channel->link = php_parallel_link_copy(link);
+	channel = php_parallel_channel_from(return_value);
+	channel->link = php_parallel_link_copy(link);
 }
 
-static zend_always_inline zend_string* php_parallel_channels_name(zend_execute_data *execute_data) {
-    while (EX(func)->type != ZEND_USER_FUNCTION) {
-        execute_data = EX(prev_execute_data);
-    }
+static zend_always_inline zend_string *php_parallel_channels_name(zend_execute_data *execute_data)
+{
+	while (EX(func)->type != ZEND_USER_FUNCTION) {
+		execute_data = EX(prev_execute_data);
+	}
 
-    if ((EX(func)->op_array.function_name == NULL) || (EX(func)->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
-            return zend_strpprintf(0, "%s#%u@%p[" ZEND_ULONG_FMT "]",
-                ZSTR_VAL(EX(func)->op_array.filename),
-                EX(opline)->lineno,
-                EX(opline),
-                ++php_parallel_channels.idc);
-    } else {
-        if (EX(func)->op_array.scope) {
-            return zend_strpprintf(0, "%s::%s#%u@%p[" ZEND_ULONG_FMT "]",
-                ZSTR_VAL(EX(func)->op_array.scope->name),
-                ZSTR_VAL(EX(func)->op_array.function_name),
-                EX(opline)->lineno,
-                EX(opline),
-                ++php_parallel_channels.idc);
-        } else {
-            return zend_strpprintf(0, "%s#%u@%p[" ZEND_ULONG_FMT "]",
-                ZSTR_VAL(EX(func)->op_array.function_name),
-                EX(opline)->lineno,
-                EX(opline),
-                ++php_parallel_channels.idc);
-        }
-    }
+	if ((EX(func)->op_array.function_name == NULL) || (EX(func)->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+		return zend_strpprintf(0, "%s#%u@%p[" ZEND_ULONG_FMT "]", ZSTR_VAL(EX(func)->op_array.filename),
+		                       EX(opline)->lineno, EX(opline), ++php_parallel_channels.idc);
+	} else {
+		if (EX(func)->op_array.scope) {
+			return zend_strpprintf(0, "%s::%s#%u@%p[" ZEND_ULONG_FMT "]", ZSTR_VAL(EX(func)->op_array.scope->name),
+			                       ZSTR_VAL(EX(func)->op_array.function_name), EX(opline)->lineno, EX(opline),
+			                       ++php_parallel_channels.idc);
+		} else {
+			return zend_strpprintf(0, "%s#%u@%p[" ZEND_ULONG_FMT "]", ZSTR_VAL(EX(func)->op_array.function_name),
+			                       EX(opline)->lineno, EX(opline), ++php_parallel_channels.idc);
+		}
+	}
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_channel_construct_arginfo, 0, 0, 0)
-    ZEND_ARG_TYPE_INFO(0, capacity, IS_LONG, 0)
+ZEND_ARG_TYPE_INFO(0, capacity, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, __construct)
 {
-    php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
-    zend_long capacity = -1;
-    bool buffered = 0;
-    zend_string *name = NULL;
+	php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
+	zend_long               capacity = -1;
+	bool                    buffered = 0;
+	zend_string            *name = NULL;
 
-    if (ZEND_NUM_ARGS()) {
-        ZEND_PARSE_PARAMETERS_START(0, 1)
-            Z_PARAM_OPTIONAL
-            Z_PARAM_LONG(capacity)
-        ZEND_PARSE_PARAMETERS_END();
+	if (ZEND_NUM_ARGS()) {
+		ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG(capacity)
+		ZEND_PARSE_PARAMETERS_END();
 
-        if (capacity < -1 || capacity == 0) {
-            php_parallel_invalid_arguments(
-                "capacity may be -1 for unlimited, or a positive integer");
-            return;
-        }
+		if (capacity < -1 || capacity == 0) {
+			php_parallel_invalid_arguments("capacity may be -1 for unlimited, or a positive integer");
+			return;
+		}
 
-        buffered = 1;
-    }
+		buffered = 1;
+	}
 
-    php_parallel_monitor_lock(php_parallel_channels.monitor);
+	php_parallel_monitor_lock(php_parallel_channels.monitor);
 
-    name = php_parallel_channels_name(EX(prev_execute_data));
+	name = php_parallel_channels_name(EX(prev_execute_data));
 
-    php_parallel_channels_make_ex(
-        channel, name, buffered, capacity);
+	php_parallel_channels_make_ex(channel, name, buffered, capacity);
 
-    php_parallel_monitor_unlock(php_parallel_channels.monitor);
+	php_parallel_monitor_unlock(php_parallel_channels.monitor);
 
-    zend_string_release(name);
+	zend_string_release(name);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_parallel_channel_make_arginfo, 0, 1, \\parallel\\Channel, 0)
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-    ZEND_ARG_TYPE_INFO(0, capacity, IS_LONG, 0)
+ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, capacity, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, make)
 {
-    zend_string *name = NULL;
-    bool    buffered = 0;
-    zend_long    capacity = -1;
+	zend_string *name = NULL;
+	bool         buffered = 0;
+	zend_long    capacity = -1;
 
-    if (ZEND_NUM_ARGS() == 1) {
-        ZEND_PARSE_PARAMETERS_START(1, 1)
-            Z_PARAM_STR(name)
-        ZEND_PARSE_PARAMETERS_END();
-    } else {
-        ZEND_PARSE_PARAMETERS_START(2, 2)
-            Z_PARAM_STR(name)
-            Z_PARAM_LONG(capacity)
-        ZEND_PARSE_PARAMETERS_END();
+	if (ZEND_NUM_ARGS() == 1) {
+		ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+		ZEND_PARSE_PARAMETERS_END();
+	} else {
+		ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_LONG(capacity)
+		ZEND_PARSE_PARAMETERS_END();
 
-        if (capacity < -1 || capacity == 0) {
-            php_parallel_invalid_arguments(
-                "capacity may be -1 for unlimited, or a positive integer");
-            return;
-        }
+		if (capacity < -1 || capacity == 0) {
+			php_parallel_invalid_arguments("capacity may be -1 for unlimited, or a positive integer");
+			return;
+		}
 
-        buffered = 1;
-    }
+		buffered = 1;
+	}
 
-    php_parallel_monitor_lock(php_parallel_channels.monitor);
+	php_parallel_monitor_lock(php_parallel_channels.monitor);
 
-    if (zend_hash_exists(&php_parallel_channels.links, name)) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_existence_ce,
-            "channel named %s already exists",
-            ZSTR_VAL(name));
-    } else {
-        php_parallel_channels_make(return_value, name, buffered, capacity);
-    }
+	if (zend_hash_exists(&php_parallel_channels.links, name)) {
+		php_parallel_exception_ex(php_parallel_channel_error_existence_ce, "channel named %s already exists",
+		                          ZSTR_VAL(name));
+	} else {
+		php_parallel_channels_make(return_value, name, buffered, capacity);
+	}
 
-    php_parallel_monitor_unlock(php_parallel_channels.monitor);
+	php_parallel_monitor_unlock(php_parallel_channels.monitor);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_parallel_channel_open_arginfo, 0, 1, \\parallel\\Channel, 0)
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, open)
 {
-    zend_string *name = NULL;
-    php_parallel_link_t *link;
+	zend_string         *name = NULL;
+	php_parallel_link_t *link;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_STR(name)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
 
-    php_parallel_monitor_lock(php_parallel_channels.monitor);
+	php_parallel_monitor_lock(php_parallel_channels.monitor);
 
-    if (!(link = zend_hash_find_ptr(&php_parallel_channels.links, name))) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_existence_ce,
-            "channel named %s not found",
-            ZSTR_VAL(name));
-    } else {
-        php_parallel_channels_open(return_value, link);
-    }
+	if (!(link = zend_hash_find_ptr(&php_parallel_channels.links, name))) {
+		php_parallel_exception_ex(php_parallel_channel_error_existence_ce, "channel named %s not found",
+		                          ZSTR_VAL(name));
+	} else {
+		php_parallel_channels_open(return_value, link);
+	}
 
-    php_parallel_monitor_unlock(php_parallel_channels.monitor);
+	php_parallel_monitor_unlock(php_parallel_channels.monitor);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_channel_send_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_INFO(0, value)
+ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, send)
 {
-    php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
-    zval *value, *error;
+	php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
+	zval                   *value, *error;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ZVAL(value)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!PARALLEL_ZVAL_CHECK(value, &error)) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_illegal_value_ce,
-            "value of type %s is illegal",
-            Z_TYPE_P(error) == IS_OBJECT ?
-                ZSTR_VAL(Z_OBJCE_P(error)->name) :
-                zend_get_type_by_const(Z_TYPE_P(error)));
-        return;
-    }
+	if (!PARALLEL_ZVAL_CHECK(value, &error)) {
+		php_parallel_exception_ex(php_parallel_channel_error_illegal_value_ce, "value of type %s is illegal",
+		                          Z_TYPE_P(error) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(error)->name)
+		                                                       : zend_get_type_by_const(Z_TYPE_P(error)));
+		return;
+	}
 
-    if (php_parallel_link_closed(channel->link) ||
-        !php_parallel_link_send(channel->link, value)) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_closed_ce,
-            "channel(%s) closed",
-            ZSTR_VAL(php_parallel_link_name(channel->link)));
-        return;
-    }
+	if (php_parallel_link_closed(channel->link) || !php_parallel_link_send(channel->link, value)) {
+		php_parallel_exception_ex(php_parallel_channel_error_closed_ce, "channel(%s) closed",
+		                          ZSTR_VAL(php_parallel_link_name(channel->link)));
+		return;
+	}
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_channel_recv_arginfo, 0, 0, 0)
@@ -235,17 +213,15 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, recv)
 {
-    php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
+	php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    if (!php_parallel_link_recv(channel->link, return_value)) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_closed_ce,
-            "channel(%s) closed",
-            ZSTR_VAL(php_parallel_link_name(channel->link)));
-        return;
-    }
+	if (!php_parallel_link_recv(channel->link, return_value)) {
+		php_parallel_exception_ex(php_parallel_channel_error_closed_ce, "channel(%s) closed",
+		                          ZSTR_VAL(php_parallel_link_name(channel->link)));
+		return;
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_channel_close_arginfo, 0, 0, IS_VOID, 0)
@@ -253,22 +229,18 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, close)
 {
-    php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
+	php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    if (!php_parallel_link_close(channel->link)) {
-        php_parallel_exception_ex(
-            php_parallel_channel_error_closed_ce,
-            "channel(%s) already closed",
-            ZSTR_VAL(php_parallel_link_name(channel->link)));
-    }
+	if (!php_parallel_link_close(channel->link)) {
+		php_parallel_exception_ex(php_parallel_channel_error_closed_ce, "channel(%s) already closed",
+		                          ZSTR_VAL(php_parallel_link_name(channel->link)));
+	}
 
-    php_parallel_monitor_lock(php_parallel_channels.monitor);
-    zend_hash_del(
-        &php_parallel_channels.links,
-            php_parallel_link_name(channel->link));
-    php_parallel_monitor_unlock(php_parallel_channels.monitor);
+	php_parallel_monitor_lock(php_parallel_channels.monitor);
+	zend_hash_del(&php_parallel_channels.links, php_parallel_link_name(channel->link));
+	php_parallel_monitor_unlock(php_parallel_channels.monitor);
 }
 
 #ifdef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
@@ -280,147 +252,137 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Channel, __toString)
 {
-    php_parallel_channel_t *channel =
-        php_parallel_channel_from(getThis());
+	php_parallel_channel_t *channel = php_parallel_channel_from(getThis());
 
-    RETURN_STR_COPY(php_parallel_link_name(channel->link));
+	RETURN_STR_COPY(php_parallel_link_name(channel->link));
 }
 
 zend_function_entry php_parallel_channel_methods[] = {
     PHP_ME(Parallel_Channel, __construct, php_parallel_channel_construct_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Channel, make, php_parallel_channel_make_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-    PHP_ME(Parallel_Channel, open, php_parallel_channel_open_arginfo, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-    PHP_ME(Parallel_Channel, send, php_parallel_channel_send_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Channel, recv, php_parallel_channel_recv_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Channel, close, php_parallel_channel_close_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Channel, __toString, php_parallel_channel___toString_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+        PHP_ME(Parallel_Channel, make, php_parallel_channel_make_arginfo, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+            PHP_ME(Parallel_Channel, open, php_parallel_channel_open_arginfo, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+                PHP_ME(Parallel_Channel, send, php_parallel_channel_send_arginfo, ZEND_ACC_PUBLIC)
+                    PHP_ME(Parallel_Channel, recv, php_parallel_channel_recv_arginfo, ZEND_ACC_PUBLIC)
+                        PHP_ME(Parallel_Channel, close, php_parallel_channel_close_arginfo, ZEND_ACC_PUBLIC)
+                            PHP_ME(Parallel_Channel, __toString, php_parallel_channel___toString_arginfo,
+                                   ZEND_ACC_PUBLIC) PHP_FE_END};
 
-static zend_object* php_parallel_channel_create(zend_class_entry *type) {
-    php_parallel_channel_t *channel = ecalloc(1,
-            sizeof(php_parallel_channel_t) + zend_object_properties_size(type));
+static zend_object *php_parallel_channel_create(zend_class_entry *type)
+{
+	php_parallel_channel_t *channel = ecalloc(1, sizeof(php_parallel_channel_t) + zend_object_properties_size(type));
 
-    zend_object_std_init(&channel->std, type);
+	zend_object_std_init(&channel->std, type);
 
-    channel->std.handlers = &php_parallel_channel_handlers;
+	channel->std.handlers = &php_parallel_channel_handlers;
 
-    return &channel->std;
+	return &channel->std;
 }
 
-static void php_parallel_channel_destroy(zend_object *o) {
-    php_parallel_channel_t *channel =
-        php_parallel_channel_fetch(o);
+static void php_parallel_channel_destroy(zend_object *o)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(o);
 
-    if (channel->link) {
-        php_parallel_link_destroy(channel->link);
-    }
+	if (channel->link) {
+		php_parallel_link_destroy(channel->link);
+	}
 
-    zend_object_std_dtor(o);
+	zend_object_std_dtor(o);
 }
 
-static int php_parallel_channel_compare(zval *lhs, zval *rhs) {
-    zend_object *lho = Z_OBJ_P(lhs),
-                *rho = Z_OBJ_P(rhs);
-    php_parallel_channel_t *lhc, *rhc;
+static int php_parallel_channel_compare(zval *lhs, zval *rhs)
+{
+	zend_object            *lho = Z_OBJ_P(lhs), *rho = Z_OBJ_P(rhs);
+	php_parallel_channel_t *lhc, *rhc;
 
-    lhc = php_parallel_channel_fetch(lho),
-    rhc = php_parallel_channel_fetch(rho);
+	lhc = php_parallel_channel_fetch(lho), rhc = php_parallel_channel_fetch(rho);
 
-    if (lhc->link == rhc->link) {
-        return 0;
-    }
+	if (lhc->link == rhc->link) {
+		return 0;
+	}
 
-    return 1;
+	return 1;
 }
 
-static HashTable* php_parallel_channel_debug(zend_object *zo, int *temp) {
-    php_parallel_channel_t *channel = php_parallel_channel_fetch(zo);
-    HashTable *debug;
+static HashTable *php_parallel_channel_debug(zend_object *zo, int *temp)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(zo);
+	HashTable              *debug;
 
-    *temp = 1;
+	*temp = 1;
 
-    ALLOC_HASHTABLE(debug);
-    zend_hash_init(debug, 3, NULL, ZVAL_PTR_DTOR, 0);
+	ALLOC_HASHTABLE(debug);
+	zend_hash_init(debug, 3, NULL, ZVAL_PTR_DTOR, 0);
 
-    php_parallel_link_debug(channel->link, debug);
+	php_parallel_link_debug(channel->link, debug);
 
-    return debug;
+	return debug;
 }
 
-static void php_parallel_channels_link_destroy(zval *zv) {
-    php_parallel_link_t *link = Z_PTR_P(zv);
+static void php_parallel_channels_link_destroy(zval *zv)
+{
+	php_parallel_link_t *link = Z_PTR_P(zv);
 
-    php_parallel_link_destroy(link);
+	php_parallel_link_destroy(link);
 }
 
-static zend_object* php_parallel_channel_clone(zend_object *src) {
-    php_parallel_channel_t *channel = php_parallel_channel_fetch(src);
-    php_parallel_channel_t *clone = ecalloc(1,
-            sizeof(php_parallel_channel_t) + 
-            zend_object_properties_size(channel->std.ce));
+static zend_object *php_parallel_channel_clone(zend_object *src)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(src);
+	php_parallel_channel_t *clone =
+	    ecalloc(1, sizeof(php_parallel_channel_t) + zend_object_properties_size(channel->std.ce));
 
-    zend_object_std_init(&clone->std, channel->std.ce);
+	zend_object_std_init(&clone->std, channel->std.ce);
 
-    clone->std.handlers = 
-        &php_parallel_channel_handlers;
-    clone->link = php_parallel_link_copy(channel->link);
+	clone->std.handlers = &php_parallel_channel_handlers;
+	clone->link = php_parallel_link_copy(channel->link);
 
-    return &clone->std;
+	return &clone->std;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_CHANNEL)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(
-        &php_parallel_channel_handlers,
-        php_parallel_standard_handlers(),
-        sizeof(zend_object_handlers));
+	memcpy(&php_parallel_channel_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_channel_handlers.offset = XtOffsetOf(php_parallel_channel_t, std);
-    php_parallel_channel_handlers.free_obj        = php_parallel_channel_destroy;
-    php_parallel_channel_handlers.compare = php_parallel_channel_compare;
-    php_parallel_channel_handlers.get_debug_info  = php_parallel_channel_debug;
-    php_parallel_channel_handlers.clone_obj       = php_parallel_channel_clone;
+	php_parallel_channel_handlers.offset = XtOffsetOf(php_parallel_channel_t, std);
+	php_parallel_channel_handlers.free_obj = php_parallel_channel_destroy;
+	php_parallel_channel_handlers.compare = php_parallel_channel_compare;
+	php_parallel_channel_handlers.get_debug_info = php_parallel_channel_debug;
+	php_parallel_channel_handlers.clone_obj = php_parallel_channel_clone;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Channel", php_parallel_channel_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Channel", php_parallel_channel_methods);
 
-    php_parallel_channel_ce = zend_register_internal_class(&ce);
-    php_parallel_channel_ce->create_object = php_parallel_channel_create;
-    php_parallel_channel_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_channel_ce = zend_register_internal_class(&ce);
+	php_parallel_channel_ce->create_object = php_parallel_channel_create;
+	php_parallel_channel_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_channel_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_channel_ce->serialize = zend_class_serialize_deny;
-        php_parallel_channel_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_channel_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_channel_ce->serialize = zend_class_serialize_deny;
+	php_parallel_channel_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    zend_declare_class_constant_long(php_parallel_channel_ce, ZEND_STRL("Infinite"), -1);
+	zend_declare_class_constant_long(php_parallel_channel_ce, ZEND_STRL("Infinite"), -1);
 
-    php_parallel_channels.monitor = php_parallel_monitor_create();
+	php_parallel_channels.monitor = php_parallel_monitor_create();
 
-    zend_hash_init(
-        &php_parallel_channels.links,
-        32,
-        NULL,
-        php_parallel_channels_link_destroy, 1);
+	zend_hash_init(&php_parallel_channels.links, 32, NULL, php_parallel_channels_link_destroy, 1);
 
-    PHP_MINIT(PARALLEL_LINK)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_LINK)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_CHANNEL)
 {
-    php_parallel_monitor_destroy(
-        php_parallel_channels.monitor);
-    zend_hash_destroy(&php_parallel_channels.links);
+	php_parallel_monitor_destroy(php_parallel_channels.monitor);
+	zend_hash_destroy(&php_parallel_channels.links);
 
-    PHP_MSHUTDOWN(PARALLEL_LINK)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_LINK)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 #endif

--- a/src/channel.h
+++ b/src/channel.h
@@ -21,19 +21,21 @@
 #include "link.h"
 
 typedef struct _php_parallel_channel_t {
-    php_parallel_link_t *link;
-    zend_object std;
+	php_parallel_link_t *link;
+	zend_object          std;
 } php_parallel_channel_t;
 
-extern zend_class_entry *php_parallel_channel_ce;
-extern zend_object_handlers php_parallel_channel_handlers;
+extern zend_class_entry                          *php_parallel_channel_ce;
+extern zend_object_handlers                       php_parallel_channel_handlers;
 
-static zend_always_inline php_parallel_channel_t* php_parallel_channel_fetch(zend_object *o) {
-    return (php_parallel_channel_t*) (((char*) o) - XtOffsetOf(php_parallel_channel_t, std));
+static zend_always_inline php_parallel_channel_t *php_parallel_channel_fetch(zend_object *o)
+{
+	return (php_parallel_channel_t *)(((char *)o) - XtOffsetOf(php_parallel_channel_t, std));
 }
 
-static zend_always_inline php_parallel_channel_t* php_parallel_channel_from(zval *z) {
-    return php_parallel_channel_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_channel_t *php_parallel_channel_from(zval *z)
+{
+	return php_parallel_channel_fetch(Z_OBJ_P(z));
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_CHANNEL);

--- a/src/check.c
+++ b/src/check.c
@@ -21,10 +21,10 @@
 #include "parallel.h"
 
 TSRM_TLS struct {
-    HashTable tasks;
-    HashTable functions;
-    HashTable types;
-    HashTable classes;
+	HashTable tasks;
+	HashTable functions;
+	HashTable types;
+	HashTable classes;
 } php_parallel_check_globals;
 
 #ifndef ZEND_TYPE_IS_COMPLEX
@@ -34,781 +34,756 @@ TSRM_TLS struct {
 #define PCG(e) php_parallel_check_globals.e
 
 typedef struct _php_parallel_check_task_t {
-    zend_function *function;
-    bool      returns;
+	zend_function *function;
+	bool           returns;
 } php_parallel_check_task_t;
 
 typedef struct _php_parallel_check_function_t {
-    zend_function *function;
-    zend_uchar     instruction;
-    bool      valid;
+	zend_function *function;
+	zend_uchar     instruction;
+	bool           valid;
 } php_parallel_check_function_t;
 
 typedef struct _php_parallel_check_type_t {
-    bool valid;
+	bool valid;
 } php_parallel_check_type_t;
 
 typedef enum {
-    PHP_PARALLEL_CHECK_CLASS_UNKNOWN,
-    PHP_PARALLEL_CHECK_CLASS_VALID,
-    PHP_PARALLEL_CHECK_CLASS_INVALID,
-    PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY
+	PHP_PARALLEL_CHECK_CLASS_UNKNOWN,
+	PHP_PARALLEL_CHECK_CLASS_VALID,
+	PHP_PARALLEL_CHECK_CLASS_INVALID,
+	PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY
 } php_parallel_check_class_result_t;
 
 typedef struct _php_parallel_check_class_t {
-    php_parallel_check_class_result_t result;
+	php_parallel_check_class_result_t result;
 } php_parallel_check_class_t;
 
-static zend_always_inline const char* php_parallel_check_opcode_name(zend_uchar opcode) { /* {{{ */
-    switch (opcode) {
-        case ZEND_DECLARE_CLASS:
-        case ZEND_DECLARE_CLASS_DELAYED:
-            return "class";
+static zend_always_inline const char *php_parallel_check_opcode_name(zend_uchar opcode)
+{ /* {{{ */
+	switch (opcode) {
+	case ZEND_DECLARE_CLASS:
+	case ZEND_DECLARE_CLASS_DELAYED:
+		return "class";
 
-        case ZEND_DECLARE_ANON_CLASS:
-            return "new class";
+	case ZEND_DECLARE_ANON_CLASS:
+		return "new class";
 
-        case ZEND_YIELD:
-        case ZEND_YIELD_FROM:
-            return "yield";
+	case ZEND_YIELD:
+	case ZEND_YIELD_FROM:
+		return "yield";
 
-        case ZEND_DECLARE_FUNCTION:
-            return "function";
+	case ZEND_DECLARE_FUNCTION:
+		return "function";
 
-        default:
-            return "class";
-    }
+	default:
+		return "class";
+	}
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_type(zend_type type) { /* {{{ */
-    zend_string      *name;
-    zend_type        *single;
-    zend_class_entry *class;
-    php_parallel_check_type_t check, *checked;
+static zend_always_inline bool php_parallel_check_type(zend_type type)
+{ /* {{{ */
+	zend_string *name;
+	zend_type   *single;
+	zend_class_entry *class;
+	php_parallel_check_type_t check, *checked;
 
-    if (ZEND_TYPE_HAS_LIST(type)) {
-        ZEND_TYPE_FOREACH(type, single) {
-            if (ZEND_TYPE_HAS_NAME(*single)) {
-                name = ZEND_TYPE_NAME(*single);
-                
-                if ((checked = zend_hash_find_ptr(&PCG(types), name))) {
-                    if (!checked->valid) {
-                        return 0;
-                    }
-                    continue;
-                }
-                
-                class = zend_lookup_class(ZEND_TYPE_NAME(*single));
+	if (ZEND_TYPE_HAS_LIST(type)) {
+		ZEND_TYPE_FOREACH(type, single)
+		{
+			if (ZEND_TYPE_HAS_NAME(*single)) {
+				name = ZEND_TYPE_NAME(*single);
 
-                if (!class) {
-                    return 0;
-                }
-                
-                memset(&check, 0, sizeof(php_parallel_check_type_t));
-                
-                if (class == zend_ce_closure ||
-                    class == php_parallel_channel_ce ||
-                    instanceof_function(class, php_parallel_sync_ce) ||
-                    !class->create_object) {
+				if ((checked = zend_hash_find_ptr(&PCG(types), name))) {
+					if (!checked->valid) {
+						return 0;
+					}
+					continue;
+				}
 
-                    check.valid = 1;
-                }
-                
-                zend_hash_add_mem(
-                    &PCG(types), name, &check, sizeof(php_parallel_check_type_t));
-                    
-                if (!check.valid) {
-                    return 0;
-                }
-            }
-        } ZEND_TYPE_FOREACH_END();
+				class = zend_lookup_class(ZEND_TYPE_NAME(*single));
 
-        return 1;
-    }
-    
-    name = ZEND_TYPE_NAME(type);
+				if (!class) {
+					return 0;
+				}
 
-    if ((checked = zend_hash_find_ptr(&PCG(types), name))) {
-        return checked->valid;
-    }
+				memset(&check, 0, sizeof(php_parallel_check_type_t));
 
-    class = zend_lookup_class(name);
+				if (class == zend_ce_closure || class == php_parallel_channel_ce ||
+				    instanceof_function(class, php_parallel_sync_ce) || !class->create_object) {
 
-    if (!class) {
-        return 0;
-    }
+					check.valid = 1;
+				}
 
-    memset(&check, 0, sizeof(php_parallel_check_type_t));
+				zend_hash_add_mem(&PCG(types), name, &check, sizeof(php_parallel_check_type_t));
 
-    if (class == zend_ce_closure ||
-        class == php_parallel_channel_ce ||
-        instanceof_function(class, php_parallel_sync_ce) ||
-        !class->create_object) {
+				if (!check.valid) {
+					return 0;
+				}
+			}
+		}
+		ZEND_TYPE_FOREACH_END();
 
-        check.valid = 1;
-    }
+		return 1;
+	}
 
-    zend_hash_add_mem(&PCG(types), name, &check, sizeof(php_parallel_check_type_t));
+	name = ZEND_TYPE_NAME(type);
 
-    return check.valid;
+	if ((checked = zend_hash_find_ptr(&PCG(types), name))) {
+		return checked->valid;
+	}
+
+	class = zend_lookup_class(name);
+
+	if (!class) {
+		return 0;
+	}
+
+	memset(&check, 0, sizeof(php_parallel_check_type_t));
+
+	if (class == zend_ce_closure || class == php_parallel_channel_ce ||
+	    instanceof_function(class, php_parallel_sync_ce) || !class->create_object) {
+
+		check.valid = 1;
+	}
+
+	zend_hash_add_mem(&PCG(types), name, &check, sizeof(php_parallel_check_type_t));
+
+	return check.valid;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_arginfo(const zend_function *function) { /* {{{ */
-    zend_arg_info *it, *end;
-    int argc = 1;
+static zend_always_inline bool php_parallel_check_arginfo(const zend_function *function)
+{ /* {{{ */
+	zend_arg_info *it, *end;
+	int            argc = 1;
 
-    if (!function->op_array.arg_info) {
-        return 1;
-    }
+	if (!function->op_array.arg_info) {
+		return 1;
+	}
 
-    if (function->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
-        it = function->op_array.arg_info - 1;
-        if (ZEND_TYPE_IS_SET(it->type) && ZEND_TYPE_IS_COMPLEX(it->type)) {
-            if (!php_parallel_check_type(it->type)) {
-                php_parallel_exception_ex(
-                    php_parallel_runtime_error_illegal_return_ce,
-                    "illegal return (%s) from task",
-                    ZSTR_VAL(ZEND_TYPE_NAME(it->type)));
-                return 0;
-            }
-        }
+	if (function->common.fn_flags & ZEND_ACC_HAS_RETURN_TYPE) {
+		it = function->op_array.arg_info - 1;
+		if (ZEND_TYPE_IS_SET(it->type) && ZEND_TYPE_IS_COMPLEX(it->type)) {
+			if (!php_parallel_check_type(it->type)) {
+				php_parallel_exception_ex(php_parallel_runtime_error_illegal_return_ce, "illegal return (%s) from task",
+				                          ZSTR_VAL(ZEND_TYPE_NAME(it->type)));
+				return 0;
+			}
+		}
 
-	if (function->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
-            php_parallel_exception_ex(
-                php_parallel_runtime_error_illegal_return_ce,
-                "illegal return (reference) from task");
-            return 0;
-        }
-    }
+		if (function->common.fn_flags & ZEND_ACC_RETURN_REFERENCE) {
+			php_parallel_exception_ex(php_parallel_runtime_error_illegal_return_ce,
+			                          "illegal return (reference) from task");
+			return 0;
+		}
+	}
 
-    it = function->op_array.arg_info;
-    end = it + function->op_array.num_args;
+	it = function->op_array.arg_info;
+	end = it + function->op_array.num_args;
 
-    if (function->common.fn_flags & ZEND_ACC_VARIADIC) {
-        end++;
-    }
+	if (function->common.fn_flags & ZEND_ACC_VARIADIC) {
+		end++;
+	}
 
-    while (it < end) {
-        if (ZEND_TYPE_IS_SET(it->type) && ZEND_TYPE_IS_COMPLEX(it->type)) {
-            if (!php_parallel_check_type(it->type)) {
-                php_parallel_exception_ex(
-                    php_parallel_runtime_error_illegal_parameter_ce,
-                    "illegal parameter (%s) accepted by task at argument %d",
-                    ZSTR_VAL(ZEND_TYPE_NAME(it->type)), argc);
-                return 0;
-            }
-        }
+	while (it < end) {
+		if (ZEND_TYPE_IS_SET(it->type) && ZEND_TYPE_IS_COMPLEX(it->type)) {
+			if (!php_parallel_check_type(it->type)) {
+				php_parallel_exception_ex(php_parallel_runtime_error_illegal_parameter_ce,
+				                          "illegal parameter (%s) accepted by task at argument %d",
+				                          ZSTR_VAL(ZEND_TYPE_NAME(it->type)), argc);
+				return 0;
+			}
+		}
 
-	if (ZEND_ARG_SEND_MODE(it)) {
-            php_parallel_exception_ex(
-                php_parallel_runtime_error_illegal_parameter_ce,
-                "illegal parameter (reference) accepted by task at argument %d", argc);
-            return 0;
-        }
-        it++;
-        argc++;
-    }
+		if (ZEND_ARG_SEND_MODE(it)) {
+			php_parallel_exception_ex(php_parallel_runtime_error_illegal_parameter_ce,
+			                          "illegal parameter (reference) accepted by task at argument %d", argc);
+			return 0;
+		}
+		it++;
+		argc++;
+	}
 
-    return 1;
+	return 1;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_statics(const zend_function *function, zend_string **errn, zval **errz) { /* {{{ */
-    HashTable *statics;
-    zval *value, *error;
-    zend_string *name;
+static zend_always_inline bool php_parallel_check_statics(const zend_function *function, zend_string **errn,
+                                                          zval **errz)
+{ /* {{{ */
+	HashTable   *statics;
+	zval        *value, *error;
+	zend_string *name;
 
-    if (!function->op_array.static_variables) {
-        return 1;
-    }
+	if (!function->op_array.static_variables) {
+		return 1;
+	}
 
-    statics = ZEND_MAP_PTR_GET(function->op_array.static_variables_ptr);
-    if (!statics) {
-        statics = function->op_array.static_variables;
-    }
+	statics = ZEND_MAP_PTR_GET(function->op_array.static_variables_ptr);
+	if (!statics) {
+		statics = function->op_array.static_variables;
+	}
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(statics, name, value) {
-        if (!PARALLEL_ZVAL_CHECK(value, &error)) {
-            if (errn) {
-                *errn = name;
-            }
-            if (errz) {
-                *errz = error;
-            }
-            return 0;
-        }
-    } ZEND_HASH_FOREACH_END();
+	ZEND_HASH_FOREACH_STR_KEY_VAL(statics, name, value)
+	{
+		if (!PARALLEL_ZVAL_CHECK(value, &error)) {
+			if (errn) {
+				*errn = name;
+			}
+			if (errz) {
+				*errz = error;
+			}
+			return 0;
+		}
+	}
+	ZEND_HASH_FOREACH_END();
 
-    return 1;
+	return 1;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_argv(zval *args, uint32_t *argc, zval **error) { /* {{{ */
-    zval *arg;
+static zend_always_inline bool php_parallel_check_argv(zval *args, uint32_t *argc, zval **error)
+{ /* {{{ */
+	zval *arg;
 
-    if (*argc == 0) {
-        *argc = 1;
-    }
+	if (*argc == 0) {
+		*argc = 1;
+	}
 
-    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), arg) {
-        if (!PARALLEL_ZVAL_CHECK(arg, error)) {
-            return 0;
-        }
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), arg)
+	{
+		if (!PARALLEL_ZVAL_CHECK(arg, error)) {
+			return 0;
+		}
 
-        (*argc)++;
-    } ZEND_HASH_FOREACH_END();
+		(*argc)++;
+	}
+	ZEND_HASH_FOREACH_END();
 
-    return 1;
+	return 1;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_use(zend_execute_data *execute_data, const zend_function *function, zend_op *bind) { /* {{{ */
-    zend_op *opline, *end;
+static zend_always_inline bool php_parallel_check_use(zend_execute_data *execute_data, const zend_function *function,
+                                                      zend_op *bind)
+{ /* {{{ */
+	zend_op *opline, *end;
 
-    if (EX(func)->type != ZEND_USER_FUNCTION) {
-        return 0;
-    }
+	if (EX(func)->type != ZEND_USER_FUNCTION) {
+		return 0;
+	}
 
-    opline = EX(func)->op_array.opcodes;
-    end    = opline + EX(func)->op_array.last;
+	opline = EX(func)->op_array.opcodes;
+	end = opline + EX(func)->op_array.last;
 
-    while (opline < end) {
-        if ((opline->opcode == ZEND_BIND_LEXICAL) && (opline->extended_value & ZEND_BIND_REF)) {
-            if (zend_string_equals(
-                zend_get_compiled_variable_name((zend_op_array*)function, bind->op1.var),
-                zend_get_compiled_variable_name((zend_op_array*)EX(func), opline->op2.var))) {
-                return 1;
-            }
-        }
-        opline++;
-    }
+	while (opline < end) {
+		if ((opline->opcode == ZEND_BIND_LEXICAL) && (opline->extended_value & ZEND_BIND_REF)) {
+			if (zend_string_equals(zend_get_compiled_variable_name((zend_op_array *)function, bind->op1.var),
+			                       zend_get_compiled_variable_name((zend_op_array *)EX(func), opline->op2.var))) {
+				return 1;
+			}
+		}
+		opline++;
+	}
 
-    return 0;
+	return 0;
 } /* }}} */
 
-bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, bool *returns) { /* {{{ */
-    php_parallel_check_task_t check, *checked;
-    zend_op *it, *end;
+bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data,
+                             const zend_function *function, zval *argv, bool *returns)
+{ /* {{{ */
+	php_parallel_check_task_t check, *checked;
+	zend_op                  *it, *end;
 
-    if (function->type != ZEND_USER_FUNCTION) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_illegal_function_ce,
-            "illegal function type (internal)");
-        return 0;
-    }
+	if (function->type != ZEND_USER_FUNCTION) {
+		php_parallel_exception_ex(php_parallel_runtime_error_illegal_function_ce, "illegal function type (internal)");
+		return 0;
+	}
 
-    if (argv && Z_TYPE_P(argv) == IS_ARRAY) {
-        uint32_t errat = 0;
-        zval *errarg;
+	if (argv && Z_TYPE_P(argv) == IS_ARRAY) {
+		uint32_t errat = 0;
+		zval    *errarg;
 
-        if (!php_parallel_check_argv(argv, &errat, &errarg)) {
-            php_parallel_exception_ex(
-                php_parallel_runtime_error_illegal_parameter_ce,
-                "illegal parameter (%s) passed to task at argument %d",
-                Z_TYPE_P(errarg) == IS_OBJECT ?
-                    ZSTR_VAL(Z_OBJCE_P(errarg)->name) :
-                    zend_get_type_by_const(Z_TYPE_P(errarg)), errat);
-            return 0;
-        }
-    }
+		if (!php_parallel_check_argv(argv, &errat, &errarg)) {
+			php_parallel_exception_ex(php_parallel_runtime_error_illegal_parameter_ce,
+			                          "illegal parameter (%s) passed to task at argument %d",
+			                          Z_TYPE_P(errarg) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(errarg)->name)
+			                                                        : zend_get_type_by_const(Z_TYPE_P(errarg)),
+			                          errat);
+			return 0;
+		}
+	}
 
-    if ((checked = zend_hash_index_find_ptr(&PCG(tasks), (zend_ulong) function->op_array.opcodes))) {
-        *returns =
-            checked->returns;
+	if ((checked = zend_hash_index_find_ptr(&PCG(tasks), (zend_ulong)function->op_array.opcodes))) {
+		*returns = checked->returns;
 
-        if (!*returns) {
-            if (EX(opline)->result_type != IS_UNUSED) {
-                *returns = 1;
-            }
-        }
+		if (!*returns) {
+			if (EX(opline)->result_type != IS_UNUSED) {
+				*returns = 1;
+			}
+		}
 
-        return 1;
-    }
+		return 1;
+	}
 
-    if (!php_parallel_check_arginfo(function)) {
-        return 0;
-    }
+	if (!php_parallel_check_arginfo(function)) {
+		return 0;
+	}
 
-    {
-        zend_string *errn;
-        zval        *errv;
-        if (!php_parallel_check_statics(function, &errn, &errv)) {
-            php_parallel_exception_ex(
-                php_parallel_runtime_error_illegal_variable_ce,
-                "illegal variable (%s) named %s in static scope of function",
-                Z_TYPE_P(errv) == IS_OBJECT ?
-                    ZSTR_VAL(Z_OBJCE_P(errv)->name) :
-                    zend_get_type_by_const(Z_TYPE_P(errv)),
-                ZSTR_VAL(errn));
-            return 0;
-        }
-    }
+	{
+		zend_string *errn;
+		zval        *errv;
+		if (!php_parallel_check_statics(function, &errn, &errv)) {
+			php_parallel_exception_ex(php_parallel_runtime_error_illegal_variable_ce,
+			                          "illegal variable (%s) named %s in static scope of function",
+			                          Z_TYPE_P(errv) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(errv)->name)
+			                                                      : zend_get_type_by_const(Z_TYPE_P(errv)),
+			                          ZSTR_VAL(errn));
+			return 0;
+		}
+	}
 
-    memset(&check, 0, sizeof(php_parallel_check_task_t));
+	memset(&check, 0, sizeof(php_parallel_check_task_t));
 
-    it  = function->op_array.opcodes;
-    end = it + function->op_array.last;
+	it = function->op_array.opcodes;
+	end = it + function->op_array.last;
 
-    while (it < end) {
-        switch (it->opcode) {
-            case ZEND_DECLARE_LAMBDA_FUNCTION: {
-                zend_string *key;
-                zend_function *dependency, *errf;
-                zend_uchar erro;
+	while (it < end) {
+		switch (it->opcode) {
+		case ZEND_DECLARE_LAMBDA_FUNCTION: {
+			zend_string   *key;
+			zend_function *dependency, *errf;
+			zend_uchar     erro;
 
-                PARALLEL_COPY_OPLINE_TO_FUNCTION(function, it, &key, &dependency);
+			PARALLEL_COPY_OPLINE_TO_FUNCTION(function, it, &key, &dependency);
 
-                if (!php_parallel_check_function(dependency, &errf, &erro)) {
-                    php_parallel_exception_ex(
-                        php_parallel_runtime_error_illegal_instruction_ce,
-                        "illegal instruction (%s) in closure on line %d of task",
-                        php_parallel_check_opcode_name(erro),
-                        errf->op_array.line_start - function->op_array.line_start);
-                    return 0;
-                }
+			if (!php_parallel_check_function(dependency, &errf, &erro)) {
+				php_parallel_exception_ex(php_parallel_runtime_error_illegal_instruction_ce,
+				                          "illegal instruction (%s) in closure on line %d of task",
+				                          php_parallel_check_opcode_name(erro),
+				                          errf->op_array.line_start - function->op_array.line_start);
+				return 0;
+			}
 
-                {
-                    zend_string *errn;
-                    zval        *errv;
-                    if (!php_parallel_check_statics(dependency, &errn, &errv)) {
-                        php_parallel_exception_ex(
-                            php_parallel_runtime_error_illegal_variable_ce,
-                            "illegal variable (%s) named %s in static scope of dependency",
-                            Z_TYPE_P(errv) == IS_OBJECT ?
-                                ZSTR_VAL(Z_OBJCE_P(errv)->name) :
-                                zend_get_type_by_const(Z_TYPE_P(errv)),
-                            ZSTR_VAL(errn));
-                        return 0;
-                    }
-                }
-            } break;
+			{
+				zend_string *errn;
+				zval        *errv;
+				if (!php_parallel_check_statics(dependency, &errn, &errv)) {
+					php_parallel_exception_ex(php_parallel_runtime_error_illegal_variable_ce,
+					                          "illegal variable (%s) named %s in static scope of dependency",
+					                          Z_TYPE_P(errv) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(errv)->name)
+					                                                      : zend_get_type_by_const(Z_TYPE_P(errv)),
+					                          ZSTR_VAL(errn));
+					return 0;
+				}
+			}
+		} break;
 
-            case ZEND_DECLARE_FUNCTION:
-            case ZEND_DECLARE_CLASS:
-            case ZEND_DECLARE_ANON_CLASS:
-            case ZEND_DECLARE_CLASS_DELAYED:
-            case ZEND_YIELD:
-            case ZEND_YIELD_FROM:
-                php_parallel_exception_ex(
-                    php_parallel_runtime_error_illegal_instruction_ce,
-                    "illegal instruction (%s) on line %d of task",
-                    php_parallel_check_opcode_name(it->opcode),
-                    it->lineno - function->op_array.line_start);
-                return 0;
+		case ZEND_DECLARE_FUNCTION:
+		case ZEND_DECLARE_CLASS:
+		case ZEND_DECLARE_ANON_CLASS:
+		case ZEND_DECLARE_CLASS_DELAYED:
+		case ZEND_YIELD:
+		case ZEND_YIELD_FROM:
+			php_parallel_exception_ex(
+			    php_parallel_runtime_error_illegal_instruction_ce, "illegal instruction (%s) on line %d of task",
+			    php_parallel_check_opcode_name(it->opcode), it->lineno - function->op_array.line_start);
+			return 0;
 
-            case ZEND_BIND_STATIC:
-                if (php_parallel_check_use(execute_data, function, it)) {
-                    php_parallel_exception_ex(
-                        php_parallel_runtime_error_illegal_instruction_ce,
-                        "illegal instruction (lexical reference) in task");
-                    return 0;
-                }
-            break;
+		case ZEND_BIND_STATIC:
+			if (php_parallel_check_use(execute_data, function, it)) {
+				php_parallel_exception_ex(php_parallel_runtime_error_illegal_instruction_ce,
+				                          "illegal instruction (lexical reference) in task");
+				return 0;
+			}
+			break;
 
-            case ZEND_THROW:
-            case ZEND_RETURN:
-            if (!*returns && it->extended_value != -1) {
-                if (EX(opline)->result_type == IS_UNUSED) {
-                    php_parallel_exception_ex(
-                        php_parallel_runtime_error_illegal_return_ce,
-                        "return on line %d of task ignored by caller, "
-                        "caller must retain reference to Future",
-                        it->lineno - function->op_array.line_start);
-                    return 0;
-                }
-                *returns = 1;
-            }
-            break;
-        }
-        it++;
-    }
+		case ZEND_THROW:
+		case ZEND_RETURN:
+			if (!*returns && it->extended_value != -1) {
+				if (EX(opline)->result_type == IS_UNUSED) {
+					php_parallel_exception_ex(php_parallel_runtime_error_illegal_return_ce,
+					                          "return on line %d of task ignored by caller, "
+					                          "caller must retain reference to Future",
+					                          it->lineno - function->op_array.line_start);
+					return 0;
+				}
+				*returns = 1;
+			}
+			break;
+		}
+		it++;
+	}
 
-    check.returns = *returns;
+	check.returns = *returns;
 
-    if (!*returns) {
-        if (EX(opline)->result_type != IS_UNUSED) {
-            *returns = 1;
-        }
-    }
+	if (!*returns) {
+		if (EX(opline)->result_type != IS_UNUSED) {
+			*returns = 1;
+		}
+	}
 
-    zend_hash_index_add_mem(
-        &PCG(tasks),
-        (zend_ulong) function->op_array.opcodes,
-        &check, sizeof(php_parallel_check_task_t));
+	zend_hash_index_add_mem(&PCG(tasks), (zend_ulong)function->op_array.opcodes, &check,
+	                        sizeof(php_parallel_check_task_t));
 
-    return 1;
+	return 1;
 } /* }}} */
 
-bool php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro) { /* {{{ */
-    php_parallel_check_function_t check, *checked;
-    zend_op *it, *end;
+bool php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro)
+{ /* {{{ */
+	php_parallel_check_function_t check, *checked;
+	zend_op                      *it, *end;
 
-    if ((checked = zend_hash_index_find_ptr(&PCG(functions), (zend_ulong) function->op_array.opcodes))) {
-        check =
-            *checked;
+	if ((checked = zend_hash_index_find_ptr(&PCG(functions), (zend_ulong)function->op_array.opcodes))) {
+		check = *checked;
 
-        goto _php_parallel_checked_function_return;
-    }
+		goto _php_parallel_checked_function_return;
+	}
 
-    memset(&check, 0, sizeof(php_parallel_check_function_t));
+	memset(&check, 0, sizeof(php_parallel_check_function_t));
 
-    it  = function->op_array.opcodes;
-    end = it + function->op_array.last;
+	it = function->op_array.opcodes;
+	end = it + function->op_array.last;
 
-    while (it < end) {
-        switch (it->opcode) {
-            case ZEND_DECLARE_FUNCTION:
-            case ZEND_DECLARE_CLASS:
-            case ZEND_DECLARE_CLASS_DELAYED:
-            case ZEND_DECLARE_ANON_CLASS:
-                check.function =
-                    (zend_function*) function;
-                check.instruction = it->opcode;
+	while (it < end) {
+		switch (it->opcode) {
+		case ZEND_DECLARE_FUNCTION:
+		case ZEND_DECLARE_CLASS:
+		case ZEND_DECLARE_CLASS_DELAYED:
+		case ZEND_DECLARE_ANON_CLASS:
+			check.function = (zend_function *)function;
+			check.instruction = it->opcode;
 
-                goto _php_parallel_checked_function_add;
+			goto _php_parallel_checked_function_add;
 
+		case ZEND_DECLARE_LAMBDA_FUNCTION: {
+			zend_string   *key;
+			zend_function *dependency;
 
-            case ZEND_DECLARE_LAMBDA_FUNCTION: {
-                zend_string *key;
-                zend_function *dependency;
+			PARALLEL_COPY_OPLINE_TO_FUNCTION(function, it, &key, &dependency);
 
-                PARALLEL_COPY_OPLINE_TO_FUNCTION(function, it, &key, &dependency);
+			if (!php_parallel_check_function(dependency, &check.function, &check.instruction)) {
+				goto _php_parallel_checked_function_add;
+			}
+		} break;
+		}
+		it++;
+	}
 
-                if (!php_parallel_check_function(dependency, &check.function, &check.instruction)) {
-                    goto _php_parallel_checked_function_add;
-                }
-            } break;
-        }
-        it++;
-    }
-
-    check.valid = 1;
+	check.valid = 1;
 
 _php_parallel_checked_function_add:
-    zend_hash_index_add_mem(
-        &PCG(functions),
-        (zend_ulong) function->op_array.opcodes,
-        &check, sizeof(php_parallel_check_function_t));
+	zend_hash_index_add_mem(&PCG(functions), (zend_ulong)function->op_array.opcodes, &check,
+	                        sizeof(php_parallel_check_function_t));
 
 _php_parallel_checked_function_return:
-    if (errf) {
-        *errf = check.function;
-    }
+	if (errf) {
+		*errf = check.function;
+	}
 
-    if (erro) {
-        *erro = check.instruction;
-    }
+	if (erro) {
+		*erro = check.instruction;
+	}
 
-    return check.valid;
+	return check.valid;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_closure(zend_closure_t *closure) { /* {{{ */
-    return php_parallel_check_statics(&closure->func, NULL, NULL) &&
-           php_parallel_check_function(&closure->func, NULL, NULL);
+static zend_always_inline bool php_parallel_check_closure(zend_closure_t *closure)
+{ /* {{{ */
+	return php_parallel_check_statics(&closure->func, NULL, NULL) &&
+	       php_parallel_check_function(&closure->func, NULL, NULL);
 } /* }}} */
 
-static php_parallel_check_class_result_t php_parallel_check_class(zend_class_entry *ce);
+static php_parallel_check_class_result_t                    php_parallel_check_class(zend_class_entry *ce);
 
-static zend_always_inline php_parallel_check_class_result_t php_parallel_check_class_inline(zend_class_entry *ce) { /* {{{ */
-    zend_property_info *info;
-    php_parallel_check_class_t check, *checked = zend_hash_index_find_ptr(&PCG(classes), (zend_ulong) ce);
+static zend_always_inline php_parallel_check_class_result_t php_parallel_check_class_inline(zend_class_entry *ce)
+{ /* {{{ */
+	zend_property_info        *info;
+	php_parallel_check_class_t check, *checked = zend_hash_index_find_ptr(&PCG(classes), (zend_ulong)ce);
 
-    if (checked) {
-        return checked->result;
-    }
-    
-    if (!ce) {
-        return PHP_PARALLEL_CHECK_CLASS_INVALID;
-    }
+	if (checked) {
+		return checked->result;
+	}
 
-    memset(&check, 0, sizeof(php_parallel_check_class_t));
+	if (!ce) {
+		return PHP_PARALLEL_CHECK_CLASS_INVALID;
+	}
 
-    if (ce == php_parallel_channel_ce ||
-        ce == zend_ce_closure) {
-        check.result =
-            PHP_PARALLEL_CHECK_CLASS_VALID;
+	memset(&check, 0, sizeof(php_parallel_check_class_t));
 
-        goto _php_parallel_checked_class;
-    }
+	if (ce == php_parallel_channel_ce || ce == zend_ce_closure) {
+		check.result = PHP_PARALLEL_CHECK_CLASS_VALID;
 
-    if (ce->create_object) {
-        check.result =
-            PHP_PARALLEL_CHECK_CLASS_INVALID;
+		goto _php_parallel_checked_class;
+	}
 
-        goto _php_parallel_checked_class;
-    }
+	if (ce->create_object) {
+		check.result = PHP_PARALLEL_CHECK_CLASS_INVALID;
 
-    if (!ce->default_properties_count) {
-        check.result =
-            PHP_PARALLEL_CHECK_CLASS_VALID;
+		goto _php_parallel_checked_class;
+	}
 
-        goto _php_parallel_checked_class;
-    }
+	if (!ce->default_properties_count) {
+		check.result = PHP_PARALLEL_CHECK_CLASS_VALID;
 
-    ZEND_HASH_FOREACH_PTR(&ce->properties_info, info) {
-        zend_class_entry *next;
+		goto _php_parallel_checked_class;
+	}
 
-        if (!ZEND_TYPE_IS_SET(info->type)) {
-            check.result =
-                PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
+	ZEND_HASH_FOREACH_PTR(&ce->properties_info, info)
+	{
+		zend_class_entry *next;
 
-            goto _php_parallel_checked_class;
-        }
+		if (!ZEND_TYPE_IS_SET(info->type)) {
+			check.result = PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
 
-        if (!ZEND_TYPE_IS_SET(info->type) || !ZEND_TYPE_IS_COMPLEX(info->type)) {
-            continue;
-        }
-        
-        if (ZEND_TYPE_HAS_LIST(info->type)) {
-            zend_type *single;
-            
-            ZEND_TYPE_FOREACH(info->type, single) {
+			goto _php_parallel_checked_class;
+		}
+
+		if (!ZEND_TYPE_IS_SET(info->type) || !ZEND_TYPE_IS_COMPLEX(info->type)) {
+			continue;
+		}
+
+		if (ZEND_TYPE_HAS_LIST(info->type)) {
+			zend_type *single;
+
+			ZEND_TYPE_FOREACH(info->type, single)
+			{
 #ifdef ZEND_TYPE_HAS_CE
-            	if (ZEND_TYPE_HAS_CE(*single)) {
-            		next = ZEND_TYPE_CE(*single);
-            	} else
+				if (ZEND_TYPE_HAS_CE(*single)) {
+					next = ZEND_TYPE_CE(*single);
+				} else
 #endif
-                if (ZEND_TYPE_HAS_NAME(*single)) {
-            		next = zend_lookup_class(ZEND_TYPE_NAME(*single));
-            	} else {
-            		continue;
-            	}
-            	
-            	if (next == ce) {
-            		continue;
-            	}
+				    if (ZEND_TYPE_HAS_NAME(*single)) {
+					next = zend_lookup_class(ZEND_TYPE_NAME(*single));
+				} else {
+					continue;
+				}
 
-            	memset(&check, 0, sizeof(php_parallel_check_class_t));
-            	
-            	switch (php_parallel_check_class(next)) {
-                    case PHP_PARALLEL_CHECK_CLASS_INVALID:
-                    case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
-                        check.result =
-                            PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
-                    break;
+				if (next == ce) {
+					continue;
+				}
 
-                    case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
-                        check.result =
-                            PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
-                    break;
+				memset(&check, 0, sizeof(php_parallel_check_class_t));
 
-                    case PHP_PARALLEL_CHECK_CLASS_VALID:
-                        check.result = 
-                            PHP_PARALLEL_CHECK_CLASS_VALID;
-                    break;
-                }
-                
-                if (check.result != PHP_PARALLEL_CHECK_CLASS_VALID) {
-                    zend_hash_index_add_mem(
-                        &PCG(classes), 
-                        (zend_ulong) next, &check, 
-                        sizeof(php_parallel_check_class_t));
-                                  
-                    check.result = PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
-                    
-                    zend_hash_index_add_mem(
-                        &PCG(classes), 
-                        (zend_ulong) ce, &check, 
-                        sizeof(php_parallel_check_class_t));
-                    
-                    return check.result;
-                }
-            } ZEND_TYPE_FOREACH_END();
-            
-        } else {
+				switch (php_parallel_check_class(next)) {
+				case PHP_PARALLEL_CHECK_CLASS_INVALID:
+				case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
+					check.result = PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
+					break;
+
+				case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
+					check.result = PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
+					break;
+
+				case PHP_PARALLEL_CHECK_CLASS_VALID:
+					check.result = PHP_PARALLEL_CHECK_CLASS_VALID;
+					break;
+				}
+
+				if (check.result != PHP_PARALLEL_CHECK_CLASS_VALID) {
+					zend_hash_index_add_mem(&PCG(classes), (zend_ulong)next, &check,
+					                        sizeof(php_parallel_check_class_t));
+
+					check.result = PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
+
+					zend_hash_index_add_mem(&PCG(classes), (zend_ulong)ce, &check, sizeof(php_parallel_check_class_t));
+
+					return check.result;
+				}
+			}
+			ZEND_TYPE_FOREACH_END();
+
+		} else {
 #ifdef ZEND_TYPE_HAS_CE
-            if (ZEND_TYPE_HAS_CE(info->type)) {
-                next = ZEND_TYPE_CE(info->type);
-            } else
+			if (ZEND_TYPE_HAS_CE(info->type)) {
+				next = ZEND_TYPE_CE(info->type);
+			} else
 #endif
-            {
-                next = zend_lookup_class(
-                        ZEND_TYPE_NAME(info->type));
-            }
-            
-            if (next == ce) {
-            	continue;
-            }
+			{
+				next = zend_lookup_class(ZEND_TYPE_NAME(info->type));
+			}
 
-            switch (php_parallel_check_class(next)) {
-                case PHP_PARALLEL_CHECK_CLASS_INVALID:
-                case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
-                    check.result =
-                        PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
-                    goto _php_parallel_checked_class;
+			if (next == ce) {
+				continue;
+			}
 
-                case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
-                    check.result =
-                        PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
-                    goto _php_parallel_checked_class;
+			switch (php_parallel_check_class(next)) {
+			case PHP_PARALLEL_CHECK_CLASS_INVALID:
+			case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
+				check.result = PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY;
+				goto _php_parallel_checked_class;
 
-                case PHP_PARALLEL_CHECK_CLASS_VALID:
-                    /* do nothing */
-                    break;
-            }
-        }
-    } ZEND_HASH_FOREACH_END();
+			case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
+				check.result = PHP_PARALLEL_CHECK_CLASS_UNKNOWN;
+				goto _php_parallel_checked_class;
 
-    check.result =
-        PHP_PARALLEL_CHECK_CLASS_VALID;
+			case PHP_PARALLEL_CHECK_CLASS_VALID:
+				/* do nothing */
+				break;
+			}
+		}
+	}
+	ZEND_HASH_FOREACH_END();
+
+	check.result = PHP_PARALLEL_CHECK_CLASS_VALID;
 
 _php_parallel_checked_class:
-    checked = zend_hash_index_add_mem(
-        &PCG(classes), (zend_ulong) ce, &check, sizeof(php_parallel_check_class_t));
+	checked = zend_hash_index_add_mem(&PCG(classes), (zend_ulong)ce, &check, sizeof(php_parallel_check_class_t));
 
-    return checked->result;
+	return checked->result;
 } /* }}} */
 
-static php_parallel_check_class_result_t php_parallel_check_class(zend_class_entry *ce) {
-    return php_parallel_check_class_inline(ce);
+static php_parallel_check_class_result_t php_parallel_check_class(zend_class_entry *ce)
+{
+	return php_parallel_check_class_inline(ce);
 }
 
-static zend_always_inline bool php_parallel_check_object(zend_object *object, zval **error) { /* {{{ */
-    if (instanceof_function(object->ce, php_parallel_channel_ce) ||
-        instanceof_function(object->ce, php_parallel_sync_ce)) {
-        return 1;
-    }
+static zend_always_inline bool php_parallel_check_object(zend_object *object, zval **error)
+{ /* {{{ */
+	if (instanceof_function(object->ce, php_parallel_channel_ce) ||
+	    instanceof_function(object->ce, php_parallel_sync_ce)) {
+		return 1;
+	}
 
-    if (object->ce->create_object) {
-        return 0;
-    }
+	if (object->ce->create_object) {
+		return 0;
+	}
 
-    if ((object->properties == NULL) || (object->properties->nNumUsed == 0)) {
-        switch (php_parallel_check_class_inline(object->ce)) {
-            case PHP_PARALLEL_CHECK_CLASS_VALID:
-                /* whole graph is typed and allowed */
-                return 1;
+	if ((object->properties == NULL) || (object->properties->nNumUsed == 0)) {
+		switch (php_parallel_check_class_inline(object->ce)) {
+		case PHP_PARALLEL_CHECK_CLASS_VALID:
+			/* whole graph is typed and allowed */
+			return 1;
 
-            case PHP_PARALLEL_CHECK_CLASS_INVALID:
-                return 0;
+		case PHP_PARALLEL_CHECK_CLASS_INVALID:
+			return 0;
 
-            case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
-                    /* type info for a property in graph is invalid, but may be undef/null */
-            case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
-                    /* not enough type info */
-            break;
-        }
-    }
+		case PHP_PARALLEL_CHECK_CLASS_INVALID_PROPERTY:
+			/* type info for a property in graph is invalid, but may be undef/null */
+		case PHP_PARALLEL_CHECK_CLASS_UNKNOWN:
+			/* not enough type info */
+			break;
+		}
+	}
 
-    if (object->ce->default_properties_count) {
-        zval *property = object->properties_table,
-             *end      = property + object->ce->default_properties_count;
+	if (object->ce->default_properties_count) {
+		zval *property = object->properties_table, *end = property + object->ce->default_properties_count;
 
-        while (property < end) {
-            if ((Z_TYPE_P(property) == IS_OBJECT) &&
-                (Z_OBJ_P(property) == object)) {
-                property++;
-                continue;
-            }
+		while (property < end) {
+			if ((Z_TYPE_P(property) == IS_OBJECT) && (Z_OBJ_P(property) == object)) {
+				property++;
+				continue;
+			}
 
-            if (!php_parallel_check_zval(property, error)) {
-                return 0;
-            }
+			if (!php_parallel_check_zval(property, error)) {
+				return 0;
+			}
 
-            property++;
-        }
-    }
+			property++;
+		}
+	}
 
-    if (object->properties) {
-        zval *property;
+	if (object->properties) {
+		zval *property;
 
-        ZEND_HASH_FOREACH_VAL(object->properties, property) {
-            if ((Z_TYPE_P(property) == IS_OBJECT) &&
-                (Z_OBJ_P(property) == object)) {
-                continue;
-            }
+		ZEND_HASH_FOREACH_VAL(object->properties, property)
+		{
+			if ((Z_TYPE_P(property) == IS_OBJECT) && (Z_OBJ_P(property) == object)) {
+				continue;
+			}
 
-            if (!php_parallel_check_zval(property, error)) {
-                return 0;
-            }
-        } ZEND_HASH_FOREACH_END();
-    }
+			if (!php_parallel_check_zval(property, error)) {
+				return 0;
+			}
+		}
+		ZEND_HASH_FOREACH_END();
+	}
 
-    return 1;
+	return 1;
 } /* }}} */
 
-static zend_always_inline bool php_parallel_check_resource(zval *zv) { /* {{{ */
-    zend_resource *resource = Z_RES_P(zv);
+static zend_always_inline bool php_parallel_check_resource(zval *zv)
+{ /* {{{ */
+	zend_resource *resource = Z_RES_P(zv);
 
-    if (resource->type == php_file_le_stream() ||
-        resource->type == php_file_le_pstream()) {
-        return 1;
-    }
+	if (resource->type == php_file_le_stream() || resource->type == php_file_le_pstream()) {
+		return 1;
+	}
 
-    return 0;
+	return 0;
 } /* }}} */
 
-bool php_parallel_check_zval(zval *zv, zval **error) { /* {{{ */
-    switch (Z_TYPE_P(zv)) {
-        case IS_OBJECT:
-            if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {
-                if (!php_parallel_check_closure((zend_closure_t*) Z_OBJ_P(zv))) {
-                    if (error) {
-                        *error = zv;
-                    }
-                    return 0;
-                }
-                return 1;
-            } else if (php_parallel_check_object(Z_OBJ_P(zv), error)) {
-                return 1;
-            }
+bool php_parallel_check_zval(zval *zv, zval **error)
+{ /* {{{ */
+	switch (Z_TYPE_P(zv)) {
+	case IS_OBJECT:
+		if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {
+			if (!php_parallel_check_closure((zend_closure_t *)Z_OBJ_P(zv))) {
+				if (error) {
+					*error = zv;
+				}
+				return 0;
+			}
+			return 1;
+		} else if (php_parallel_check_object(Z_OBJ_P(zv), error)) {
+			return 1;
+		}
 
-            if (error) {
-                *error = zv;
-            }
-            return 0;
+		if (error) {
+			*error = zv;
+		}
+		return 0;
 
-        case IS_ARRAY: {
-            zval *el;
+	case IS_ARRAY: {
+		zval *el;
 
-            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(zv), el) {
-                if ((Z_TYPE_P(el) == IS_ARRAY) &&
-                    (Z_ARRVAL_P(el) == Z_ARRVAL_P(zv))) {
-                    continue;
-                }
+		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(zv), el)
+		{
+			if ((Z_TYPE_P(el) == IS_ARRAY) && (Z_ARRVAL_P(el) == Z_ARRVAL_P(zv))) {
+				continue;
+			}
 
-                if (!php_parallel_check_zval(el, error)) {
-                    if (error) {
-                        *error = el;
-                    }
-                    return 0;
-                }
-            } ZEND_HASH_FOREACH_END();
-        } break;
+			if (!php_parallel_check_zval(el, error)) {
+				if (error) {
+					*error = el;
+				}
+				return 0;
+			}
+		}
+		ZEND_HASH_FOREACH_END();
+	} break;
 
-        case IS_RESOURCE:
-            if (php_parallel_check_resource(zv)) {
-                return 1;
-            }
+	case IS_RESOURCE:
+		if (php_parallel_check_resource(zv)) {
+			return 1;
+		}
 
-            if (error) {
-                *error = zv;
-            }
-            return 0;
-    }
-    return 1;
+		if (error) {
+			*error = zv;
+		}
+		return 0;
+	}
+	return 1;
 } /* }}} */
 
 /* {{{ */
-static void php_parallel_checked_dtor(zval *zv) {
-    efree(Z_PTR_P(zv));
-}
+static void php_parallel_checked_dtor(zval *zv) { efree(Z_PTR_P(zv)); }
 
 PHP_RINIT_FUNCTION(PARALLEL_CHECK)
 {
-    zend_hash_init(&PCG(tasks),    32, NULL, php_parallel_checked_dtor, 0);
-    zend_hash_init(&PCG(functions),32, NULL, php_parallel_checked_dtor, 0);
-    zend_hash_init(&PCG(types),    32, NULL, php_parallel_checked_dtor, 0);
-    zend_hash_init(&PCG(classes),  32, NULL, php_parallel_checked_dtor, 0);
+	zend_hash_init(&PCG(tasks), 32, NULL, php_parallel_checked_dtor, 0);
+	zend_hash_init(&PCG(functions), 32, NULL, php_parallel_checked_dtor, 0);
+	zend_hash_init(&PCG(types), 32, NULL, php_parallel_checked_dtor, 0);
+	zend_hash_init(&PCG(classes), 32, NULL, php_parallel_checked_dtor, 0);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(PARALLEL_CHECK)
 {
-    zend_hash_destroy(&PCG(classes));
-    zend_hash_destroy(&PCG(types));
-    zend_hash_destroy(&PCG(functions));
-    zend_hash_destroy(&PCG(tasks));
+	zend_hash_destroy(&PCG(classes));
+	zend_hash_destroy(&PCG(types));
+	zend_hash_destroy(&PCG(functions));
+	zend_hash_destroy(&PCG(tasks));
 
-    return SUCCESS;
+	return SUCCESS;
 }
 /* }}} */
 #endif

--- a/src/check.h
+++ b/src/check.h
@@ -18,58 +18,62 @@
 #ifndef HAVE_PARALLEL_CHECK_H
 #define HAVE_PARALLEL_CHECK_H
 
-bool      php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data, const zend_function * function, zval *argv, bool *returns);
-bool      php_parallel_check_zval(zval *zv, zval **error);
-bool      php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro);
+bool php_parallel_check_task(php_parallel_runtime_t *runtime, zend_execute_data *execute_data,
+                             const zend_function *function, zval *argv, bool *returns);
+bool php_parallel_check_zval(zval *zv, zval **error);
+bool php_parallel_check_function(const zend_function *function, zend_function **errf, zend_uchar *erro);
 
 #define PARALLEL_ZVAL_CHECK php_parallel_check_zval
 #define PARALLEL_ZVAL_CHECK_CLOSURES php_parallel_check_zval_closures
 
-#define PARALLEL_ZVAL_CHECK_CLOSURE(zv) \
-    (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ce_closure)
+#define PARALLEL_ZVAL_CHECK_CLOSURE(zv) (Z_TYPE_P(zv) == IS_OBJECT && Z_OBJCE_P(zv) == zend_ce_closure)
 
-static zend_always_inline bool php_parallel_check_zval_closures(zval *zv) { /* {{{ */
-    if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {
-        return 1;
-    }
+static zend_always_inline bool php_parallel_check_zval_closures(zval *zv)
+{ /* {{{ */
+	if (PARALLEL_ZVAL_CHECK_CLOSURE(zv)) {
+		return 1;
+	}
 
-    if (Z_TYPE_P(zv) == IS_ARRAY) {
-        zval *val;
+	if (Z_TYPE_P(zv) == IS_ARRAY) {
+		zval *val;
 
-        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(zv), val) {
-            if (PARALLEL_ZVAL_CHECK_CLOSURE(val)) {
-                return 1;
-            }
-        } ZEND_HASH_FOREACH_END();
-    }
+		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(zv), val)
+		{
+			if (PARALLEL_ZVAL_CHECK_CLOSURE(val)) {
+				return 1;
+			}
+		}
+		ZEND_HASH_FOREACH_END();
+	}
 
-    if (Z_TYPE_P(zv) == IS_OBJECT) {
-        zend_object *object = Z_OBJ_P(zv);
+	if (Z_TYPE_P(zv) == IS_OBJECT) {
+		zend_object *object = Z_OBJ_P(zv);
 
-        if (object->ce->default_properties_count) {
-            zval *property = object->properties_table,
-                 *end     = property + object->ce->default_properties_count;
+		if (object->ce->default_properties_count) {
+			zval *property = object->properties_table, *end = property + object->ce->default_properties_count;
 
-            while (property < end) {
-                if (PARALLEL_ZVAL_CHECK_CLOSURE(property)) {
-                    return 1;
-                }
-                property++;
-            }
-        }
+			while (property < end) {
+				if (PARALLEL_ZVAL_CHECK_CLOSURE(property)) {
+					return 1;
+				}
+				property++;
+			}
+		}
 
-        if (object->properties) {
-            zval *property;
+		if (object->properties) {
+			zval *property;
 
-            ZEND_HASH_FOREACH_VAL(object->properties, property) {
-                if (PARALLEL_ZVAL_CHECK_CLOSURE(property)) {
-                    return 1;
-                }
-            } ZEND_HASH_FOREACH_END();
-        }
-    }
+			ZEND_HASH_FOREACH_VAL(object->properties, property)
+			{
+				if (PARALLEL_ZVAL_CHECK_CLOSURE(property)) {
+					return 1;
+				}
+			}
+			ZEND_HASH_FOREACH_END();
+		}
+	}
 
-    return 0;
+	return 0;
 } /* }}} */
 
 PHP_RINIT_FUNCTION(PARALLEL_CHECK);

--- a/src/copy.c
+++ b/src/copy.c
@@ -20,1096 +20,1049 @@
 
 #include "parallel.h"
 
-#include "php_streams.h"
 #include "php_network.h"
+#include "php_streams.h"
 
 TSRM_TLS struct {
-    HashTable scope;
-    zval      unavailable;
-    php_parallel_copy_context_t *context;
+	HashTable                    scope;
+	zval                         unavailable;
+	php_parallel_copy_context_t *context;
 } php_parallel_copy_globals;
 
 static struct {
-    pthread_mutex_t mutex;
-    HashTable       table;
+	pthread_mutex_t mutex;
+	HashTable       table;
 } php_parallel_copy_strings = {PTHREAD_MUTEX_INITIALIZER};
 
-zend_class_entry* php_parallel_copy_type_unavailable_ce;
-zend_class_entry* php_parallel_copy_object_unavailable_ce;
+zend_class_entry *php_parallel_copy_type_unavailable_ce;
+zend_class_entry *php_parallel_copy_object_unavailable_ce;
 
 #define PCG(e) php_parallel_copy_globals.e
 #define PCS(e) php_parallel_copy_strings.e
 
-static void php_parallel_copy_zval_persistent(
-                zval *dest, zval *source,
-                zend_string* (*php_parallel_copy_string_func)(zend_string*),
-                void* (*php_parallel_copy_memory_func)(void *source, zend_long size));
+static void           php_parallel_copy_zval_persistent(zval *dest, zval *source,
+                                                        zend_string *(*php_parallel_copy_string_func)(zend_string *),
+                                                        void *(*php_parallel_copy_memory_func)(void *source, zend_long size));
 
 static const uint32_t php_parallel_copy_uninitialized_bucket[-HT_MIN_MASK] = {HT_INVALID_IDX, HT_INVALID_IDX};
 
-static void php_parallel_copy_string_free(zval *zv) {
-    free(Z_PTR_P(zv));
+static void           php_parallel_copy_string_free(zval *zv) { free(Z_PTR_P(zv)); }
+
+static zend_always_inline zend_string *php_parallel_copy_string_ex(zend_string *source, bool persistent)
+{
+	zend_string *dest = zend_string_alloc(ZSTR_LEN(source), persistent);
+
+	memcpy(ZSTR_VAL(dest), ZSTR_VAL(source), ZSTR_LEN(source));
+
+	ZSTR_VAL(dest)[ZSTR_LEN(dest)] = 0;
+
+	ZSTR_LEN(dest) = ZSTR_LEN(source);
+	ZSTR_H(dest) = ZSTR_H(source);
+
+	return dest;
 }
 
-static zend_always_inline zend_string* php_parallel_copy_string_ex(zend_string *source, bool persistent) {
-    zend_string *dest = zend_string_alloc(ZSTR_LEN(source), persistent);
+zend_string *php_parallel_copy_string_interned(zend_string *source)
+{
+	zend_string *dest;
 
-    memcpy(ZSTR_VAL(dest),
-           ZSTR_VAL(source),
-           ZSTR_LEN(source));
+	pthread_mutex_lock(&PCS(mutex));
 
-    ZSTR_VAL(dest)[ZSTR_LEN(dest)] = 0;
+	if (!(dest = zend_hash_find_ptr(&PCS(table), source))) {
 
-    ZSTR_LEN(dest) = ZSTR_LEN(source);
-    ZSTR_H(dest)   = ZSTR_H(source);
+		dest = php_parallel_copy_string_ex(source, 1);
 
-    return dest;
+		zend_string_hash_val(dest);
+
+		GC_TYPE_INFO(dest) = IS_STRING | ((IS_STR_INTERNED | IS_STR_PERMANENT) << GC_FLAGS_SHIFT);
+
+		zend_hash_add_ptr(&PCS(table), dest, dest);
+	}
+
+	pthread_mutex_unlock(&PCS(mutex));
+
+	return dest;
 }
 
-zend_string* php_parallel_copy_string_interned(zend_string *source) {
-    zend_string *dest;
+static zend_always_inline void php_parallel_copy_string_dtor(zend_string *source, bool persistent)
+{
+	if (ZSTR_IS_INTERNED(source)) {
+		return;
+	}
 
-    pthread_mutex_lock(&PCS(mutex));
-
-    if (!(dest = zend_hash_find_ptr(&PCS(table), source))) {
-
-        dest = php_parallel_copy_string_ex(source, 1);
-
-        zend_string_hash_val(dest);
-
-        GC_TYPE_INFO(dest) =
-            IS_STRING |
-            ((IS_STR_INTERNED | IS_STR_PERMANENT) << GC_FLAGS_SHIFT);
-
-        zend_hash_add_ptr(&PCS(table), dest, dest);
-    }
-
-    pthread_mutex_unlock(&PCS(mutex));
-
-    return dest;
+	if (GC_DELREF(source) == 0) {
+		pefree(source, persistent);
+	}
 }
 
-static zend_always_inline void php_parallel_copy_string_dtor(zend_string *source, bool persistent) {
-    if (ZSTR_IS_INTERNED(source)) {
-        return;
-    }
+static zend_always_inline zend_string *php_parallel_copy_string_ctor(zend_string *source, bool persistent)
+{
+	if (ZSTR_IS_INTERNED(source)) {
+		return php_parallel_copy_string_interned(source);
+	}
 
-    if (GC_DELREF(source) == 0) {
-        pefree(source, persistent);
-    }
+	return php_parallel_copy_string_ex(source, persistent);
 }
 
-static zend_always_inline zend_string* php_parallel_copy_string_ctor(zend_string *source, bool persistent) {
-    if (ZSTR_IS_INTERNED(source)) {
-        return php_parallel_copy_string_interned(source);
-    }
-
-    return php_parallel_copy_string_ex(source, persistent);
+zend_string *php_parallel_copy_string(zend_string *source, bool persistent)
+{
+	return php_parallel_copy_string_ctor(source, persistent);
 }
 
-zend_string* php_parallel_copy_string(zend_string *source, bool persistent) {
-    return php_parallel_copy_string_ctor(source, persistent);
-}
+zend_class_entry *php_parallel_copy_scope(zend_class_entry *class)
+{
+	zend_class_entry *scope, *exists_ce;
 
-zend_class_entry* php_parallel_copy_scope(zend_class_entry *class) {
-    zend_class_entry *scope, *exists_ce;
+	if (class->ce_flags & ZEND_ACC_IMMUTABLE) {
+		exists_ce = zend_lookup_class_ex(class->name, NULL, ZEND_FETCH_CLASS_NO_AUTOLOAD);
+		if (exists_ce) {
+			return class;
+		}
+	}
 
-    if (class->ce_flags & ZEND_ACC_IMMUTABLE) {
-        exists_ce = zend_lookup_class_ex(class->name, NULL, ZEND_FETCH_CLASS_NO_AUTOLOAD);
-        if (exists_ce) {
-            return class;
-        }
-    }
-
-    if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong) class))) {
-        return scope;
-    }
+	if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong) class))) {
+		return scope;
+	}
 
 #ifdef ZSTR_HAS_CE_CACHE
-    void *caching = NULL;
+	void *caching = NULL;
 
-    if (ZSTR_HAS_CE_CACHE(class->name) &&
-        ZSTR_VALID_CE_CACHE(class->name)) {
-        caching =
-            ZSTR_GET_CE_CACHE(class->name);
-        ZSTR_SET_CE_CACHE(class->name, NULL);
-    }
+	if (ZSTR_HAS_CE_CACHE(class->name) && ZSTR_VALID_CE_CACHE(class->name)) {
+		caching = ZSTR_GET_CE_CACHE(class->name);
+		ZSTR_SET_CE_CACHE(class->name, NULL);
+	}
 #endif
 
-    scope = zend_lookup_class(class->name);
+	scope = zend_lookup_class(class->name);
 
 #ifdef ZSTR_HAS_CE_CACHE
-    if (caching) {
-        ZSTR_SET_CE_CACHE(class->name, caching);
-    }
+	if (caching) {
+		ZSTR_SET_CE_CACHE(class->name, caching);
+	}
 #endif
 
-    if (!scope) {
-        return php_parallel_copy_type_unavailable_ce;
-    }
+	if (!scope) {
+		return php_parallel_copy_type_unavailable_ce;
+	}
 
-    return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong) class, scope);
+	return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong) class, scope);
 }
 
-static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, bool persistent) {
+static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, bool persistent)
+{
 #ifndef _WIN32
-    if (source->type == php_file_le_stream() ||
-        source->type == php_file_le_pstream()) {
-        int fd;
+	if (source->type == php_file_le_stream() || source->type == php_file_le_pstream()) {
+		int fd;
 
-        if (php_stream_cast((php_stream*) source->ptr, PHP_STREAM_AS_FD, (void*)&fd, 0) == SUCCESS) {
-            return (zend_long) fd;
-        }
-    }
+		if (php_stream_cast((php_stream *)source->ptr, PHP_STREAM_AS_FD, (void *)&fd, 0) == SUCCESS) {
+			return (zend_long)fd;
+		}
+	}
 #endif
-    return -1;
+	return -1;
 }
 
-static zend_always_inline HashTable* php_parallel_copy_hash_persistent_inline(
-                HashTable *source,
-                zend_string* (*php_parallel_copy_string_func)(zend_string*),
-                void* (*php_parallel_copy_memory_func)(void *source, zend_long size)) {
-    HashTable *ht;
-    uint32_t idx;
+static zend_always_inline HashTable *
+php_parallel_copy_hash_persistent_inline(HashTable *source,
+                                         zend_string *(*php_parallel_copy_string_func)(zend_string *),
+                                         void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+{
+	HashTable                   *ht;
+	uint32_t                     idx;
 
-    php_parallel_copy_context_t *context, *restore;
+	php_parallel_copy_context_t *context, *restore;
 
-    context = php_parallel_copy_context_start(
-        PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
-        &restore);
+	context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_PERSISTENT, &restore);
 
-    if ((ht = php_parallel_copy_context_find(context, source))) {
-        GC_ADDREF(ht);
-        php_parallel_copy_context_end(context, restore);
-        return ht;
-    } else {
-        ht = php_parallel_copy_memory_func(source, sizeof(HashTable));
-        php_parallel_copy_context_insert(
-            context, source, ht);
-    }
+	if ((ht = php_parallel_copy_context_find(context, source))) {
+		GC_ADDREF(ht);
+		php_parallel_copy_context_end(context, restore);
+		return ht;
+	} else {
+		ht = php_parallel_copy_memory_func(source, sizeof(HashTable));
+		php_parallel_copy_context_insert(context, source, ht);
+	}
 
-    // see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
-    // TODO: needs fixing
-    GC_SET_REFCOUNT(ht, 2);
-    GC_SET_PERSISTENT_TYPE(ht, GC_ARRAY);
-    GC_ADD_FLAGS(ht, IS_ARRAY_IMMUTABLE);
+	// see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
+	// TODO: needs fixing
+	GC_SET_REFCOUNT(ht, 2);
+	GC_SET_PERSISTENT_TYPE(ht, GC_ARRAY);
+	GC_ADD_FLAGS(ht, IS_ARRAY_IMMUTABLE);
 
-    ht->pDestructor = ZVAL_PTR_DTOR;
+	ht->pDestructor = ZVAL_PTR_DTOR;
 
-    ht->u.flags |= HASH_FLAG_STATIC_KEYS;
-    if (ht->nNumUsed == 0) {
-        ht->u.flags = HASH_FLAG_UNINITIALIZED;
-        ht->nNextFreeElement = 0;
-        ht->nTableMask = HT_MIN_MASK;
-        HT_SET_DATA_ADDR(ht, &php_parallel_copy_uninitialized_bucket);
-        php_parallel_copy_context_end(context, restore);
-        return ht;
-    }
+	ht->u.flags |= HASH_FLAG_STATIC_KEYS;
+	if (ht->nNumUsed == 0) {
+		ht->u.flags = HASH_FLAG_UNINITIALIZED;
+		ht->nNextFreeElement = 0;
+		ht->nTableMask = HT_MIN_MASK;
+		HT_SET_DATA_ADDR(ht, &php_parallel_copy_uninitialized_bucket);
+		php_parallel_copy_context_end(context, restore);
+		return ht;
+	}
 
 #ifdef HT_PACKED_SIZE
-    // if array is packed, copy it as packed
-    if (HT_IS_PACKED(ht)) {
-        HT_SET_DATA_ADDR(ht, php_parallel_copy_memory_func(HT_GET_DATA_ADDR(source), HT_PACKED_SIZE_EX(source->nTableSize, HT_MIN_MASK)));
+	// if array is packed, copy it as packed
+	if (HT_IS_PACKED(ht)) {
+		HT_SET_DATA_ADDR(ht, php_parallel_copy_memory_func(HT_GET_DATA_ADDR(source),
+		                                                   HT_PACKED_SIZE_EX(source->nTableSize, HT_MIN_MASK)));
 
-        for (idx = 0; idx < ht->nNumUsed; idx++) {
-            zval *zv = ht->arPacked + idx;
+		for (idx = 0; idx < ht->nNumUsed; idx++) {
+			zval *zv = ht->arPacked + idx;
 
-            if (Z_TYPE_P(zv) == IS_UNDEF)
-                continue;
+			if (Z_TYPE_P(zv) == IS_UNDEF)
+				continue;
 
-            if (Z_OPT_REFCOUNTED_P(zv)) {
-                php_parallel_copy_zval_persistent(
-                    zv,
-                    zv,
-                    php_parallel_copy_string_func,
-                    php_parallel_copy_memory_func);
-            }
-        }
-        ht->nNextFreeElement = ht->nNumUsed;
-        php_parallel_copy_context_end(context, restore);
-        return ht;
-    }
+			if (Z_OPT_REFCOUNTED_P(zv)) {
+				php_parallel_copy_zval_persistent(zv, zv, php_parallel_copy_string_func, php_parallel_copy_memory_func);
+			}
+		}
+		ht->nNextFreeElement = ht->nNumUsed;
+		php_parallel_copy_context_end(context, restore);
+		return ht;
+	}
 #endif
-    ht->nNextFreeElement = 0;
-    ht->nInternalPointer = 0;
+	ht->nNextFreeElement = 0;
+	ht->nInternalPointer = 0;
 
-    HT_SET_DATA_ADDR(ht, php_parallel_copy_memory_func(HT_GET_DATA_ADDR(source), HT_SIZE(source)));
+	HT_SET_DATA_ADDR(ht, php_parallel_copy_memory_func(HT_GET_DATA_ADDR(source), HT_SIZE(source)));
 
-    for (idx = 0; idx < ht->nNumUsed; idx++) {
-        Bucket *p = ht->arData + idx;
+	for (idx = 0; idx < ht->nNumUsed; idx++) {
+		Bucket *p = ht->arData + idx;
 
-        if (Z_TYPE(p->val) == IS_UNDEF)
-            continue;
+		if (Z_TYPE(p->val) == IS_UNDEF)
+			continue;
 
-        if (p->key) {
-            p->key = php_parallel_copy_string_interned(p->key);
-            ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
-        } else if ((zend_long) p->h >= (zend_long) ht->nNextFreeElement) {
-            ht->nNextFreeElement = p->h + 1;
-        }
+		if (p->key) {
+			p->key = php_parallel_copy_string_interned(p->key);
+			ht->u.flags &= ~HASH_FLAG_STATIC_KEYS;
+		} else if ((zend_long)p->h >= (zend_long)ht->nNextFreeElement) {
+			ht->nNextFreeElement = p->h + 1;
+		}
 
-        if (Z_OPT_REFCOUNTED(p->val)) {
-            php_parallel_copy_zval_persistent(
-                &p->val,
-                &p->val,
-                php_parallel_copy_string_func,
-                php_parallel_copy_memory_func);
-        }
-    }
-    php_parallel_copy_context_end(context, restore);
-    return ht;
+		if (Z_OPT_REFCOUNTED(p->val)) {
+			php_parallel_copy_zval_persistent(&p->val, &p->val, php_parallel_copy_string_func,
+			                                  php_parallel_copy_memory_func);
+		}
+	}
+	php_parallel_copy_context_end(context, restore);
+	return ht;
 }
 
-static zend_always_inline HashTable* php_parallel_copy_hash_thread(HashTable *source) {
-    HashTable *ht;
+static zend_always_inline HashTable *php_parallel_copy_hash_thread(HashTable *source)
+{
+	HashTable                   *ht;
 
-    php_parallel_copy_context_t *context, *restore;
+	php_parallel_copy_context_t *context, *restore;
 
-    context = php_parallel_copy_context_start(
-        PHP_PARALLEL_COPY_DIRECTION_THREAD,
-        &restore);
+	context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_THREAD, &restore);
 
-    if ((ht = php_parallel_copy_context_find(context, source))) {
-        GC_ADDREF(ht);
-        php_parallel_copy_context_end(
-            context, restore);
-        return ht;
-    } else {
-        ht = php_parallel_copy_mem(source, sizeof(HashTable), 0);
-        php_parallel_copy_context_insert(
-            context, source, ht);
-    }
+	if ((ht = php_parallel_copy_context_find(context, source))) {
+		GC_ADDREF(ht);
+		php_parallel_copy_context_end(context, restore);
+		return ht;
+	} else {
+		ht = php_parallel_copy_mem(source, sizeof(HashTable), 0);
+		php_parallel_copy_context_insert(context, source, ht);
+	}
 
-    GC_SET_REFCOUNT(ht, 1);
-    GC_DEL_FLAGS(ht, IS_ARRAY_IMMUTABLE);
+	GC_SET_REFCOUNT(ht, 1);
+	GC_DEL_FLAGS(ht, IS_ARRAY_IMMUTABLE);
 
-    GC_TYPE_INFO(ht) = GC_ARRAY;
+	GC_TYPE_INFO(ht) = GC_ARRAY;
 
-    ht->pDestructor = ZVAL_PTR_DTOR;
+	ht->pDestructor = ZVAL_PTR_DTOR;
 
-    if (ht->nNumUsed == 0) {
-        HT_SET_DATA_ADDR(ht, &php_parallel_copy_uninitialized_bucket);
-        php_parallel_copy_context_end(context, restore);
-        return ht;
-    }
+	if (ht->nNumUsed == 0) {
+		HT_SET_DATA_ADDR(ht, &php_parallel_copy_uninitialized_bucket);
+		php_parallel_copy_context_end(context, restore);
+		return ht;
+	}
 
-    HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
-    memcpy(
-        HT_GET_DATA_ADDR(ht),
-        HT_GET_DATA_ADDR(source),
-        HT_HASH_SIZE(ht->nTableMask));
+	HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
+	memcpy(HT_GET_DATA_ADDR(ht), HT_GET_DATA_ADDR(source), HT_HASH_SIZE(ht->nTableMask));
 #ifdef HT_PACKED_SIZE
-    if (HT_IS_PACKED(ht)) {
-        zval *p = ht->arPacked,
-        *q = source->arPacked,
-        *p_end = p + ht->nNumUsed;
-        for (; p < p_end; p++, q++) {
-            *p = *q;
-            if (Z_OPT_REFCOUNTED_P(p)) {
-                PARALLEL_ZVAL_COPY(p, q, 0);
-            }
-        }
-    } else
+	if (HT_IS_PACKED(ht)) {
+		zval *p = ht->arPacked, *q = source->arPacked, *p_end = p + ht->nNumUsed;
+		for (; p < p_end; p++, q++) {
+			*p = *q;
+			if (Z_OPT_REFCOUNTED_P(p)) {
+				PARALLEL_ZVAL_COPY(p, q, 0);
+			}
+		}
+	} else
 #endif
-    if (ht->u.flags & HASH_FLAG_STATIC_KEYS) {
-        Bucket *p = ht->arData,
-        *q = source->arData,
-        *p_end = p + ht->nNumUsed;
-        for (; p < p_end; p++, q++) {
-            *p = *q;
-            if (Z_OPT_REFCOUNTED(p->val)) {
-                PARALLEL_ZVAL_COPY(&p->val, &p->val, 0);
-            }
-        }
-    } else {
-        Bucket *p = ht->arData,
-        *q = source->arData,
-        *p_end = p + ht->nNumUsed;
-        for (; p < p_end; p++, q++) {
-            if (Z_TYPE(q->val) == IS_UNDEF) {
-                ZVAL_UNDEF(&p->val);
-                continue;
-            }
+	    if (ht->u.flags & HASH_FLAG_STATIC_KEYS) {
+		Bucket *p = ht->arData, *q = source->arData, *p_end = p + ht->nNumUsed;
+		for (; p < p_end; p++, q++) {
+			*p = *q;
+			if (Z_OPT_REFCOUNTED(p->val)) {
+				PARALLEL_ZVAL_COPY(&p->val, &p->val, 0);
+			}
+		}
+	} else {
+		Bucket *p = ht->arData, *q = source->arData, *p_end = p + ht->nNumUsed;
+		for (; p < p_end; p++, q++) {
+			if (Z_TYPE(q->val) == IS_UNDEF) {
+				ZVAL_UNDEF(&p->val);
+				continue;
+			}
 
-            p->val = q->val;
-            p->h = q->h;
-            if (q->key) {
-                p->key = php_parallel_copy_string_ctor(q->key, 0);
-            } else {
-                p->key = NULL;
-            }
+			p->val = q->val;
+			p->h = q->h;
+			if (q->key) {
+				p->key = php_parallel_copy_string_ctor(q->key, 0);
+			} else {
+				p->key = NULL;
+			}
 
-            if (Z_OPT_REFCOUNTED(p->val)) {
-                PARALLEL_ZVAL_COPY(&p->val, &p->val, 0);
-            }
-        }
-    }
+			if (Z_OPT_REFCOUNTED(p->val)) {
+				PARALLEL_ZVAL_COPY(&p->val, &p->val, 0);
+			}
+		}
+	}
 
-    php_parallel_copy_context_end(context, restore);
-    return ht;
+	php_parallel_copy_context_end(context, restore);
+	return ht;
 }
 
-static void* php_parallel_copy_mem_persistent(void *source, zend_long size) {
-    return php_parallel_copy_mem(source, size, 1);
+static void *php_parallel_copy_mem_persistent(void *source, zend_long size)
+{
+	return php_parallel_copy_mem(source, size, 1);
 }
 
-static zend_string* php_parallel_copy_string_persistent(zend_string *string) {
-    return php_parallel_copy_string_ctor(string, 1);
+static zend_string *php_parallel_copy_string_persistent(zend_string *string)
+{
+	return php_parallel_copy_string_ctor(string, 1);
 }
 
-HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent) {
-    if (persistent) {
-        return php_parallel_copy_hash_persistent_inline(
-                source,
-                php_parallel_copy_string_persistent,
-                php_parallel_copy_mem_persistent);
-    }
-    return php_parallel_copy_hash_thread(source);
+HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent)
+{
+	if (persistent) {
+		return php_parallel_copy_hash_persistent_inline(source, php_parallel_copy_string_persistent,
+		                                                php_parallel_copy_mem_persistent);
+	}
+	return php_parallel_copy_hash_thread(source);
 }
 
 HashTable *php_parallel_copy_hash_persistent(HashTable *source,
-            zend_string* (*php_parallel_copy_string_func)(zend_string*),
-            void* (*php_parallel_copy_memory_func)(void *source, zend_long size)) {
-        return php_parallel_copy_hash_persistent_inline(source,
-                php_parallel_copy_string_func,
-                php_parallel_copy_memory_func);
+                                             zend_string *(*php_parallel_copy_string_func)(zend_string *),
+                                             void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+{
+	return php_parallel_copy_hash_persistent_inline(source, php_parallel_copy_string_func,
+	                                                php_parallel_copy_memory_func);
 }
 
-void php_parallel_copy_hash_dtor(HashTable *table, bool persistent) {
-    // see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
-    // TODO: needs fixing
-    if (GC_DELREF(table) == (persistent ? 1 : 0)) {
-        if (!persistent) {
-            GC_REMOVE_FROM_BUFFER(table);
-            GC_TYPE_INFO(table) =
+void php_parallel_copy_hash_dtor(HashTable *table, bool persistent)
+{
+	// see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
+	// TODO: needs fixing
+	if (GC_DELREF(table) == (persistent ? 1 : 0)) {
+		if (!persistent) {
+			GC_REMOVE_FROM_BUFFER(table);
+			GC_TYPE_INFO(table) =
 #ifdef GC_WHITE
-                IS_NULL | (GC_WHITE << 16);
+			    IS_NULL | (GC_WHITE << 16);
 #else
-                IS_NULL;
+			    IS_NULL;
 #endif
-        }
+		}
 
 #ifdef HT_PACKED_SIZE
-        if (HT_IS_PACKED(table)){
-            zval *p = table->arPacked,
-                *end = p + table->nNumUsed;
-            while (p < end) {
-                if (Z_OPT_REFCOUNTED_P(p)) {
-                    PARALLEL_ZVAL_DTOR(p);
-                }
-                p++;
-            }
-        } else
+		if (HT_IS_PACKED(table)) {
+			zval *p = table->arPacked, *end = p + table->nNumUsed;
+			while (p < end) {
+				if (Z_OPT_REFCOUNTED_P(p)) {
+					PARALLEL_ZVAL_DTOR(p);
+				}
+				p++;
+			}
+		} else
 #endif
-        if (HT_HAS_STATIC_KEYS_ONLY(table)) {
-            Bucket *p = table->arData,
-                *end = p + table->nNumUsed;
-            while (p < end) {
-                if (Z_OPT_REFCOUNTED(p->val)) {
-                    PARALLEL_ZVAL_DTOR(&p->val);
-                }
-                p++;
-            }
-        } else {
-            Bucket *p = table->arData,
-                *end = p + table->nNumUsed;
-            while (p < end) {
-                if (Z_ISUNDEF(p->val)) {
-                    p++;
-                    continue;
-                }
+		    if (HT_HAS_STATIC_KEYS_ONLY(table)) {
+			Bucket *p = table->arData, *end = p + table->nNumUsed;
+			while (p < end) {
+				if (Z_OPT_REFCOUNTED(p->val)) {
+					PARALLEL_ZVAL_DTOR(&p->val);
+				}
+				p++;
+			}
+		} else {
+			Bucket *p = table->arData, *end = p + table->nNumUsed;
+			while (p < end) {
+				if (Z_ISUNDEF(p->val)) {
+					p++;
+					continue;
+				}
 
-                if (p->key) {
-                    php_parallel_copy_string_dtor(
-                        p->key,
-                        GC_FLAGS(p->key) & IS_STR_PERSISTENT);
-                }
+				if (p->key) {
+					php_parallel_copy_string_dtor(p->key, GC_FLAGS(p->key) & IS_STR_PERSISTENT);
+				}
 
-                if (Z_OPT_REFCOUNTED(p->val)) {
-                    php_parallel_copy_zval_dtor(&p->val);
-                }
+				if (Z_OPT_REFCOUNTED(p->val)) {
+					php_parallel_copy_zval_dtor(&p->val);
+				}
 
-                p++;
-            }
-        }
+				p++;
+			}
+		}
 
-        if (HT_GET_DATA_ADDR(table) != (void*) &php_parallel_copy_uninitialized_bucket) {
-            pefree(HT_GET_DATA_ADDR(table), persistent);
-        }
+		if (HT_GET_DATA_ADDR(table) != (void *)&php_parallel_copy_uninitialized_bucket) {
+			pefree(HT_GET_DATA_ADDR(table), persistent);
+		}
 
-        pefree(table, persistent);
-    }
+		pefree(table, persistent);
+	}
 }
 
-static zend_always_inline zend_object* php_parallel_copy_closure_persistent(zend_object *source) {
-    zend_closure_t *closure = (zend_closure_t*) source;
-    zend_closure_t *copy =
-        (zend_closure_t*)
-            php_parallel_copy_mem(
-                source, sizeof(zend_closure_t), 1);
+static zend_always_inline zend_object *php_parallel_copy_closure_persistent(zend_object *source)
+{
+	zend_closure_t *closure = (zend_closure_t *)source;
+	zend_closure_t *copy = (zend_closure_t *)php_parallel_copy_mem(source, sizeof(zend_closure_t), 1);
 
-    php_parallel_cache_closure(&closure->func, &copy->func);
+	php_parallel_cache_closure(&closure->func, &copy->func);
 
-    GC_ADD_FLAGS(&copy->std, GC_IMMUTABLE);
+	GC_ADD_FLAGS(&copy->std, GC_IMMUTABLE);
 
-    copy->func.common.fn_flags |= ZEND_ACC_CLOSURE;
+	copy->func.common.fn_flags |= ZEND_ACC_CLOSURE;
 
-    if (Z_TYPE(copy->this_ptr) == IS_OBJECT) {
-        PARALLEL_ZVAL_COPY(&copy->this_ptr, &copy->this_ptr, 1);
-    }
+	if (Z_TYPE(copy->this_ptr) == IS_OBJECT) {
+		PARALLEL_ZVAL_COPY(&copy->this_ptr, &copy->this_ptr, 1);
+	}
 
-    php_parallel_dependencies_store(&copy->func);
+	php_parallel_dependencies_store(&copy->func);
 
-    return &copy->std;
+	return &copy->std;
 }
 
-static zend_always_inline void php_parallel_copy_closure_init_run_time_cache(zend_op_array *function) {
-    void *rtc;
+static zend_always_inline void php_parallel_copy_closure_init_run_time_cache(zend_op_array *function)
+{
+	void *rtc;
 
-    function->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
+	function->fn_flags |= ZEND_ACC_HEAP_RT_CACHE;
 #if PHP_VERSION_ID >= 80200
-    rtc = emalloc(function->cache_size);
+	rtc = emalloc(function->cache_size);
 
-    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
+	ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
 #else
-    rtc = emalloc(sizeof(void*) + function->cache_size);
+	rtc = emalloc(sizeof(void *) + function->cache_size);
 
-    ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
+	ZEND_MAP_PTR_INIT(function->run_time_cache, rtc);
 
-    rtc = (char*)rtc + sizeof(void*);
+	rtc = (char *)rtc + sizeof(void *);
 
-    ZEND_MAP_PTR_SET(function->run_time_cache, rtc);
+	ZEND_MAP_PTR_SET(function->run_time_cache, rtc);
 #endif
 
-    memset(rtc, 0, function->cache_size);
+	memset(rtc, 0, function->cache_size);
 }
 
-static zend_always_inline zend_object* php_parallel_copy_closure_thread(zend_object *source) {
-    zend_closure_t *copy =
-        (zend_closure_t*)
-            php_parallel_copy_mem(
-                source, sizeof(zend_closure_t), 0);
-    zend_class_entry *scope =
-        copy->func.op_array.scope;
-    zend_op_array *function =
-        (zend_op_array*) &copy->func;
+static zend_always_inline zend_object *php_parallel_copy_closure_thread(zend_object *source)
+{
+	zend_closure_t   *copy = (zend_closure_t *)php_parallel_copy_mem(source, sizeof(zend_closure_t), 0);
+	zend_class_entry *scope = copy->func.op_array.scope;
+	zend_op_array    *function = (zend_op_array *)&copy->func;
 
-    GC_DEL_FLAGS(&copy->std, GC_IMMUTABLE);
+	GC_DEL_FLAGS(&copy->std, GC_IMMUTABLE);
 
-    zend_object_std_init(&copy->std, zend_ce_closure);
+	zend_object_std_init(&copy->std, zend_ce_closure);
 
-    if (copy->called_scope &&
-        copy->called_scope->type == ZEND_USER_CLASS) {
-        copy->called_scope =
-            php_parallel_copy_scope(copy->called_scope);
-    }
+	if (copy->called_scope && copy->called_scope->type == ZEND_USER_CLASS) {
+		copy->called_scope = php_parallel_copy_scope(copy->called_scope);
+	}
 
-    if (scope &&
-        scope->type == ZEND_USER_CLASS) {
-        function->scope = php_parallel_copy_scope(scope);
-    }
+	if (scope && scope->type == ZEND_USER_CLASS) {
+		function->scope = php_parallel_copy_scope(scope);
+	}
 
-    if (function->static_variables) {
-        function->static_variables =
-            php_parallel_copy_hash_ctor(function->static_variables, 0);
-    }
+	if (function->static_variables) {
+		function->static_variables = php_parallel_copy_hash_ctor(function->static_variables, 0);
+	}
 
 #if PHP_VERSION_ID >= 80200
-    ZEND_MAP_PTR_INIT(function->static_variables_ptr, function->static_variables);
+	ZEND_MAP_PTR_INIT(function->static_variables_ptr, function->static_variables);
 #else
-    ZEND_MAP_PTR_INIT(function->static_variables_ptr, &function->static_variables);
+	ZEND_MAP_PTR_INIT(function->static_variables_ptr, &function->static_variables);
 #endif
 
-    php_parallel_copy_closure_init_run_time_cache(function);
+	php_parallel_copy_closure_init_run_time_cache(function);
 
-    if (Z_TYPE(copy->this_ptr) == IS_OBJECT) {
-        PARALLEL_ZVAL_COPY(&copy->this_ptr, &copy->this_ptr, 0);
-    }
+	if (Z_TYPE(copy->this_ptr) == IS_OBJECT) {
+		PARALLEL_ZVAL_COPY(&copy->this_ptr, &copy->this_ptr, 0);
+	}
 
-    php_parallel_dependencies_load((zend_function*) function);
+	php_parallel_dependencies_load((zend_function *)function);
 
-    return &copy->std;
+	return &copy->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_closure_ctor(zend_object *source, bool persistent) {
-    if (persistent) {
-        return php_parallel_copy_closure_persistent(source);
-    }
+static zend_always_inline zend_object *php_parallel_copy_closure_ctor(zend_object *source, bool persistent)
+{
+	if (persistent) {
+		return php_parallel_copy_closure_persistent(source);
+	}
 
-    return php_parallel_copy_closure_thread(source);
+	return php_parallel_copy_closure_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_closure_dtor(zend_object *source, bool persistent) {
-    zend_closure_t *closure;
+static zend_always_inline void php_parallel_copy_closure_dtor(zend_object *source, bool persistent)
+{
+	zend_closure_t *closure;
 
-    if (!persistent) {
-        OBJ_RELEASE(source);
-        return;
-    }
+	if (!persistent) {
+		OBJ_RELEASE(source);
+		return;
+	}
 
-    closure = (zend_closure_t*) source;
+	closure = (zend_closure_t *)source;
 
-    if (closure->func.op_array.static_variables) {
-        php_parallel_copy_hash_dtor(
-            closure->func.op_array.static_variables, 1);
-    }
+	if (closure->func.op_array.static_variables) {
+		php_parallel_copy_hash_dtor(closure->func.op_array.static_variables, 1);
+	}
 
-    if (Z_TYPE(closure->this_ptr) == IS_OBJECT) {
-        PARALLEL_ZVAL_DTOR(&closure->this_ptr);
-    }
+	if (Z_TYPE(closure->this_ptr) == IS_OBJECT) {
+		PARALLEL_ZVAL_DTOR(&closure->this_ptr);
+	}
 
-    pefree(closure, 1);
+	pefree(closure, 1);
 }
 
-static zend_always_inline zend_reference* php_parallel_copy_reference_persistent(zend_reference *source) {
-    zend_reference *reference =
-        php_parallel_copy_mem(source, sizeof(zend_reference), 1);
+static zend_always_inline zend_reference *php_parallel_copy_reference_persistent(zend_reference *source)
+{
+	zend_reference *reference = php_parallel_copy_mem(source, sizeof(zend_reference), 1);
 
-    GC_SET_REFCOUNT(reference, 1);
-    GC_ADD_FLAGS(reference, GC_IMMUTABLE);
+	GC_SET_REFCOUNT(reference, 1);
+	GC_ADD_FLAGS(reference, GC_IMMUTABLE);
 
-    PARALLEL_ZVAL_COPY(&reference->val, &source->val, 1);
+	PARALLEL_ZVAL_COPY(&reference->val, &source->val, 1);
 
-    return reference;
+	return reference;
 }
 
-static zend_always_inline zend_reference* php_parallel_copy_reference_thread(zend_reference *source) {
-    zend_reference *reference =
-        php_parallel_copy_mem(source, sizeof(zend_reference), 0);
+static zend_always_inline zend_reference *php_parallel_copy_reference_thread(zend_reference *source)
+{
+	zend_reference *reference = php_parallel_copy_mem(source, sizeof(zend_reference), 0);
 
-    GC_DEL_FLAGS(reference, GC_IMMUTABLE);
+	GC_DEL_FLAGS(reference, GC_IMMUTABLE);
 
-    PARALLEL_ZVAL_COPY(&reference->val, &source->val, 0);
+	PARALLEL_ZVAL_COPY(&reference->val, &source->val, 0);
 
-    return reference;
+	return reference;
 }
 
-static zend_always_inline zend_reference* php_parallel_copy_reference_ctor(zend_reference *source, bool persistent) {
-    if (persistent) {
-        return php_parallel_copy_reference_persistent(source);
-    }
-    return php_parallel_copy_reference_thread(source);
+static zend_always_inline zend_reference *php_parallel_copy_reference_ctor(zend_reference *source, bool persistent)
+{
+	if (persistent) {
+		return php_parallel_copy_reference_persistent(source);
+	}
+	return php_parallel_copy_reference_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_reference_dtor(zend_reference *source, bool persistent) {
-    if (GC_DELREF(source) == 0) {
-        PARALLEL_ZVAL_DTOR(
-            &source->val);
-        pefree(source, persistent);
-    }
+static zend_always_inline void php_parallel_copy_reference_dtor(zend_reference *source, bool persistent)
+{
+	if (GC_DELREF(source) == 0) {
+		PARALLEL_ZVAL_DTOR(&source->val);
+		pefree(source, persistent);
+	}
 }
 
-static size_t _php_parallel_copy_channel_size = 0;
+static size_t                    _php_parallel_copy_channel_size = 0;
 
-static zend_always_inline size_t php_parallel_copy_channel_size() {
-    if (_php_parallel_copy_channel_size == 0) {
-        _php_parallel_copy_channel_size =
-            sizeof(php_parallel_channel_t) +
-            zend_object_properties_size(php_parallel_channel_ce);
-    }
+static zend_always_inline size_t php_parallel_copy_channel_size()
+{
+	if (_php_parallel_copy_channel_size == 0) {
+		_php_parallel_copy_channel_size =
+		    sizeof(php_parallel_channel_t) + zend_object_properties_size(php_parallel_channel_ce);
+	}
 
-    return _php_parallel_copy_channel_size;
+	return _php_parallel_copy_channel_size;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_channel_persistent(zend_object *source) {
-    php_parallel_channel_t *channel = php_parallel_channel_fetch(source),
-                           *dest    = php_parallel_copy_mem(channel, php_parallel_copy_channel_size(), 1);
+static zend_always_inline zend_object *php_parallel_copy_channel_persistent(zend_object *source)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(source),
+	                       *dest = php_parallel_copy_mem(channel, php_parallel_copy_channel_size(), 1);
 
-    GC_ADD_FLAGS(&dest->std, GC_IMMUTABLE);
+	GC_ADD_FLAGS(&dest->std, GC_IMMUTABLE);
 
-    dest->link = php_parallel_link_copy(channel->link);
+	dest->link = php_parallel_link_copy(channel->link);
 
-    return &dest->std;
+	return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_channel_thread(zend_object *source) {
-    php_parallel_channel_t *channel = php_parallel_channel_fetch(source),
-                           *dest    = php_parallel_copy_mem(channel, php_parallel_copy_channel_size(), 0);
+static zend_always_inline zend_object *php_parallel_copy_channel_thread(zend_object *source)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(source),
+	                       *dest = php_parallel_copy_mem(channel, php_parallel_copy_channel_size(), 0);
 
-    GC_DEL_FLAGS(&dest->std, GC_IMMUTABLE);
+	GC_DEL_FLAGS(&dest->std, GC_IMMUTABLE);
 
-    zend_object_std_init(&dest->std, php_parallel_channel_ce);
+	zend_object_std_init(&dest->std, php_parallel_channel_ce);
 
-    dest->std.handlers = &php_parallel_channel_handlers;
+	dest->std.handlers = &php_parallel_channel_handlers;
 
-    dest->link = php_parallel_link_copy(channel->link);
+	dest->link = php_parallel_link_copy(channel->link);
 
-    return &dest->std;
+	return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_channel_ctor(zend_object *source, bool persistent) {
-    if (persistent) {
-        return php_parallel_copy_channel_persistent(source);
-    }
-    return php_parallel_copy_channel_thread(source);
+static zend_always_inline zend_object *php_parallel_copy_channel_ctor(zend_object *source, bool persistent)
+{
+	if (persistent) {
+		return php_parallel_copy_channel_persistent(source);
+	}
+	return php_parallel_copy_channel_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_channel_dtor(zend_object *source, bool persistent) {
-    php_parallel_channel_t *channel = php_parallel_channel_fetch(source);
+static zend_always_inline void php_parallel_copy_channel_dtor(zend_object *source, bool persistent)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(source);
 
-    if (!persistent) {
-        OBJ_RELEASE(source);
-        return;
-    }
+	if (!persistent) {
+		OBJ_RELEASE(source);
+		return;
+	}
 
-    php_parallel_link_destroy(channel->link);
+	php_parallel_link_destroy(channel->link);
 
-    pefree(channel, persistent);
+	pefree(channel, persistent);
 }
 
-static size_t _php_parallel_copy_sync_size = 0;
+static size_t                    _php_parallel_copy_sync_size = 0;
 
-static zend_always_inline size_t php_parallel_copy_sync_size() {
-    if (_php_parallel_copy_sync_size == 0) {
-        _php_parallel_copy_sync_size =
-            sizeof(php_parallel_sync_object_t) +
-            zend_object_properties_size(php_parallel_sync_ce);
-    }
+static zend_always_inline size_t php_parallel_copy_sync_size()
+{
+	if (_php_parallel_copy_sync_size == 0) {
+		_php_parallel_copy_sync_size =
+		    sizeof(php_parallel_sync_object_t) + zend_object_properties_size(php_parallel_sync_ce);
+	}
 
-    return _php_parallel_copy_sync_size;
+	return _php_parallel_copy_sync_size;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_sync_persistent(zend_object *source) {
-    php_parallel_sync_object_t *object  = php_parallel_sync_object_fetch(source),
-                                 *dest    = php_parallel_copy_mem(object, php_parallel_copy_sync_size(), 1);
+static zend_always_inline zend_object *php_parallel_copy_sync_persistent(zend_object *source)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source),
+	                           *dest = php_parallel_copy_mem(object, php_parallel_copy_sync_size(), 1);
 
-    GC_ADD_FLAGS(&dest->std, GC_IMMUTABLE);
+	GC_ADD_FLAGS(&dest->std, GC_IMMUTABLE);
 
-    dest->sync = php_parallel_sync_copy(object->sync);
+	dest->sync = php_parallel_sync_copy(object->sync);
 
-    return &dest->std;
+	return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_sync_thread(zend_object *source) {
-    php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source),
-                                 *dest    = php_parallel_copy_mem(object, php_parallel_copy_sync_size(), 0);
+static zend_always_inline zend_object *php_parallel_copy_sync_thread(zend_object *source)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source),
+	                           *dest = php_parallel_copy_mem(object, php_parallel_copy_sync_size(), 0);
 
-    GC_DEL_FLAGS(&dest->std, GC_IMMUTABLE);
+	GC_DEL_FLAGS(&dest->std, GC_IMMUTABLE);
 
-    zend_object_std_init(&dest->std, dest->std.ce);
+	zend_object_std_init(&dest->std, dest->std.ce);
 #if PHP_VERSION_ID >= 80300
-    dest->std.handlers = source->handlers;
+	dest->std.handlers = source->handlers;
 #endif
 
-    dest->sync = php_parallel_sync_copy(object->sync);
+	dest->sync = php_parallel_sync_copy(object->sync);
 
-    return &dest->std;
+	return &dest->std;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_sync_ctor(zend_object *source, bool persistent) {
-    if (persistent) {
-        return php_parallel_copy_sync_persistent(source);
-    }
-    return php_parallel_copy_sync_thread(source);
+static zend_always_inline zend_object *php_parallel_copy_sync_ctor(zend_object *source, bool persistent)
+{
+	if (persistent) {
+		return php_parallel_copy_sync_persistent(source);
+	}
+	return php_parallel_copy_sync_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_sync_dtor(zend_object *source, bool persistent) {
-    php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source);
+static zend_always_inline void php_parallel_copy_sync_dtor(zend_object *source, bool persistent)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(source);
 
-    if (!persistent) {
-        OBJ_RELEASE(source);
-        return;
-    }
+	if (!persistent) {
+		OBJ_RELEASE(source);
+		return;
+	}
 
-    php_parallel_sync_release(object->sync);
+	php_parallel_sync_release(object->sync);
 
-    pefree(object, persistent);
+	pefree(object, persistent);
 }
 
-static zend_always_inline zend_object* php_parallel_copy_object_persistent(zend_object *source) {
-    zend_object *dest;
-    zend_class_entry *ce;
+static zend_always_inline zend_object *php_parallel_copy_object_persistent(zend_object *source)
+{
+	zend_object      *dest;
+	zend_class_entry *ce;
 
-    if (source->ce->create_object) {
-        ce = php_parallel_copy_object_unavailable_ce;
-    } else {
-        ce = source->ce;
-    }
+	if (source->ce->create_object) {
+		ce = php_parallel_copy_object_unavailable_ce;
+	} else {
+		ce = source->ce;
+	}
 
-    php_parallel_copy_context_t *context, *restore;
+	php_parallel_copy_context_t *context, *restore;
 
-    context = php_parallel_copy_context_start(
-        PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
-        &restore);
+	context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_PERSISTENT, &restore);
 
-    if ((dest = php_parallel_copy_context_find(context, source))) {
-        GC_ADDREF(dest);
-        php_parallel_copy_context_end(context, restore);
-        return dest;
-    } else {
-        dest = php_parallel_copy_mem(
-            source,
-            sizeof(zend_object) + zend_object_properties_size(ce), 1);
-        php_parallel_copy_context_insert(
-            context, source, dest);
-    }
+	if ((dest = php_parallel_copy_context_find(context, source))) {
+		GC_ADDREF(dest);
+		php_parallel_copy_context_end(context, restore);
+		return dest;
+	} else {
+		dest = php_parallel_copy_mem(source, sizeof(zend_object) + zend_object_properties_size(ce), 1);
+		php_parallel_copy_context_insert(context, source, dest);
+	}
 
-    GC_SET_REFCOUNT(dest, 1);
-    GC_ADD_FLAGS(dest, GC_IMMUTABLE);
+	GC_SET_REFCOUNT(dest, 1);
+	GC_ADD_FLAGS(dest, GC_IMMUTABLE);
 
-    if (ce == php_parallel_copy_object_unavailable_ce) {
-        dest->ce = ce;
-        dest->handlers = zend_get_std_object_handlers();
-    }
+	if (ce == php_parallel_copy_object_unavailable_ce) {
+		dest->ce = ce;
+		dest->handlers = zend_get_std_object_handlers();
+	}
 
-    if (ce->default_properties_count) {
-        zval *property   = source->properties_table,
-             *slot       = dest->properties_table,
-             *end        = property + source->ce->default_properties_count;
+	if (ce->default_properties_count) {
+		zval *property = source->properties_table, *slot = dest->properties_table,
+		     *end = property + source->ce->default_properties_count;
 
-        while (property < end) {
-            PARALLEL_ZVAL_COPY(slot, property, 1);
-            property++;
-            slot++;
-        }
-    }
+		while (property < end) {
+			PARALLEL_ZVAL_COPY(slot, property, 1);
+			property++;
+			slot++;
+		}
+	}
 
-    if (dest->properties) {
-        dest->properties =
-            php_parallel_copy_hash_ctor(source->properties, 1);
-    }
+	if (dest->properties) {
+		dest->properties = php_parallel_copy_hash_ctor(source->properties, 1);
+	}
 
-    php_parallel_copy_context_end(context, restore);
-    return dest;
+	php_parallel_copy_context_end(context, restore);
+	return dest;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_object_thread(zend_object *source) {
-    zend_object *dest;
-    zend_class_entry *ce;
+static zend_always_inline zend_object *php_parallel_copy_object_thread(zend_object *source)
+{
+	zend_object      *dest;
+	zend_class_entry *ce;
 
-    if (source->ce->create_object) {
-        ce = php_parallel_copy_object_unavailable_ce;
-    } else {
-        ce = php_parallel_copy_scope(source->ce);
-    }
+	if (source->ce->create_object) {
+		ce = php_parallel_copy_object_unavailable_ce;
+	} else {
+		ce = php_parallel_copy_scope(source->ce);
+	}
 
-    php_parallel_copy_context_t *context, *restore;
+	php_parallel_copy_context_t *context, *restore;
 
-    context = php_parallel_copy_context_start(
-        PHP_PARALLEL_COPY_DIRECTION_THREAD,
-        &restore);
+	context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_THREAD, &restore);
 
-    if ((dest = php_parallel_copy_context_find(context, source))) {
-        GC_ADDREF(dest);
-        php_parallel_copy_context_end(context, restore);
-        return dest;
-    } else {
-        dest = php_parallel_copy_mem(
-            source,
-            sizeof(zend_object) + zend_object_properties_size(ce), 0);
-        php_parallel_copy_context_insert(
-            context, source, dest);
-    }
+	if ((dest = php_parallel_copy_context_find(context, source))) {
+		GC_ADDREF(dest);
+		php_parallel_copy_context_end(context, restore);
+		return dest;
+	} else {
+		dest = php_parallel_copy_mem(source, sizeof(zend_object) + zend_object_properties_size(ce), 0);
+		php_parallel_copy_context_insert(context, source, dest);
+	}
 
-    if (ce == php_parallel_copy_object_unavailable_ce) {
-        dest->ce = ce;
-        dest->handlers = zend_get_std_object_handlers();
-    }
+	if (ce == php_parallel_copy_object_unavailable_ce) {
+		dest->ce = ce;
+		dest->handlers = zend_get_std_object_handlers();
+	}
 
-    zend_object_std_init(dest, ce);
+	zend_object_std_init(dest, ce);
 
-    GC_DEL_FLAGS(dest, GC_IMMUTABLE);
+	GC_DEL_FLAGS(dest, GC_IMMUTABLE);
 
-    if (ce->default_properties_count) {
-        zval *property   = source->properties_table,
-             *slot       = dest->properties_table,
-             *end        = property + source->ce->default_properties_count;
+	if (ce->default_properties_count) {
+		zval *property = source->properties_table, *slot = dest->properties_table,
+		     *end = property + source->ce->default_properties_count;
 
-        while (property < end) {
-            PARALLEL_ZVAL_COPY(slot, property, 0);
-            property++;
-            slot++;
-        }
-    }
+		while (property < end) {
+			PARALLEL_ZVAL_COPY(slot, property, 0);
+			property++;
+			slot++;
+		}
+	}
 
-    if (source->properties) {
-        dest->properties =
-            php_parallel_copy_hash_ctor(source->properties, 0);
-    }
+	if (source->properties) {
+		dest->properties = php_parallel_copy_hash_ctor(source->properties, 0);
+	}
 
-    php_parallel_copy_context_end(context, restore);
-    return dest;
+	php_parallel_copy_context_end(context, restore);
+	return dest;
 }
 
-static zend_always_inline zend_object* php_parallel_copy_object_ctor(zend_object *source, bool persistent) {
-    if (source->ce == zend_ce_closure) {
-        return php_parallel_copy_closure_ctor(source, persistent);
-    }
+static zend_always_inline zend_object *php_parallel_copy_object_ctor(zend_object *source, bool persistent)
+{
+	if (source->ce == zend_ce_closure) {
+		return php_parallel_copy_closure_ctor(source, persistent);
+	}
 
-    if (source->ce == php_parallel_channel_ce) {
-        return php_parallel_copy_channel_ctor(source, persistent);
-    }
+	if (source->ce == php_parallel_channel_ce) {
+		return php_parallel_copy_channel_ctor(source, persistent);
+	}
 
-    if (instanceof_function(source->ce, php_parallel_sync_ce)) {
-        return php_parallel_copy_sync_ctor(source, persistent);
-    }
+	if (instanceof_function(source->ce, php_parallel_sync_ce)) {
+		return php_parallel_copy_sync_ctor(source, persistent);
+	}
 
-    if (persistent) {
-        return php_parallel_copy_object_persistent(source);
-    }
+	if (persistent) {
+		return php_parallel_copy_object_persistent(source);
+	}
 
-    return php_parallel_copy_object_thread(source);
+	return php_parallel_copy_object_thread(source);
 }
 
-static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source, bool persistent) {
-    if (source->ce == zend_ce_closure) {
-        php_parallel_copy_closure_dtor(source, persistent);
-        return;
-    }
+static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source, bool persistent)
+{
+	if (source->ce == zend_ce_closure) {
+		php_parallel_copy_closure_dtor(source, persistent);
+		return;
+	}
 
-    if (source->ce == php_parallel_channel_ce) {
-        php_parallel_copy_channel_dtor(source, persistent);
-        return;
-    }
+	if (source->ce == php_parallel_channel_ce) {
+		php_parallel_copy_channel_dtor(source, persistent);
+		return;
+	}
 
-    if (instanceof_function(source->ce, php_parallel_sync_ce)) {
-        php_parallel_copy_sync_dtor(source, persistent);
-        return;
-    }
+	if (instanceof_function(source->ce, php_parallel_sync_ce)) {
+		php_parallel_copy_sync_dtor(source, persistent);
+		return;
+	}
 
-    if (!persistent) {
-        OBJ_RELEASE(source);
-        return;
-    }
+	if (!persistent) {
+		OBJ_RELEASE(source);
+		return;
+	}
 
-    if (GC_DELREF(source) == 0) {
-        if (source->ce->default_properties_count) {
-            zval *property = source->properties_table,
-                 *end      = property + source->ce->default_properties_count;
+	if (GC_DELREF(source) == 0) {
+		if (source->ce->default_properties_count) {
+			zval *property = source->properties_table, *end = property + source->ce->default_properties_count;
 
-            while (property < end) {
-                PARALLEL_ZVAL_DTOR(property);
-                property++;
-            }
-        }
+			while (property < end) {
+				PARALLEL_ZVAL_DTOR(property);
+				property++;
+			}
+		}
 
-        if (source->properties) {
-            php_parallel_copy_hash_dtor(source->properties, 1);
-        }
+		if (source->properties) {
+			php_parallel_copy_hash_dtor(source->properties, 1);
+		}
 
-        pefree(source, 1);
-    }
+		pefree(source, 1);
+	}
 }
 
-void php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent) {
-    switch (Z_TYPE_P(source)) {
-        case IS_NULL:
-        case IS_TRUE:
-        case IS_FALSE:
-        case IS_LONG:
-        case IS_DOUBLE:
-        case IS_UNDEF:
-            if (source != dest) {
-                *dest = *source;
-            }
-        break;
+void php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent)
+{
+	switch (Z_TYPE_P(source)) {
+	case IS_NULL:
+	case IS_TRUE:
+	case IS_FALSE:
+	case IS_LONG:
+	case IS_DOUBLE:
+	case IS_UNDEF:
+		if (source != dest) {
+			*dest = *source;
+		}
+		break;
 
-        case IS_STRING:
-            ZVAL_STR(dest, php_parallel_copy_string_ctor(Z_STR_P(source), persistent));
-        break;
+	case IS_STRING:
+		ZVAL_STR(dest, php_parallel_copy_string_ctor(Z_STR_P(source), persistent));
+		break;
 
-        case IS_ARRAY:
-            ZVAL_ARR(dest, php_parallel_copy_hash_ctor(Z_ARRVAL_P(source), persistent));
-        break;
+	case IS_ARRAY:
+		ZVAL_ARR(dest, php_parallel_copy_hash_ctor(Z_ARRVAL_P(source), persistent));
+		break;
 
-        case IS_OBJECT: {
-            zend_object *copy = php_parallel_copy_object_ctor(Z_OBJ_P(source), persistent);
+	case IS_OBJECT: {
+		zend_object *copy = php_parallel_copy_object_ctor(Z_OBJ_P(source), persistent);
 
-            if (!copy) {
-                ZVAL_NULL(dest);
-            } else {
-                ZVAL_OBJ(dest, copy);
-            }
-        } break;
+		if (!copy) {
+			ZVAL_NULL(dest);
+		} else {
+			ZVAL_OBJ(dest, copy);
+		}
+	} break;
 
-        case IS_REFERENCE:
-            ZVAL_REF(dest, php_parallel_copy_reference_ctor(Z_REF_P(source), persistent));
-        break;
+	case IS_REFERENCE:
+		ZVAL_REF(dest, php_parallel_copy_reference_ctor(Z_REF_P(source), persistent));
+		break;
 
-        case IS_RESOURCE: {
-            zend_long fd = php_parallel_copy_resource_ctor(Z_RES_P(source), persistent);
+	case IS_RESOURCE: {
+		zend_long fd = php_parallel_copy_resource_ctor(Z_RES_P(source), persistent);
 
-            if (fd == -1) {
-                ZVAL_NULL(dest);
-            } else {
-                ZVAL_LONG(dest, fd);
-            }
-        } break;
+		if (fd == -1) {
+			ZVAL_NULL(dest);
+		} else {
+			ZVAL_LONG(dest, fd);
+		}
+	} break;
 
-        default:
-            ZVAL_BOOL(dest, zend_is_true(source));
-    }
+	default:
+		ZVAL_BOOL(dest, zend_is_true(source));
+	}
 }
 
-void php_parallel_copy_zval_dtor(zval *zv) {
-    switch (Z_TYPE_P(zv)) {
-        case IS_ARRAY:
-            php_parallel_copy_hash_dtor(Z_ARRVAL_P(zv), GC_FLAGS(Z_ARRVAL_P(zv)) & IS_ARRAY_IMMUTABLE);
-        break;
+void php_parallel_copy_zval_dtor(zval *zv)
+{
+	switch (Z_TYPE_P(zv)) {
+	case IS_ARRAY:
+		php_parallel_copy_hash_dtor(Z_ARRVAL_P(zv), GC_FLAGS(Z_ARRVAL_P(zv)) & IS_ARRAY_IMMUTABLE);
+		break;
 
-        case IS_STRING:
-            php_parallel_copy_string_dtor(Z_STR_P(zv), GC_FLAGS(Z_STR_P(zv)) & IS_STR_PERSISTENT);
-        break;
+	case IS_STRING:
+		php_parallel_copy_string_dtor(Z_STR_P(zv), GC_FLAGS(Z_STR_P(zv)) & IS_STR_PERSISTENT);
+		break;
 
-        case IS_REFERENCE:
-            php_parallel_copy_reference_dtor(Z_REF_P(zv), GC_FLAGS(Z_REF_P(zv)) & GC_IMMUTABLE);
-        break;
+	case IS_REFERENCE:
+		php_parallel_copy_reference_dtor(Z_REF_P(zv), GC_FLAGS(Z_REF_P(zv)) & GC_IMMUTABLE);
+		break;
 
-        case IS_OBJECT:
-            php_parallel_copy_object_dtor(Z_OBJ_P(zv), GC_FLAGS(Z_OBJ_P(zv)) & GC_IMMUTABLE);
-        break;
+	case IS_OBJECT:
+		php_parallel_copy_object_dtor(Z_OBJ_P(zv), GC_FLAGS(Z_OBJ_P(zv)) & GC_IMMUTABLE);
+		break;
 
-        default:
-            zval_ptr_dtor(zv);
-    }
+	default:
+		zval_ptr_dtor(zv);
+	}
 }
 
-static void php_parallel_copy_zval_persistent(
-                zval *dest, zval *source,
-                zend_string* (*php_parallel_copy_string_func)(zend_string*),
-                void* (*php_parallel_copy_memory_func)(void *source, zend_long size)) {
-    if (Z_TYPE_P(source) == IS_ARRAY) {
-        ZVAL_ARR(dest,
-            php_parallel_copy_hash_persistent(
-                Z_ARRVAL_P(source),
-                php_parallel_copy_string_func,
-                php_parallel_copy_memory_func));
-    } else if (Z_TYPE_P(source) == IS_REFERENCE) {
-        ZVAL_REF(dest,
-            php_parallel_copy_reference_persistent(
-                Z_REF_P(source)));
-    } else if (Z_TYPE_P(source) == IS_STRING) {
-        ZVAL_STR(dest, php_parallel_copy_string_func(Z_STR_P(source)));
-    } else {
-        PARALLEL_ZVAL_COPY(dest, source, 1);
-    }
+static void php_parallel_copy_zval_persistent(zval *dest, zval *source,
+                                              zend_string *(*php_parallel_copy_string_func)(zend_string *),
+                                              void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+{
+	if (Z_TYPE_P(source) == IS_ARRAY) {
+		ZVAL_ARR(dest, php_parallel_copy_hash_persistent(Z_ARRVAL_P(source), php_parallel_copy_string_func,
+		                                                 php_parallel_copy_memory_func));
+	} else if (Z_TYPE_P(source) == IS_REFERENCE) {
+		ZVAL_REF(dest, php_parallel_copy_reference_persistent(Z_REF_P(source)));
+	} else if (Z_TYPE_P(source) == IS_STRING) {
+		ZVAL_STR(dest, php_parallel_copy_string_func(Z_STR_P(source)));
+	} else {
+		PARALLEL_ZVAL_COPY(dest, source, 1);
+	}
 }
 
-zend_function* php_parallel_copy_function(const zend_function *function, bool persistent) {
-    if (persistent) {
-        function =      	
-            php_parallel_cache_function(function);
+zend_function *php_parallel_copy_function(const zend_function *function, bool persistent)
+{
+	if (persistent) {
+		function = php_parallel_cache_function(function);
+		php_parallel_dependencies_store(function);
+	} else {
+		php_parallel_dependencies_load(function);
+	}
 
-        php_parallel_dependencies_store(function);
-    } else {
-        php_parallel_dependencies_load(function);
-    }
-
-    return (zend_function*) function;
+	return (zend_function *)function;
 }
 
-php_parallel_copy_context_t* php_parallel_copy_context_start(
-    php_parallel_copy_direction_t direction,
-    php_parallel_copy_context_t **previous) {
+php_parallel_copy_context_t *php_parallel_copy_context_start(php_parallel_copy_direction_t direction,
+                                                             php_parallel_copy_context_t **previous)
+{
 
-    if (PCG(context) &&
-        PCG(context)->direction == direction) {
-        php_parallel_atomic_addref(
-            &PCG(context)->refcount);
-        return *previous = PCG(context);
-    }
+	if (PCG(context) && PCG(context)->direction == direction) {
+		php_parallel_atomic_addref(&PCG(context)->refcount);
+		return *previous = PCG(context);
+	}
 
-    *previous = PCG(context);
+	*previous = PCG(context);
 
-    PCG(context) =
-        (php_parallel_copy_context_t*)
-            pemalloc(sizeof(php_parallel_copy_context_t), 1);
-    zend_hash_init(
-        &PCG(context)->copied, 32, NULL,
-        NULL, 1);
-    PCG(context)->refcount = 1;
-    PCG(context)->direction = direction;
+	PCG(context) = (php_parallel_copy_context_t *)pemalloc(sizeof(php_parallel_copy_context_t), 1);
+	zend_hash_init(&PCG(context)->copied, 32, NULL, NULL, 1);
+	PCG(context)->refcount = 1;
+	PCG(context)->direction = direction;
 
-    return PCG(context);
+	return PCG(context);
 }
 
-void* php_parallel_copy_context_find(php_parallel_copy_context_t *context, void *address) {
-    return zend_hash_index_find_ptr(&context->copied, (zend_ulong) address);
+void *php_parallel_copy_context_find(php_parallel_copy_context_t *context, void *address)
+{
+	return zend_hash_index_find_ptr(&context->copied, (zend_ulong)address);
 }
 
-void php_parallel_copy_context_insert(php_parallel_copy_context_t *context, void *address, void *assigned) {
-    zend_hash_index_update_ptr(
-        &context->copied, (zend_ulong) address, assigned);
+void php_parallel_copy_context_insert(php_parallel_copy_context_t *context, void *address, void *assigned)
+{
+	zend_hash_index_update_ptr(&context->copied, (zend_ulong)address, assigned);
 }
 
-void php_parallel_copy_context_end(
-    php_parallel_copy_context_t *context,
-    php_parallel_copy_context_t *previous) {
+void php_parallel_copy_context_end(php_parallel_copy_context_t *context, php_parallel_copy_context_t *previous)
+{
 
-    if (php_parallel_atomic_delref(&context->refcount) == 0) {
-        zend_hash_destroy(
-            &context->copied);
-        pefree(context, 1);
-    }
+	if (php_parallel_atomic_delref(&context->refcount) == 0) {
+		zend_hash_destroy(&context->copied);
+		pefree(context, 1);
+	}
 
-    PCG(context) = previous;
+	PCG(context) = previous;
 }
 
 PHP_RINIT_FUNCTION(PARALLEL_COPY)
 {
-    zend_hash_init(&PCG(scope),     32, NULL, NULL, 0);
+	zend_hash_init(&PCG(scope), 32, NULL, NULL, 0);
 
-    PHP_RINIT(PARALLEL_CHECK)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_RINIT(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RINIT(PARALLEL_CHECK)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RINIT(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
 
-    object_init_ex(&PCG(unavailable), php_parallel_copy_object_unavailable_ce);
+	object_init_ex(&PCG(unavailable), php_parallel_copy_object_unavailable_ce);
 
-    PCG(context) = NULL;
+	PCG(context) = NULL;
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(PARALLEL_COPY)
 {
-    zend_hash_destroy(&PCG(scope));
+	zend_hash_destroy(&PCG(scope));
 
-    PHP_RSHUTDOWN(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_RSHUTDOWN(PARALLEL_CHECK)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RSHUTDOWN(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RSHUTDOWN(PARALLEL_CHECK)(INIT_FUNC_ARGS_PASSTHRU);
 
-    zval_ptr_dtor(&PCG(unavailable));
+	zval_ptr_dtor(&PCG(unavailable));
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_COPY_STRINGS)
 {
-    zend_hash_init(&PCS(table), 32, NULL, php_parallel_copy_string_free, 1);
+	zend_hash_init(&PCS(table), 32, NULL, php_parallel_copy_string_free, 1);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_COPY)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Type", "Unavailable", NULL);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Type", "Unavailable", NULL);
 
-    php_parallel_copy_type_unavailable_ce = zend_register_internal_class(&ce);
+	php_parallel_copy_type_unavailable_ce = zend_register_internal_class(&ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Object", "Unavailable", NULL);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Object", "Unavailable", NULL);
 
-    php_parallel_copy_object_unavailable_ce = zend_register_internal_class(&ce);
+	php_parallel_copy_object_unavailable_ce = zend_register_internal_class(&ce);
 
-    PHP_MINIT(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_CACHE)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_COPY_STRINGS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_CACHE)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_COPY_STRINGS)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 static PHP_MSHUTDOWN_FUNCTION(PARALLEL_COPY_STRINGS)
 {
-    zend_hash_destroy(&PCS(table));
+	zend_hash_destroy(&PCS(table));
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_COPY)
 {
-    PHP_MSHUTDOWN(PARALLEL_CACHE)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_COPY_STRINGS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_CACHE)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_DEPENDENCIES)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_COPY_STRINGS)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/copy.h
+++ b/src/copy.h
@@ -18,76 +18,76 @@
 #ifndef HAVE_PARALLEL_COPY_H
 #define HAVE_PARALLEL_COPY_H
 
-#define GC_SET_PERSISTENT_TYPE(ref, type) \
-    (GC_TYPE_INFO(ref) = type | (GC_PERSISTENT << GC_FLAGS_SHIFT))
+#define GC_SET_PERSISTENT_TYPE(ref, type) (GC_TYPE_INFO(ref) = type | (GC_PERSISTENT << GC_FLAGS_SHIFT))
 
 #define PARALLEL_ZVAL_COPY php_parallel_copy_zval_ctor
 #define PARALLEL_ZVAL_DTOR php_parallel_copy_zval_dtor
 
 #if PHP_VERSION_ID >= 80100
-# define PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, key, destination) do { \
-	*key = NULL; \
-	*destination = (zend_function*) function->op_array.dynamic_func_defs[opline->op2.num]; \
-} while(0)
+#define PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, key, destination)                                           \
+	do {                                                                                                               \
+		*key = NULL;                                                                                                   \
+		*destination = (zend_function *)function->op_array.dynamic_func_defs[opline->op2.num];                         \
+	} while (0)
 #else
-# define PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, key, destination) do { \
-     zval *_tmp; \
-     *key = Z_STR_P(RT_CONSTANT(opline, opline->op1)); \
-     _tmp  = zend_hash_find_ex(EG(function_table), *key, 1); \
-    *destination = Z_FUNC_P(_tmp); \
-  } while(0)
+#define PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, key, destination)                                           \
+	do {                                                                                                               \
+		zval *_tmp;                                                                                                    \
+		*key = Z_STR_P(RT_CONSTANT(opline, opline->op1));                                                              \
+		_tmp = zend_hash_find_ex(EG(function_table), *key, 1);                                                         \
+		*destination = Z_FUNC_P(_tmp);                                                                                 \
+	} while (0)
 #endif
 
 typedef struct _zend_closure_t {
-    zend_object       std;
-    zend_function     func;
-    zval              this_ptr;
-    zend_class_entry *called_scope;
-    zif_handler       orig_internal_handler;
+	zend_object       std;
+	zend_function     func;
+	zval              this_ptr;
+	zend_class_entry *called_scope;
+	zif_handler       orig_internal_handler;
 } zend_closure_t;
 
-static zend_always_inline void* php_parallel_copy_mem(void *source, size_t size, bool persistent) {
-    void *destination = (void*) pemalloc(PARALLEL_PLATFORM_ALIGNED(size), persistent);
+static zend_always_inline void *php_parallel_copy_mem(void *source, size_t size, bool persistent)
+{
+	void *destination = (void *)pemalloc(PARALLEL_PLATFORM_ALIGNED(size), persistent);
 
-    memcpy(destination, source, size);
+	memcpy(destination, source, size);
 
-    return destination;
+	return destination;
 }
 
-zend_function* php_parallel_copy_function(const zend_function *function, bool persistent);
+zend_function    *php_parallel_copy_function(const zend_function *function, bool persistent);
 
-zend_string*   php_parallel_copy_string_interned(zend_string *source);
-zend_string*   php_parallel_copy_string(zend_string *source, bool persistent);
+zend_string      *php_parallel_copy_string_interned(zend_string *source);
+zend_string      *php_parallel_copy_string(zend_string *source, bool persistent);
 
-HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent);
-void php_parallel_copy_hash_dtor(HashTable *table, bool persistent);
+HashTable        *php_parallel_copy_hash_ctor(HashTable *source, bool persistent);
+void              php_parallel_copy_hash_dtor(HashTable *table, bool persistent);
 
-HashTable *php_parallel_copy_hash_persistent(HashTable *source, zend_string* (*)(zend_string*), void* (*)(void *, zend_long));
+HashTable        *php_parallel_copy_hash_persistent(HashTable *source, zend_string *(*)(zend_string *),
+                                                    void *(*)(void *, zend_long));
 
-void           php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent);
-void           php_parallel_copy_zval_dtor(zval *zv);
+void              php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent);
+void              php_parallel_copy_zval_dtor(zval *zv);
 
-zend_class_entry* php_parallel_copy_scope(zend_class_entry *);
+zend_class_entry *php_parallel_copy_scope(zend_class_entry *);
 
 typedef enum _php_parallel_copy_direction_t {
-    PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
-    PHP_PARALLEL_COPY_DIRECTION_THREAD,
+	PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
+	PHP_PARALLEL_COPY_DIRECTION_THREAD,
 } php_parallel_copy_direction_t;
 
 typedef struct _php_parallel_copy_context_t {
-    php_parallel_copy_direction_t direction;
-    HashTable                     copied;
-    uint32_t                      refcount;
+	php_parallel_copy_direction_t direction;
+	HashTable                     copied;
+	uint32_t                      refcount;
 } php_parallel_copy_context_t;
 
-php_parallel_copy_context_t* php_parallel_copy_context_start(
-    php_parallel_copy_direction_t direction,
-    php_parallel_copy_context_t **previous);
-void* php_parallel_copy_context_find(php_parallel_copy_context_t *context, void *address);
+php_parallel_copy_context_t *php_parallel_copy_context_start(php_parallel_copy_direction_t direction,
+                                                             php_parallel_copy_context_t **previous);
+void                        *php_parallel_copy_context_find(php_parallel_copy_context_t *context, void *address);
 void php_parallel_copy_context_insert(php_parallel_copy_context_t *context, void *address, void *assigned);
-void php_parallel_copy_context_end(
-    php_parallel_copy_context_t *context,
-    php_parallel_copy_context_t *previous);
+void php_parallel_copy_context_end(php_parallel_copy_context_t *context, php_parallel_copy_context_t *previous);
 
 PHP_RINIT_FUNCTION(PARALLEL_COPY);
 PHP_RSHUTDOWN_FUNCTION(PARALLEL_COPY);

--- a/src/dependencies.c
+++ b/src/dependencies.c
@@ -21,196 +21,189 @@
 #include "parallel.h"
 
 static struct {
-    pthread_mutex_t mutex;
-    HashTable       table;
+	pthread_mutex_t mutex;
+	HashTable       table;
 } php_parallel_dependencies_map;
 
 #define PDM(e) php_parallel_dependencies_map.e
 
 TSRM_TLS struct {
-    HashTable activated;
-    HashTable used;
+	HashTable activated;
+	HashTable used;
 } php_parallel_dependencies_globals;
 
 #define PDG(e) php_parallel_dependencies_globals.e
 
 /* {{{ */
-static zend_always_inline void php_parallel_dependencies_load_globals_vars(const zend_function *function) {
-    zend_string **variables = function->op_array.vars;
-    int it = 0,
-        end = function->op_array.last_var;
+static zend_always_inline void php_parallel_dependencies_load_globals_vars(const zend_function *function)
+{
+	zend_string **variables = function->op_array.vars;
+	int           it = 0, end = function->op_array.last_var;
 
-    while (it < end) {
-        zend_is_auto_global(variables[it]);
-        it++;
-    }
+	while (it < end) {
+		zend_is_auto_global(variables[it]);
+		it++;
+	}
 } /* }}} */
 
 /* {{{ */
-static zend_always_inline void php_parallel_dependencies_load_globals_literals(const zend_function *function) {
-    zval *literals = function->op_array.literals;
-    int it = 0,
-        end = function->op_array.last_literal;
+static zend_always_inline void php_parallel_dependencies_load_globals_literals(const zend_function *function)
+{
+	zval *literals = function->op_array.literals;
+	int   it = 0, end = function->op_array.last_literal;
 
-    while (it < end) {
-        if (Z_TYPE(literals[it]) == IS_STRING) {
-            zend_is_auto_global(Z_STR(literals[it]));
-        }
-        it++;
-    }
+	while (it < end) {
+		if (Z_TYPE(literals[it]) == IS_STRING) {
+			zend_is_auto_global(Z_STR(literals[it]));
+		}
+		it++;
+	}
 } /* }}} */
 
 /* {{{ */
-static void php_parallel_dependencies_load_globals(const zend_function *function) {
-    if (zend_hash_index_exists(&PDG(activated), (zend_ulong) function->op_array.opcodes)) {
-        return;
-    }
+static void php_parallel_dependencies_load_globals(const zend_function *function)
+{
+	if (zend_hash_index_exists(&PDG(activated), (zend_ulong)function->op_array.opcodes)) {
+		return;
+	}
 
-    php_parallel_dependencies_load_globals_vars(function);
-    php_parallel_dependencies_load_globals_literals(function);
+	php_parallel_dependencies_load_globals_vars(function);
+	php_parallel_dependencies_load_globals_literals(function);
 
 #if PHP_VERSION_ID >= 80100
-    if (function->op_array.dynamic_func_defs) {
-    	uint32_t it = 0, end = function->op_array.num_dynamic_func_defs;
-    	
-    	while (it < end) {
-    	    php_parallel_dependencies_load_globals(
-    	    	(zend_function*) function->op_array.dynamic_func_defs[it]);
-    	    it++;
-    	}
-    }
+	if (function->op_array.dynamic_func_defs) {
+		uint32_t it = 0, end = function->op_array.num_dynamic_func_defs;
+
+		while (it < end) {
+			php_parallel_dependencies_load_globals((zend_function *)function->op_array.dynamic_func_defs[it]);
+			it++;
+		}
+	}
 #endif
 
-    zend_hash_index_add_empty_element(&PDG(activated), (zend_ulong) function->op_array.opcodes);
+	zend_hash_index_add_empty_element(&PDG(activated), (zend_ulong)function->op_array.opcodes);
 } /* }}} */
 
-
-void php_parallel_dependencies_store(const zend_function *function) { /* {{{ */
+void php_parallel_dependencies_store(const zend_function *function)
+{ /* {{{ */
 #if PHP_VERSION_ID < 80100
-    HashTable dependencies;
+	HashTable dependencies;
 
-    pthread_mutex_lock(&PDM(mutex));
+	pthread_mutex_lock(&PDM(mutex));
 
-    if (zend_hash_index_exists(&PDM(table), (zend_ulong) function->op_array.opcodes)) {
-        pthread_mutex_unlock(&PDM(mutex));
-        return;
-    }
+	if (zend_hash_index_exists(&PDM(table), (zend_ulong)function->op_array.opcodes)) {
+		pthread_mutex_unlock(&PDM(mutex));
+		return;
+	}
 
-    memset(&dependencies, 0, sizeof(HashTable));
-    {
-        zend_op *opline = function->op_array.opcodes,
-                *end = opline + function->op_array.last;
+	memset(&dependencies, 0, sizeof(HashTable));
+	{
+		zend_op *opline = function->op_array.opcodes, *end = opline + function->op_array.last;
 
-        while (opline < end) {
-            if (opline->opcode == ZEND_DECLARE_LAMBDA_FUNCTION) {
-                zend_string   *key;
-                zend_function *dependency;
+		while (opline < end) {
+			if (opline->opcode == ZEND_DECLARE_LAMBDA_FUNCTION) {
+				zend_string   *key;
+				zend_function *dependency;
 
-                PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, &key, &dependency);
+				PARALLEL_COPY_OPLINE_TO_FUNCTION(function, opline, &key, &dependency);
 
-                dependency = php_parallel_copy_function(dependency, 1);
+				dependency = php_parallel_copy_function(dependency, 1);
 
-                if (dependencies.nNumUsed == 0) {
-                    zend_hash_init(&dependencies, 8, NULL, NULL, 1);
-                }
+				if (dependencies.nNumUsed == 0) {
+					zend_hash_init(&dependencies, 8, NULL, NULL, 1);
+				}
 
-                zend_hash_add_ptr(
-                    &dependencies,
-                    php_parallel_copy_string_interned(key),
-                    dependency);
+				zend_hash_add_ptr(&dependencies, php_parallel_copy_string_interned(key), dependency);
 
-                php_parallel_dependencies_store(dependency);
-            }
-            opline++;
-        }
-    }
+				php_parallel_dependencies_store(dependency);
+			}
+			opline++;
+		}
+	}
 
-    zend_hash_index_add_mem(
-        &PDM(table),
-        (zend_ulong) function->op_array.opcodes,
-        &dependencies, sizeof(HashTable));
+	zend_hash_index_add_mem(&PDM(table), (zend_ulong)function->op_array.opcodes, &dependencies, sizeof(HashTable));
 
-    pthread_mutex_unlock(&PDM(mutex));
+	pthread_mutex_unlock(&PDM(mutex));
 #endif
 } /* }}} */
 
-void php_parallel_dependencies_load(const zend_function *function) { /* {{{ */
+void php_parallel_dependencies_load(const zend_function *function)
+{ /* {{{ */
 #if PHP_VERSION_ID < 80100
-    HashTable *dependencies;
-    zend_string *key;
-    zend_function *dependency;
+	HashTable     *dependencies;
+	zend_string   *key;
+	zend_function *dependency;
 #endif
 
-    php_parallel_dependencies_load_globals(function);
+	php_parallel_dependencies_load_globals(function);
 
 #if PHP_VERSION_ID < 80100
-    pthread_mutex_lock(&PDM(mutex));
-    dependencies = zend_hash_index_find_ptr(
-        &PDM(table), (zend_ulong) function->op_array.opcodes);
-    pthread_mutex_unlock(&PDM(mutex));
+	pthread_mutex_lock(&PDM(mutex));
+	dependencies = zend_hash_index_find_ptr(&PDM(table), (zend_ulong)function->op_array.opcodes);
+	pthread_mutex_unlock(&PDM(mutex));
 
-    /* read only table */
+	/* read only table */
 
-    if (!dependencies || !dependencies->nNumUsed) {
-        return;
-    }
+	if (!dependencies || !dependencies->nNumUsed) {
+		return;
+	}
 
-    ZEND_HASH_FOREACH_STR_KEY_PTR(dependencies, key, dependency) {
-        if (!zend_hash_exists(EG(function_table), key)) {
-            zend_op_array *used =
-                (zend_op_array*)
-                    php_parallel_copy_function(dependency, 0);
+	ZEND_HASH_FOREACH_STR_KEY_PTR(dependencies, key, dependency)
+	{
+		if (!zend_hash_exists(EG(function_table), key)) {
+			zend_op_array *used = (zend_op_array *)php_parallel_copy_function(dependency, 0);
 
-            zend_hash_add_ptr(EG(function_table), key, used);
+			zend_hash_add_ptr(EG(function_table), key, used);
 
-            ZEND_MAP_PTR_NEW(used->run_time_cache);
+			ZEND_MAP_PTR_NEW(used->run_time_cache);
 
-            zend_hash_add_empty_element(&PDG(used), key);
-        }
-    } ZEND_HASH_FOREACH_END();
+			zend_hash_add_empty_element(&PDG(used), key);
+		}
+	}
+	ZEND_HASH_FOREACH_END();
 #endif
 } /* }}} */
 
-static void php_parallel_dependencies_dtor(zval *zv) { /* {{{ */
-    zend_hash_destroy(Z_PTR_P(zv));
-    pefree(Z_PTR_P(zv), 1);
+static void php_parallel_dependencies_dtor(zval *zv)
+{ /* {{{ */
+	zend_hash_destroy(Z_PTR_P(zv));
+	pefree(Z_PTR_P(zv), 1);
 } /* }}} */
 
 PHP_RINIT_FUNCTION(PARALLEL_DEPENDENCIES)
 {
-    zend_hash_init(&PDG(activated), 32, NULL, NULL, 0);
-    zend_hash_init(&PDG(used), 32, NULL, NULL, 0);
+	zend_hash_init(&PDG(activated), 32, NULL, NULL, 0);
+	zend_hash_init(&PDG(used), 32, NULL, NULL, 0);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(PARALLEL_DEPENDENCIES)
 {
-    zend_string *key;
+	zend_string *key;
 
-    zend_hash_destroy(&PDG(activated));
-    ZEND_HASH_FOREACH_STR_KEY(&PDG(used), key) {
-        zend_hash_del(EG(function_table), key);
-    } ZEND_HASH_FOREACH_END();
-    zend_hash_destroy(&PDG(used));
+	zend_hash_destroy(&PDG(activated));
+	ZEND_HASH_FOREACH_STR_KEY(&PDG(used), key) { zend_hash_del(EG(function_table), key); }
+	ZEND_HASH_FOREACH_END();
+	zend_hash_destroy(&PDG(used));
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_DEPENDENCIES)
 {
-    php_parallel_mutex_init(&PDM(mutex), 1);
+	php_parallel_mutex_init(&PDM(mutex), 1);
 
-    zend_hash_init(&PDM(table), 32, NULL, php_parallel_dependencies_dtor, 1);
+	zend_hash_init(&PDM(table), 32, NULL, php_parallel_dependencies_dtor, 1);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_DEPENDENCIES)
 {
-    zend_hash_destroy(&PDM(table));
-    php_parallel_mutex_destroy(&PDM(mutex));
+	zend_hash_destroy(&PDM(table));
+	php_parallel_mutex_destroy(&PDM(mutex));
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/event.c
+++ b/src/event.c
@@ -20,126 +20,110 @@
 
 #include "parallel.h"
 
-zend_class_entry* php_parallel_events_event_ce;
-zend_class_entry* php_parallel_events_event_type_ce;
+zend_class_entry   *php_parallel_events_event_ce;
+zend_class_entry   *php_parallel_events_event_type_ce;
 
 static zend_string *php_parallel_events_event_type;
 static zend_string *php_parallel_events_event_source;
 static zend_string *php_parallel_events_event_object;
 static zend_string *php_parallel_events_event_value;
 
-static uint32_t php_parallel_events_event_type_offset;
-static uint32_t php_parallel_events_event_source_offset;
-static uint32_t php_parallel_events_event_object_offset;
-static uint32_t php_parallel_events_event_value_offset;
+static uint32_t     php_parallel_events_event_type_offset;
+static uint32_t     php_parallel_events_event_source_offset;
+static uint32_t     php_parallel_events_event_object_offset;
+static uint32_t     php_parallel_events_event_value_offset;
 
-#define PHP_PARALLEL_EVENTS_EVENT_PROPERTY(t, p) \
-    ZVAL_##t(OBJ_PROP(Z_OBJ_P(return_value), php_parallel_events_event_##p##_offset), p)
+#define PHP_PARALLEL_EVENTS_EVENT_PROPERTY(t, p)                                                                       \
+	ZVAL_##t(OBJ_PROP(Z_OBJ_P(return_value), php_parallel_events_event_##p##_offset), p)
 
-void php_parallel_events_event_construct(
-        php_parallel_events_t *events,
-        php_parallel_events_event_type_t type,
-        zend_string *source,
-        zend_object *object,
-        zval *value,
-        zval *return_value) {
-    object_init_ex(
-        return_value,
-        php_parallel_events_event_ce);
+void php_parallel_events_event_construct(php_parallel_events_t *events, php_parallel_events_event_type_t type,
+                                         zend_string *source, zend_object *object, zval *value, zval *return_value)
+{
+	object_init_ex(return_value, php_parallel_events_event_ce);
 
-    GC_ADDREF(object);
+	GC_ADDREF(object);
 
-    PHP_PARALLEL_EVENTS_EVENT_PROPERTY(LONG,      type);
-    PHP_PARALLEL_EVENTS_EVENT_PROPERTY(STR,       source);
-    PHP_PARALLEL_EVENTS_EVENT_PROPERTY(OBJ,       object);
+	PHP_PARALLEL_EVENTS_EVENT_PROPERTY(LONG, type);
+	PHP_PARALLEL_EVENTS_EVENT_PROPERTY(STR, source);
+	PHP_PARALLEL_EVENTS_EVENT_PROPERTY(OBJ, object);
 
-    if (type == PHP_PARALLEL_EVENTS_EVENT_WRITE) {
-        php_parallel_events_input_remove(&events->input, source);
-    } else if (type == PHP_PARALLEL_EVENTS_EVENT_READ ||
-               type == PHP_PARALLEL_EVENTS_EVENT_ERROR) {
-        PHP_PARALLEL_EVENTS_EVENT_PROPERTY(COPY_VALUE, value);
-    }
+	if (type == PHP_PARALLEL_EVENTS_EVENT_WRITE) {
+		php_parallel_events_input_remove(&events->input, source);
+	} else if (type == PHP_PARALLEL_EVENTS_EVENT_READ || type == PHP_PARALLEL_EVENTS_EVENT_ERROR) {
+		PHP_PARALLEL_EVENTS_EVENT_PROPERTY(COPY_VALUE, value);
+	}
 
-    zend_hash_del(&events->targets, source);
+	zend_hash_del(&events->targets, source);
 }
 
 PHP_METHOD(Parallel_Event, __construct)
 {
-    php_parallel_exception_ex(
-        php_parallel_events_event_error_ce,
-        "construction of Events\\Event objects is not allowed");
+	php_parallel_exception_ex(php_parallel_events_event_error_ce,
+	                          "construction of Events\\Event objects is not allowed");
 }
 
 zend_function_entry php_parallel_events_event_methods[] = {
-    PHP_ME(Parallel_Event, __construct, php_parallel_no_args_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+    PHP_ME(Parallel_Event, __construct, php_parallel_no_args_arginfo, ZEND_ACC_PUBLIC) PHP_FE_END};
 
-static uint32_t php_parallel_events_event_offsetof(zend_string *property) {
-    zend_property_info *info =
-        zend_get_property_info(php_parallel_events_event_ce, property, 1);
+static uint32_t php_parallel_events_event_offsetof(zend_string *property)
+{
+	zend_property_info *info = zend_get_property_info(php_parallel_events_event_ce, property, 1);
 
-    return info->offset;
+	return info->offset;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS_EVENT)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Event", php_parallel_events_event_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Event", php_parallel_events_event_methods);
 
-    php_parallel_events_event_ce = zend_register_internal_class(&ce);
-    php_parallel_events_event_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_events_event_ce = zend_register_internal_class(&ce);
+	php_parallel_events_event_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Event", "Type", NULL);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Event", "Type", NULL);
 
-    php_parallel_events_event_type_ce = zend_register_internal_class(&ce);
-    php_parallel_events_event_type_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_events_event_type_ce = zend_register_internal_class(&ce);
+	php_parallel_events_event_type_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Read"),   PHP_PARALLEL_EVENTS_EVENT_READ);
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Write"),  PHP_PARALLEL_EVENTS_EVENT_WRITE);
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Close"),  PHP_PARALLEL_EVENTS_EVENT_CLOSE);
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Cancel"), PHP_PARALLEL_EVENTS_EVENT_CANCEL);
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Kill"),   PHP_PARALLEL_EVENTS_EVENT_KILL);
-    zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Error"),  PHP_PARALLEL_EVENTS_EVENT_ERROR);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Read"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_READ);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Write"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_WRITE);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Close"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_CLOSE);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Cancel"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_CANCEL);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Kill"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_KILL);
+	zend_declare_class_constant_long(php_parallel_events_event_type_ce, ZEND_STRL("Error"),
+	                                 PHP_PARALLEL_EVENTS_EVENT_ERROR);
 
-    php_parallel_events_event_type =
-        zend_new_interned_string(
-            zend_string_init(ZEND_STRL("type"), 1));
-    php_parallel_events_event_source =
-        zend_new_interned_string(
-            zend_string_init(ZEND_STRL("source"), 1));
-    php_parallel_events_event_object =
-        zend_new_interned_string(
-            zend_string_init(ZEND_STRL("object"), 1));
-    php_parallel_events_event_value =
-        zend_new_interned_string(
-            zend_string_init(ZEND_STRL("value"), 1));
+	php_parallel_events_event_type = zend_new_interned_string(zend_string_init(ZEND_STRL("type"), 1));
+	php_parallel_events_event_source = zend_new_interned_string(zend_string_init(ZEND_STRL("source"), 1));
+	php_parallel_events_event_object = zend_new_interned_string(zend_string_init(ZEND_STRL("object"), 1));
+	php_parallel_events_event_value = zend_new_interned_string(zend_string_init(ZEND_STRL("value"), 1));
 
-    zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("type"), ZEND_ACC_PUBLIC);
-    zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("source"), ZEND_ACC_PUBLIC);
-    zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("object"), ZEND_ACC_PUBLIC);
-    zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("value"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("type"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("source"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("object"), ZEND_ACC_PUBLIC);
+	zend_declare_property_null(php_parallel_events_event_ce, ZEND_STRL("value"), ZEND_ACC_PUBLIC);
 
-    php_parallel_events_event_type_offset =
-        php_parallel_events_event_offsetof(php_parallel_events_event_type);
-    php_parallel_events_event_source_offset =
-        php_parallel_events_event_offsetof(php_parallel_events_event_source);
-    php_parallel_events_event_object_offset =
-        php_parallel_events_event_offsetof(php_parallel_events_event_object);
-    php_parallel_events_event_value_offset =
-        php_parallel_events_event_offsetof(php_parallel_events_event_value);
+	php_parallel_events_event_type_offset = php_parallel_events_event_offsetof(php_parallel_events_event_type);
+	php_parallel_events_event_source_offset = php_parallel_events_event_offsetof(php_parallel_events_event_source);
+	php_parallel_events_event_object_offset = php_parallel_events_event_offsetof(php_parallel_events_event_object);
+	php_parallel_events_event_value_offset = php_parallel_events_event_offsetof(php_parallel_events_event_value);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_EVENT)
 {
-    zend_string_release(php_parallel_events_event_type);
-    zend_string_release(php_parallel_events_event_source);
-    zend_string_release(php_parallel_events_event_object);
-    zend_string_release(php_parallel_events_event_value);
+	zend_string_release(php_parallel_events_event_type);
+	zend_string_release(php_parallel_events_event_source);
+	zend_string_release(php_parallel_events_event_object);
+	zend_string_release(php_parallel_events_event_value);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/event.h
+++ b/src/event.h
@@ -21,24 +21,19 @@
 #include "events.h"
 
 typedef enum {
-    PHP_PARALLEL_EVENTS_EVENT_READ = 1,
-    PHP_PARALLEL_EVENTS_EVENT_WRITE,
-    PHP_PARALLEL_EVENTS_EVENT_CLOSE,
-    PHP_PARALLEL_EVENTS_EVENT_ERROR,
-    PHP_PARALLEL_EVENTS_EVENT_CANCEL,
-    PHP_PARALLEL_EVENTS_EVENT_KILL
+	PHP_PARALLEL_EVENTS_EVENT_READ = 1,
+	PHP_PARALLEL_EVENTS_EVENT_WRITE,
+	PHP_PARALLEL_EVENTS_EVENT_CLOSE,
+	PHP_PARALLEL_EVENTS_EVENT_ERROR,
+	PHP_PARALLEL_EVENTS_EVENT_CANCEL,
+	PHP_PARALLEL_EVENTS_EVENT_KILL
 } php_parallel_events_event_type_t;
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS_EVENT);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_EVENT);
 
-void php_parallel_events_event_construct(
-        php_parallel_events_t *events,
-        php_parallel_events_event_type_t type,
-        zend_string *source,
-        zend_object *object,
-        zval *value,
-        zval *return_value);
+void         php_parallel_events_event_construct(php_parallel_events_t *events, php_parallel_events_event_type_t type,
+                                                 zend_string *source, zend_object *object, zval *value, zval *return_value);
 
-zend_string* php_parallel_events_event_source_local(zend_string *source);
+zend_string *php_parallel_events_event_source_local(zend_string *source);
 #endif

--- a/src/events.c
+++ b/src/events.c
@@ -18,236 +18,224 @@
 #ifndef HAVE_PARALLEL_EVENTS
 #define HAVE_PARALLEL_EVENTS
 
+#include "loop.h"
 #include "parallel.h"
 #include "poll.h"
-#include "loop.h"
 
-zend_class_entry* php_parallel_events_ce;
+zend_class_entry    *php_parallel_events_ce;
 zend_object_handlers php_parallel_events_handlers;
 
-static zend_object* php_parallel_events_create(zend_class_entry *type) {
-    php_parallel_events_t *events =
-        (php_parallel_events_t*) ecalloc(1,
-            sizeof(php_parallel_events_t) + zend_object_properties_size(type));
+static zend_object  *php_parallel_events_create(zend_class_entry *type)
+{
+	php_parallel_events_t *events =
+	    (php_parallel_events_t *)ecalloc(1, sizeof(php_parallel_events_t) + zend_object_properties_size(type));
 
-    zend_object_std_init(&events->std, type);
+	zend_object_std_init(&events->std, type);
 
-    events->std.handlers = &php_parallel_events_handlers;
+	events->std.handlers = &php_parallel_events_handlers;
 
-    zend_hash_init(
-        &events->targets, 32, NULL, ZVAL_PTR_DTOR, 0);
+	zend_hash_init(&events->targets, 32, NULL, ZVAL_PTR_DTOR, 0);
 
-    events->timeout = -1;
-    events->blocking = 1;
+	events->timeout = -1;
+	events->blocking = 1;
 
-    ZVAL_UNDEF(&events->input);
-    ZVAL_UNDEF(&events->blocker);
+	ZVAL_UNDEF(&events->input);
+	ZVAL_UNDEF(&events->blocker);
 
-    return &events->std;
+	return &events->std;
 }
 
-static zend_always_inline bool php_parallel_events_add(php_parallel_events_t *events, zend_string *name, zval *object, zend_string **key) {
-    if(instanceof_function(Z_OBJCE_P(object), php_parallel_channel_ce)) {
-        php_parallel_channel_t *channel =
-            (php_parallel_channel_t*)
-                 php_parallel_channel_from(object);
+static zend_always_inline bool php_parallel_events_add(php_parallel_events_t *events, zend_string *name, zval *object,
+                                                       zend_string **key)
+{
+	if (instanceof_function(Z_OBJCE_P(object), php_parallel_channel_ce)) {
+		php_parallel_channel_t *channel = (php_parallel_channel_t *)php_parallel_channel_from(object);
 
-        name = php_parallel_link_name(channel->link);
-    } else {
-        name = php_parallel_copy_string_interned(name);
-    }
+		name = php_parallel_link_name(channel->link);
+	} else {
+		name = php_parallel_copy_string_interned(name);
+	}
 
-    *key = name;
+	*key = name;
 
-    if (!zend_hash_add(&events->targets, name, object)) {
-        return 0;
-    }
+	if (!zend_hash_add(&events->targets, name, object)) {
+		return 0;
+	}
 
-    Z_ADDREF_P(object);
+	Z_ADDREF_P(object);
 
-    return 1;
+	return 1;
 }
 
-static zend_always_inline bool php_parallel_events_remove(php_parallel_events_t *events, zend_string *name) {
-    return zend_hash_del(&events->targets, name) == SUCCESS;
+static zend_always_inline bool php_parallel_events_remove(php_parallel_events_t *events, zend_string *name)
+{
+	return zend_hash_del(&events->targets, name) == SUCCESS;
 }
 
-static void php_parallel_events_destroy(zend_object *zo) {
-    php_parallel_events_t *events =
-        php_parallel_events_fetch(zo);
+static void php_parallel_events_destroy(zend_object *zo)
+{
+	php_parallel_events_t *events = php_parallel_events_fetch(zo);
 
-    if (!Z_ISUNDEF(events->input)) {
-        zval_ptr_dtor(&events->input);
-    }
+	if (!Z_ISUNDEF(events->input)) {
+		zval_ptr_dtor(&events->input);
+	}
 
-    if (!Z_ISUNDEF(events->blocker)) {
-        zval_ptr_dtor(&events->blocker);
-    }
+	if (!Z_ISUNDEF(events->blocker)) {
+		zval_ptr_dtor(&events->blocker);
+	}
 
-    zend_hash_destroy(&events->targets);
+	zend_hash_destroy(&events->targets);
 
-    zend_object_std_dtor(zo);
+	zend_object_std_dtor(zo);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_set_input_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_OBJ_INFO(0, input, \\parallel\\Events\\Input, 0)
+ZEND_ARG_OBJ_INFO(0, input, \\parallel\\Events\\Input, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, setInput)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zval *input;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zval                  *input;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_OBJECT_OF_CLASS(input, php_parallel_events_input_ce);
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_OBJECT_OF_CLASS(input, php_parallel_events_input_ce);
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (Z_TYPE(events->input) == IS_OBJECT) {
-        zval_ptr_dtor(&events->input);
-    }
+	if (Z_TYPE(events->input) == IS_OBJECT) {
+		zval_ptr_dtor(&events->input);
+	}
 
-    ZVAL_COPY(&events->input, input);
+	ZVAL_COPY(&events->input, input);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_add_channel_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_OBJ_INFO(0, channel, \\parallel\\Channel, 0)
+ZEND_ARG_OBJ_INFO(0, channel, \\parallel\\Channel, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, addChannel)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zval *target = NULL;
-    zend_string *key = NULL;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zval                  *target = NULL;
+	zend_string           *key = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_OBJECT_OF_CLASS(target, php_parallel_channel_ce)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_OBJECT_OF_CLASS(target, php_parallel_channel_ce)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!php_parallel_events_add(events, NULL, target, &key)) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_existence_ce,
-            "target named \"%s\" already added",
-            ZSTR_VAL(key));
-    }
+	if (!php_parallel_events_add(events, NULL, target, &key)) {
+		php_parallel_exception_ex(php_parallel_events_error_existence_ce, "target named \"%s\" already added",
+		                          ZSTR_VAL(key));
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_add_future_arginfo, 0, 2, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-    ZEND_ARG_OBJ_INFO(0, future, \\parallel\\Future, 0)
+ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_ARG_OBJ_INFO(0, future, \\parallel\\Future, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, addFuture)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zval *target = NULL;
-    zend_string *name = NULL;
-    zend_string *key = NULL;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zval                  *target = NULL;
+	zend_string           *name = NULL;
+	zend_string           *key = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(2, 2)
-        Z_PARAM_STR(name)
-        Z_PARAM_OBJECT_OF_CLASS(target, php_parallel_future_ce)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+	Z_PARAM_STR(name)
+	Z_PARAM_OBJECT_OF_CLASS(target, php_parallel_future_ce)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!php_parallel_events_add(events, name, target, &key)) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_existence_ce,
-            "target named \"%s\" already added",
-            ZSTR_VAL(key));
-    }
+	if (!php_parallel_events_add(events, name, target, &key)) {
+		php_parallel_exception_ex(php_parallel_events_error_existence_ce, "target named \"%s\" already added",
+		                          ZSTR_VAL(key));
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_remove_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, remove)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zend_string *target = NULL;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zend_string           *target = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_STR(target)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_STR(target)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!php_parallel_events_remove(events, target)) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_existence_ce,
-            "target named \"%s\" not found",
-            ZSTR_VAL(target));
-    }
+	if (!php_parallel_events_remove(events, target)) {
+		php_parallel_exception_ex(php_parallel_events_error_existence_ce, "target named \"%s\" not found",
+		                          ZSTR_VAL(target));
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_set_timeout_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
+ZEND_ARG_TYPE_INFO(0, timeout, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, setTimeout)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zend_long timeout = -1;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zend_long              timeout = -1;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_LONG(timeout)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_LONG(timeout)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!events->blocking) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_ce,
-            "cannot set timeout on loop in non-blocking mode");
-        return;
-    }
+	if (!events->blocking) {
+		php_parallel_exception_ex(php_parallel_events_error_ce, "cannot set timeout on loop in non-blocking mode");
+		return;
+	}
 
-    events->timeout = timeout;
+	events->timeout = timeout;
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_set_blocking_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, blocking, _IS_BOOL, 0)
+ZEND_ARG_TYPE_INFO(0, blocking, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, setBlocking)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    bool blocking;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	bool                   blocking;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_BOOL(blocking)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_BOOL(blocking)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (events->timeout > -1) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_ce,
-            "cannot set blocking mode on loop with timeout");
-        return;
-    }
+	if (events->timeout > -1) {
+		php_parallel_exception_ex(php_parallel_events_error_ce, "cannot set blocking mode on loop with timeout");
+		return;
+	}
 
-    events->blocking = blocking;
+	events->blocking = blocking;
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_set_blocker_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_CALLABLE_INFO(0, blocker, 0)
+ZEND_ARG_CALLABLE_INFO(0, blocker, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, setBlocker)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
-    zval *blocker = NULL;
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
+	zval                  *blocker = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ZVAL(blocker)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_ZVAL(blocker)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!events->blocking) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_ce,
-            "cannot set blocker for non-blocking event loop");
-        return;
-    }
+	if (!events->blocking) {
+		php_parallel_exception_ex(php_parallel_events_error_ce, "cannot set blocker for non-blocking event loop");
+		return;
+	}
 
-    if (!Z_ISUNDEF(events->blocker)) {
-        zval_ptr_dtor(&events->blocker);
-    }
+	if (!Z_ISUNDEF(events->blocker)) {
+		zval_ptr_dtor(&events->blocker);
+	}
 
-    ZVAL_COPY(&events->blocker, blocker);
+	ZVAL_COPY(&events->blocker, blocker);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_parallel_events_poll_arginfo, 0, 0, \\parallel\\Events\\Event, 1)
@@ -255,11 +243,11 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, poll)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    php_parallel_events_poll(events, return_value);
+	php_parallel_events_poll(events, return_value);
 }
 
 #ifdef ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX
@@ -271,65 +259,61 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Events, count)
 {
-    php_parallel_events_t *events = php_parallel_events_from(getThis());
+	php_parallel_events_t *events = php_parallel_events_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    RETURN_LONG(zend_hash_num_elements(&events->targets));
+	RETURN_LONG(zend_hash_num_elements(&events->targets));
 }
 
 zend_function_entry php_parallel_events_methods[] = {
-    PHP_ME(Parallel_Events, setInput,     php_parallel_events_set_input_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, addChannel,   php_parallel_events_add_channel_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, addFuture,    php_parallel_events_add_future_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, remove,       php_parallel_events_remove_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, setBlocking,  php_parallel_events_set_blocking_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, setBlocker,   php_parallel_events_set_blocker_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, setTimeout,   php_parallel_events_set_timeout_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, poll,         php_parallel_events_poll_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Events, count,        php_parallel_events_count_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+    PHP_ME(Parallel_Events, setInput, php_parallel_events_set_input_arginfo, ZEND_ACC_PUBLIC)
+        PHP_ME(Parallel_Events, addChannel, php_parallel_events_add_channel_arginfo, ZEND_ACC_PUBLIC)
+            PHP_ME(Parallel_Events, addFuture, php_parallel_events_add_future_arginfo,
+                   ZEND_ACC_PUBLIC) PHP_ME(Parallel_Events, remove, php_parallel_events_remove_arginfo, ZEND_ACC_PUBLIC)
+                PHP_ME(Parallel_Events, setBlocking, php_parallel_events_set_blocking_arginfo, ZEND_ACC_PUBLIC)
+                    PHP_ME(Parallel_Events, setBlocker, php_parallel_events_set_blocker_arginfo, ZEND_ACC_PUBLIC)
+                        PHP_ME(Parallel_Events, setTimeout, php_parallel_events_set_timeout_arginfo, ZEND_ACC_PUBLIC)
+                            PHP_ME(Parallel_Events, poll, php_parallel_events_poll_arginfo, ZEND_ACC_PUBLIC)
+                                PHP_ME(Parallel_Events, count, php_parallel_events_count_arginfo, ZEND_ACC_PUBLIC)
+                                    PHP_FE_END};
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(
-        &php_parallel_events_handlers,
-        php_parallel_standard_handlers(),
-        sizeof(zend_object_handlers));
+	memcpy(&php_parallel_events_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_events_handlers.offset = XtOffsetOf(php_parallel_events_t, std);
-    php_parallel_events_handlers.free_obj = php_parallel_events_destroy;
+	php_parallel_events_handlers.offset = XtOffsetOf(php_parallel_events_t, std);
+	php_parallel_events_handlers.free_obj = php_parallel_events_destroy;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Events", php_parallel_events_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Events", php_parallel_events_methods);
 
-    php_parallel_events_ce = zend_register_internal_class(&ce);
-    php_parallel_events_ce->create_object = php_parallel_events_create;
-    php_parallel_events_ce->get_iterator  = php_parallel_events_loop_create;
-    php_parallel_events_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_events_ce = zend_register_internal_class(&ce);
+	php_parallel_events_ce->create_object = php_parallel_events_create;
+	php_parallel_events_ce->get_iterator = php_parallel_events_loop_create;
+	php_parallel_events_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_events_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_events_ce->serialize = zend_class_serialize_deny;
-        php_parallel_events_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_events_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_events_ce->serialize = zend_class_serialize_deny;
+	php_parallel_events_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    zend_class_implements(php_parallel_events_ce, 1, zend_ce_countable);
+	zend_class_implements(php_parallel_events_ce, 1, zend_ce_countable);
 
-    PHP_MINIT(PARALLEL_EVENTS_EVENT)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_EVENTS_INPUT)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_EVENTS_EVENT)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_EVENTS_INPUT)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS)
 {
-    PHP_MSHUTDOWN(PARALLEL_EVENTS_EVENT)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_EVENTS_INPUT)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_EVENTS_EVENT)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_EVENTS_INPUT)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/events.h
+++ b/src/events.h
@@ -19,39 +19,36 @@
 #define HAVE_PARALLEL_EVENTS_H
 
 typedef struct _php_parallel_events_t {
-    zval        input;
-    HashTable   targets;
-    zend_long   timeout;
-    bool   blocking;
-    zval        blocker;
-    zend_object std;
+	zval        input;
+	HashTable   targets;
+	zend_long   timeout;
+	bool        blocking;
+	zval        blocker;
+	zend_object std;
 } php_parallel_events_t;
 
-typedef enum {
-    PHP_PARALLEL_EVENTS_LINK = 1,
-    PHP_PARALLEL_EVENTS_FUTURE
-} php_parallel_events_type_t;
+typedef enum { PHP_PARALLEL_EVENTS_LINK = 1, PHP_PARALLEL_EVENTS_FUTURE } php_parallel_events_type_t;
 
 typedef struct _php_parallel_events_state_t {
-    php_parallel_events_type_t type;
-    zend_string *name;
-    bool readable;
-    bool writable;
-    bool closed;
-    zend_object *object;
+	php_parallel_events_type_t type;
+	zend_string               *name;
+	bool                       readable;
+	bool                       writable;
+	bool                       closed;
+	zend_object               *object;
 } php_parallel_events_state_t;
 
-#define php_parallel_events_state_initializer {0, NULL, 0, 0, NULL}
-
-static zend_always_inline php_parallel_events_t* php_parallel_events_fetch(zend_object *o) {
-    return (php_parallel_events_t*) (((char*) o) - XtOffsetOf(php_parallel_events_t, std));
+static zend_always_inline php_parallel_events_t *php_parallel_events_fetch(zend_object *o)
+{
+	return (php_parallel_events_t *)(((char *)o) - XtOffsetOf(php_parallel_events_t, std));
 }
 
-static zend_always_inline php_parallel_events_t* php_parallel_events_from(zval *z) {
-    return php_parallel_events_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_events_t *php_parallel_events_from(zval *z)
+{
+	return php_parallel_events_fetch(Z_OBJ_P(z));
 }
 
-extern zend_class_entry* php_parallel_events_ce;
+extern zend_class_entry *php_parallel_events_ce;
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS);

--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -21,311 +21,287 @@
 #include "parallel.h"
 
 struct _php_parallel_exception_t {
-    zval class;
-    zval file;
-    zval line;
-    zval code;
-    zval message;
-    zval trace;
-    zval previous;
-    const zend_object_handlers *handlers;
+	zval class;
+	zval                        file;
+	zval                        line;
+	zval                        code;
+	zval                        message;
+	zval                        trace;
+	zval                        previous;
+	const zend_object_handlers *handlers;
 };
 
-zend_class_entry* php_parallel_error_ce;
-zend_class_entry* php_parallel_error_invalid_arguments_ce;
+zend_class_entry               *php_parallel_error_ce;
+zend_class_entry               *php_parallel_error_invalid_arguments_ce;
 
-zend_class_entry* php_parallel_runtime_error_ce;
-zend_class_entry* php_parallel_runtime_error_bootstrap_ce;
-zend_class_entry* php_parallel_runtime_error_closed_ce;
-zend_class_entry* php_parallel_runtime_error_killed_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_function_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_instruction_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_variable_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_parameter_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_type_ce;
-zend_class_entry* php_parallel_runtime_error_illegal_return_ce;
+zend_class_entry               *php_parallel_runtime_error_ce;
+zend_class_entry               *php_parallel_runtime_error_bootstrap_ce;
+zend_class_entry               *php_parallel_runtime_error_closed_ce;
+zend_class_entry               *php_parallel_runtime_error_killed_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_function_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_instruction_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_variable_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_parameter_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_type_ce;
+zend_class_entry               *php_parallel_runtime_error_illegal_return_ce;
 
-zend_class_entry* php_parallel_future_error_ce;
-zend_class_entry* php_parallel_future_error_killed_ce;
-zend_class_entry* php_parallel_future_error_cancelled_ce;
-zend_class_entry* php_parallel_future_error_foreign_ce;
+zend_class_entry               *php_parallel_future_error_ce;
+zend_class_entry               *php_parallel_future_error_killed_ce;
+zend_class_entry               *php_parallel_future_error_cancelled_ce;
+zend_class_entry               *php_parallel_future_error_foreign_ce;
 
-zend_class_entry* php_parallel_channel_error_ce;
-zend_class_entry* php_parallel_channel_error_existence_ce;
-zend_class_entry* php_parallel_channel_error_illegal_value_ce;
-zend_class_entry* php_parallel_channel_error_closed_ce;
+zend_class_entry               *php_parallel_channel_error_ce;
+zend_class_entry               *php_parallel_channel_error_existence_ce;
+zend_class_entry               *php_parallel_channel_error_illegal_value_ce;
+zend_class_entry               *php_parallel_channel_error_closed_ce;
 
-zend_class_entry* php_parallel_sync_error_ce;
-zend_class_entry* php_parallel_sync_error_illegal_value_ce;
-zend_class_entry* php_parallel_sync_error_illegal_type_ce;
-zend_class_entry* php_parallel_sync_error_illegal_offset_ce;
-zend_class_entry* php_parallel_sync_error_illegal_access_ce;
+zend_class_entry               *php_parallel_sync_error_ce;
+zend_class_entry               *php_parallel_sync_error_illegal_value_ce;
+zend_class_entry               *php_parallel_sync_error_illegal_type_ce;
+zend_class_entry               *php_parallel_sync_error_illegal_offset_ce;
+zend_class_entry               *php_parallel_sync_error_illegal_access_ce;
 
-zend_class_entry* php_parallel_events_error_ce;
-zend_class_entry* php_parallel_events_error_existence_ce;
-zend_class_entry* php_parallel_events_error_timeout_ce;
+zend_class_entry               *php_parallel_events_error_ce;
+zend_class_entry               *php_parallel_events_error_existence_ce;
+zend_class_entry               *php_parallel_events_error_timeout_ce;
 
-zend_class_entry* php_parallel_events_input_error_ce;
-zend_class_entry* php_parallel_events_input_error_existence_ce;
-zend_class_entry* php_parallel_events_input_error_illegal_value_ce;
+zend_class_entry               *php_parallel_events_input_error_ce;
+zend_class_entry               *php_parallel_events_input_error_existence_ce;
+zend_class_entry               *php_parallel_events_input_error_illegal_value_ce;
 
-zend_class_entry* php_parallel_events_event_error_ce;
+zend_class_entry               *php_parallel_events_event_error_ce;
 
-static zend_always_inline zval* php_parallel_exceptions_read(zend_object *exception, zend_string *property) {
-    zend_property_info *info;
-    zend_class_entry *scope = EG(fake_scope);
+static zend_always_inline zval *php_parallel_exceptions_read(zend_object *exception, zend_string *property)
+{
+	zend_property_info *info;
+	zend_class_entry   *scope = EG(fake_scope);
 
-    EG(fake_scope) = zend_ce_error;
+	EG(fake_scope) = zend_ce_error;
 
-    info = zend_get_property_info(zend_ce_error, property, 1);
+	info = zend_get_property_info(zend_ce_error, property, 1);
 
-    EG(fake_scope) = scope;
+	EG(fake_scope) = scope;
 
-    return OBJ_PROP(exception, info->offset);
+	return OBJ_PROP(exception, info->offset);
 }
 
-static zend_always_inline void php_parallel_exceptions_write(zend_object *exception, zend_string *property, zval *value) {
-    zend_property_info *info;
-    zend_class_entry *scope = EG(fake_scope);
-    zval *slot;
+static zend_always_inline void php_parallel_exceptions_write(zend_object *exception, zend_string *property, zval *value)
+{
+	zend_property_info *info;
+	zend_class_entry   *scope = EG(fake_scope);
+	zval               *slot;
 
-    EG(fake_scope) = zend_ce_error;
+	EG(fake_scope) = zend_ce_error;
 
-    info = zend_get_property_info(zend_ce_error, property, 1);
+	info = zend_get_property_info(zend_ce_error, property, 1);
 
-    slot = OBJ_PROP(exception, info->offset);
+	slot = OBJ_PROP(exception, info->offset);
 
-    if (Z_REFCOUNTED_P(slot)) {
-        zval_ptr_dtor(slot);
-    }
+	if (Z_REFCOUNTED_P(slot)) {
+		zval_ptr_dtor(slot);
+	}
 
-    ZVAL_COPY_VALUE(slot, value);
+	ZVAL_COPY_VALUE(slot, value);
 
-    EG(fake_scope) = scope;
+	EG(fake_scope) = scope;
 }
 
-void php_parallel_exceptions_destroy(php_parallel_exception_t *ex) {
-    PARALLEL_ZVAL_DTOR(&ex->class);
-    PARALLEL_ZVAL_DTOR(&ex->file);
-    PARALLEL_ZVAL_DTOR(&ex->line);
-    PARALLEL_ZVAL_DTOR(&ex->message);
-    PARALLEL_ZVAL_DTOR(&ex->code);
-    PARALLEL_ZVAL_DTOR(&ex->trace);
-    PARALLEL_ZVAL_DTOR(&ex->previous);
+void php_parallel_exceptions_destroy(php_parallel_exception_t *ex)
+{
+	PARALLEL_ZVAL_DTOR(&ex->class);
+	PARALLEL_ZVAL_DTOR(&ex->file);
+	PARALLEL_ZVAL_DTOR(&ex->line);
+	PARALLEL_ZVAL_DTOR(&ex->message);
+	PARALLEL_ZVAL_DTOR(&ex->code);
+	PARALLEL_ZVAL_DTOR(&ex->trace);
+	PARALLEL_ZVAL_DTOR(&ex->previous);
 
-    pefree(ex, 1);
+	pefree(ex, 1);
 }
 
-void php_parallel_exceptions_save(zval *saved, zend_object *exception) {
-    zval class,
-         *file     = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_FILE)),
-         *line     = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_LINE)),
-         *message  = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_MESSAGE)),
-         *code     = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_CODE)),
-         *trace    = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_TRACE)),
-         previous;
+void php_parallel_exceptions_save(zval *saved, zend_object *exception)
+{
+	zval class, *file = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_FILE)),
+	            *line = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_LINE)),
+	            *message = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_MESSAGE)),
+	            *code = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_CODE)),
+	            *trace = php_parallel_exceptions_read(exception, ZSTR_KNOWN(ZEND_STR_TRACE)), previous;
 
-    php_parallel_exception_t *ex =
-        (php_parallel_exception_t*)
-            pecalloc(1, sizeof(php_parallel_exception_t), 1);
+	php_parallel_exception_t *ex = (php_parallel_exception_t *)pecalloc(1, sizeof(php_parallel_exception_t), 1);
 
-    /* todo */
-    ZVAL_NULL(&previous);
+	/* todo */
+	ZVAL_NULL(&previous);
 
-    ZVAL_STR(&class, exception->ce->name);
+	ZVAL_STR(&class, exception->ce->name);
 
-    PARALLEL_ZVAL_COPY(&ex->class,   &class,     1);
-    PARALLEL_ZVAL_COPY(&ex->file,    file,       1);
-    PARALLEL_ZVAL_COPY(&ex->line,    line,       1);
-    PARALLEL_ZVAL_COPY(&ex->message, message,    1);
-    PARALLEL_ZVAL_COPY(&ex->code,    code,       1);
-    PARALLEL_ZVAL_COPY(&ex->trace,   trace,      1);
-    PARALLEL_ZVAL_COPY(&ex->previous, &previous, 1);
+	PARALLEL_ZVAL_COPY(&ex->class, &class, 1);
+	PARALLEL_ZVAL_COPY(&ex->file, file, 1);
+	PARALLEL_ZVAL_COPY(&ex->line, line, 1);
+	PARALLEL_ZVAL_COPY(&ex->message, message, 1);
+	PARALLEL_ZVAL_COPY(&ex->code, code, 1);
+	PARALLEL_ZVAL_COPY(&ex->trace, trace, 1);
+	PARALLEL_ZVAL_COPY(&ex->previous, &previous, 1);
 
-    ex->handlers = exception->handlers;
+	ex->handlers = exception->handlers;
 
-    ZVAL_PTR(saved, ex);
+	ZVAL_PTR(saved, ex);
 
-    zend_clear_exception();
+	zend_clear_exception();
 }
 
-zend_object* php_parallel_exceptions_restore(zval *exception) {
-    zend_object      *object;
-    zend_class_entry *type;
-    zval file, line, message, code, trace, previous;
+zend_object *php_parallel_exceptions_restore(zval *exception)
+{
+	zend_object              *object;
+	zend_class_entry         *type;
+	zval                      file, line, message, code, trace, previous;
 
-    php_parallel_exception_t *ex =
-        (php_parallel_exception_t*) Z_PTR_P(exception);
+	php_parallel_exception_t *ex = (php_parallel_exception_t *)Z_PTR_P(exception);
 
-    PARALLEL_ZVAL_COPY(&file,     &ex->file,     0);
-    PARALLEL_ZVAL_COPY(&line,     &ex->line,     0);
-    PARALLEL_ZVAL_COPY(&message,  &ex->message,  0);
-    PARALLEL_ZVAL_COPY(&code,     &ex->code,     0);
-    PARALLEL_ZVAL_COPY(&trace,    &ex->trace,    0);
-    PARALLEL_ZVAL_COPY(&previous, &ex->previous, 0);
+	PARALLEL_ZVAL_COPY(&file, &ex->file, 0);
+	PARALLEL_ZVAL_COPY(&line, &ex->line, 0);
+	PARALLEL_ZVAL_COPY(&message, &ex->message, 0);
+	PARALLEL_ZVAL_COPY(&code, &ex->code, 0);
+	PARALLEL_ZVAL_COPY(&trace, &ex->trace, 0);
+	PARALLEL_ZVAL_COPY(&previous, &ex->previous, 0);
 
-    type = zend_lookup_class(Z_STR(ex->class));
+	type = zend_lookup_class(Z_STR(ex->class));
 
-    if (!type) {
-        /* we lost type info */
-        type = php_parallel_future_error_foreign_ce;
-    }
+	if (!type) {
+		/* we lost type info */
+		type = php_parallel_future_error_foreign_ce;
+	}
 
-    object = zend_objects_new(type);
-    object->handlers = ex->handlers;
-    object_properties_init(object, type);
+	object = zend_objects_new(type);
+	object->handlers = ex->handlers;
+	object_properties_init(object, type);
 
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_FILE),     &file);
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_LINE),     &line);
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_MESSAGE),  &message);
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_CODE),     &code);
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_TRACE),    &trace);
-    php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &previous);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_FILE), &file);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_LINE), &line);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_MESSAGE), &message);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_CODE), &code);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_TRACE), &trace);
+	php_parallel_exceptions_write(object, ZSTR_KNOWN(ZEND_STR_PREVIOUS), &previous);
 
-    return object;
+	return object;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_EXCEPTIONS)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    /*
-    * Base Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Error", NULL);
-    php_parallel_error_ce =
-        zend_register_internal_class_ex(&ce, zend_ce_error);
+	/*
+	 * Base Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Error", NULL);
+	php_parallel_error_ce = zend_register_internal_class_ex(&ce, zend_ce_error);
 
-    /*
-    * Runtime Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime", "Error", NULL);
-    php_parallel_runtime_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Runtime Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime", "Error", NULL);
+	php_parallel_runtime_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Bootstrap", NULL);
-    php_parallel_runtime_error_bootstrap_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Bootstrap", NULL);
+	php_parallel_runtime_error_bootstrap_ce = zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Closed", NULL);
-    php_parallel_runtime_error_closed_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Closed", NULL);
+	php_parallel_runtime_error_closed_ce = zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Killed", NULL);
-    php_parallel_runtime_error_killed_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "Killed", NULL);
+	php_parallel_runtime_error_killed_ce = zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalFunction", NULL);
-    php_parallel_runtime_error_illegal_function_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalFunction", NULL);
+	php_parallel_runtime_error_illegal_function_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalVariable", NULL);
-    php_parallel_runtime_error_illegal_variable_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalVariable", NULL);
+	php_parallel_runtime_error_illegal_variable_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalParameter", NULL);
-    php_parallel_runtime_error_illegal_parameter_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalParameter", NULL);
+	php_parallel_runtime_error_illegal_parameter_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalInstruction", NULL);
-    php_parallel_runtime_error_illegal_instruction_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalInstruction", NULL);
+	php_parallel_runtime_error_illegal_instruction_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalReturn", NULL);
-    php_parallel_runtime_error_illegal_return_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Runtime\\Error", "IllegalReturn", NULL);
+	php_parallel_runtime_error_illegal_return_ce = zend_register_internal_class_ex(&ce, php_parallel_runtime_error_ce);
 
-    /*
-    * Future Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Future", "Error", NULL);
-    php_parallel_future_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Future Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Future", "Error", NULL);
+	php_parallel_future_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Killed", NULL);
-    php_parallel_future_error_killed_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Killed", NULL);
+	php_parallel_future_error_killed_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Cancelled", NULL);
-    php_parallel_future_error_cancelled_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Cancelled", NULL);
+	php_parallel_future_error_cancelled_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Foreign", NULL);
-    php_parallel_future_error_foreign_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Future\\Error", "Foreign", NULL);
+	php_parallel_future_error_foreign_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    /*
-    * Channel Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel", "Error", NULL);
-    php_parallel_channel_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Channel Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel", "Error", NULL);
+	php_parallel_channel_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "Existence", NULL);
-    php_parallel_channel_error_existence_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "Existence", NULL);
+	php_parallel_channel_error_existence_ce = zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "IllegalValue", NULL);
-    php_parallel_channel_error_illegal_value_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "IllegalValue", NULL);
+	php_parallel_channel_error_illegal_value_ce = zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "Closed", NULL);
-    php_parallel_channel_error_closed_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Channel\\Error", "Closed", NULL);
+	php_parallel_channel_error_closed_ce = zend_register_internal_class_ex(&ce, php_parallel_channel_error_ce);
 
-    /*
-    * Sync Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Sync", "Error", NULL);
-    php_parallel_sync_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Sync Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Sync", "Error", NULL);
+	php_parallel_sync_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Sync\\Error", "IllegalValue", NULL);
-    php_parallel_sync_error_illegal_value_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_sync_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Sync\\Error", "IllegalValue", NULL);
+	php_parallel_sync_error_illegal_value_ce = zend_register_internal_class_ex(&ce, php_parallel_sync_error_ce);
 
-    /*
-    * Events Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Error", NULL);
-    php_parallel_events_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Events Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Error", NULL);
+	php_parallel_events_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Error", "Existence", NULL);
-    php_parallel_events_error_existence_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_events_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Error", "Existence", NULL);
+	php_parallel_events_error_existence_ce = zend_register_internal_class_ex(&ce, php_parallel_events_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Error", "Timeout", NULL);
-    php_parallel_events_error_timeout_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_events_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Error", "Timeout", NULL);
+	php_parallel_events_error_timeout_ce = zend_register_internal_class_ex(&ce, php_parallel_events_error_ce);
 
-    /*
-    * Input Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input", "Error", NULL);
-    php_parallel_events_input_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Input Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input", "Error", NULL);
+	php_parallel_events_input_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input\\Error", "Existence", NULL);
-    php_parallel_events_input_error_existence_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_events_input_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input\\Error", "Existence", NULL);
+	php_parallel_events_input_error_existence_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_events_input_error_ce);
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input\\Error", "IllegalValue", NULL);
-    php_parallel_events_input_error_illegal_value_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_events_input_error_ce);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Input\\Error", "IllegalValue", NULL);
+	php_parallel_events_input_error_illegal_value_ce =
+	    zend_register_internal_class_ex(&ce, php_parallel_events_input_error_ce);
 
-    /*
-    * Event Exceptions
-    */
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Event", "Error", NULL);
-    php_parallel_events_event_error_ce =
-        zend_register_internal_class_ex(&ce, php_parallel_error_ce);
+	/*
+	 * Event Exceptions
+	 */
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events\\Event", "Error", NULL);
+	php_parallel_events_event_error_ce = zend_register_internal_class_ex(&ce, php_parallel_error_ce);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-PHP_MSHUTDOWN_FUNCTION(PARALLEL_EXCEPTIONS)
-{
-    return SUCCESS;
-}
+PHP_MSHUTDOWN_FUNCTION(PARALLEL_EXCEPTIONS) { return SUCCESS; }
 #endif

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -18,75 +18,74 @@
 #ifndef HAVE_PARALLEL_EXCEPTIONS_H
 #define HAVE_PARALLEL_EXCEPTIONS_H
 
-#define php_parallel_exception_ex(type, m, ...)      zend_throw_exception_ex(type, 0, m, ##__VA_ARGS__)
-#define php_parallel_exception(m, ...)               php_parallel_exception_ex(php_parallel_error_ce, m, ##__VA_ARGS__)
-#define php_parallel_invalid_arguments(m, ...)       php_parallel_exception_ex(zend_ce_type_error, m, ##__VA_ARGS__)
+#define php_parallel_exception_ex(type, m, ...) zend_throw_exception_ex(type, 0, m, ##__VA_ARGS__)
+#define php_parallel_exception(m, ...) php_parallel_exception_ex(php_parallel_error_ce, m, ##__VA_ARGS__)
+#define php_parallel_invalid_arguments(m, ...) php_parallel_exception_ex(zend_ce_type_error, m, ##__VA_ARGS__)
 
 /*
-* Base Exception
-*/
-extern zend_class_entry* php_parallel_error_ce;
-
-
-/*
-* Runtime Exceptions
-*/
-extern zend_class_entry* php_parallel_runtime_error_ce;
-extern zend_class_entry* php_parallel_runtime_error_bootstrap_ce;
-extern zend_class_entry* php_parallel_runtime_error_closed_ce;
-extern zend_class_entry* php_parallel_runtime_error_killed_ce;
-extern zend_class_entry* php_parallel_runtime_error_illegal_function_ce;
-extern zend_class_entry* php_parallel_runtime_error_illegal_instruction_ce;
-extern zend_class_entry* php_parallel_runtime_error_illegal_variable_ce;
-extern zend_class_entry* php_parallel_runtime_error_illegal_parameter_ce;
-extern zend_class_entry* php_parallel_runtime_error_illegal_return_ce;
+ * Base Exception
+ */
+extern zend_class_entry                 *php_parallel_error_ce;
 
 /*
-* Future Exceptions
-*/
-extern zend_class_entry* php_parallel_future_error_ce;
-extern zend_class_entry* php_parallel_future_error_killed_ce;
-extern zend_class_entry* php_parallel_future_error_cancelled_ce;
-extern zend_class_entry* php_parallel_future_error_foreign_ce;
+ * Runtime Exceptions
+ */
+extern zend_class_entry                 *php_parallel_runtime_error_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_bootstrap_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_closed_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_killed_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_illegal_function_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_illegal_instruction_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_illegal_variable_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_illegal_parameter_ce;
+extern zend_class_entry                 *php_parallel_runtime_error_illegal_return_ce;
 
 /*
-* Channel Exceptions
-*/
-extern zend_class_entry* php_parallel_channel_error_ce;
-extern zend_class_entry* php_parallel_channel_error_existence_ce;
-extern zend_class_entry* php_parallel_channel_error_illegal_value_ce;
-extern zend_class_entry* php_parallel_channel_error_closed_ce;
+ * Future Exceptions
+ */
+extern zend_class_entry                 *php_parallel_future_error_ce;
+extern zend_class_entry                 *php_parallel_future_error_killed_ce;
+extern zend_class_entry                 *php_parallel_future_error_cancelled_ce;
+extern zend_class_entry                 *php_parallel_future_error_foreign_ce;
 
 /*
-* Sync Exceptions
-*/
-extern zend_class_entry* php_parallel_sync_error_ce;
-extern zend_class_entry* php_parallel_sync_error_illegal_value_ce;
+ * Channel Exceptions
+ */
+extern zend_class_entry                 *php_parallel_channel_error_ce;
+extern zend_class_entry                 *php_parallel_channel_error_existence_ce;
+extern zend_class_entry                 *php_parallel_channel_error_illegal_value_ce;
+extern zend_class_entry                 *php_parallel_channel_error_closed_ce;
 
 /*
-* Events Exceptions
-*/
-extern zend_class_entry* php_parallel_events_error_ce;
-extern zend_class_entry* php_parallel_events_error_existence_ce;
-extern zend_class_entry* php_parallel_events_error_timeout_ce;
+ * Sync Exceptions
+ */
+extern zend_class_entry                 *php_parallel_sync_error_ce;
+extern zend_class_entry                 *php_parallel_sync_error_illegal_value_ce;
 
 /*
-* Input Exceptions
-*/
-extern zend_class_entry* php_parallel_events_input_error_ce;
-extern zend_class_entry* php_parallel_events_input_error_existence_ce;
-extern zend_class_entry* php_parallel_events_input_error_illegal_value_ce;
+ * Events Exceptions
+ */
+extern zend_class_entry                 *php_parallel_events_error_ce;
+extern zend_class_entry                 *php_parallel_events_error_existence_ce;
+extern zend_class_entry                 *php_parallel_events_error_timeout_ce;
 
 /*
-* Event Exceptions
-*/
-extern zend_class_entry* php_parallel_events_event_error_ce;
+ * Input Exceptions
+ */
+extern zend_class_entry                 *php_parallel_events_input_error_ce;
+extern zend_class_entry                 *php_parallel_events_input_error_existence_ce;
+extern zend_class_entry                 *php_parallel_events_input_error_illegal_value_ce;
+
+/*
+ * Event Exceptions
+ */
+extern zend_class_entry                 *php_parallel_events_event_error_ce;
 
 typedef struct _php_parallel_exception_t php_parallel_exception_t;
 
-void         php_parallel_exceptions_save(zval *saved, zend_object *exception);
-zend_object* php_parallel_exceptions_restore(zval *exception);
-void         php_parallel_exceptions_destroy(php_parallel_exception_t *ex);
+void                                     php_parallel_exceptions_save(zval *saved, zend_object *exception);
+zend_object                             *php_parallel_exceptions_restore(zval *exception);
+void                                     php_parallel_exceptions_destroy(php_parallel_exception_t *ex);
 
 PHP_MINIT_FUNCTION(PARALLEL_EXCEPTIONS);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EXCEPTIONS);

--- a/src/future.c
+++ b/src/future.c
@@ -20,126 +20,111 @@
 
 #include "parallel.h"
 
-zend_class_entry *php_parallel_future_ce;
+zend_class_entry    *php_parallel_future_ce;
 zend_object_handlers php_parallel_future_handlers;
 
-zend_string *php_parallel_future_string_runtime;
+zend_string         *php_parallel_future_string_runtime;
 
-bool php_parallel_future_lock(php_parallel_future_t *future) {
-    return php_parallel_monitor_lock(future->monitor);
+bool php_parallel_future_lock(php_parallel_future_t *future) { return php_parallel_monitor_lock(future->monitor); }
+
+bool php_parallel_future_readable(php_parallel_future_t *future)
+{
+	return php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY);
 }
 
-bool php_parallel_future_readable(php_parallel_future_t *future) {
-    return php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY);
+static zend_always_inline void php_parallel_future_value_inline(php_parallel_future_t *future, zval *return_value)
+{
+	if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_DONE)) {
+		zval garbage = future->value;
+
+		PARALLEL_ZVAL_COPY(&future->value, &garbage, 0);
+
+		if (Z_OPT_REFCOUNTED(garbage)) {
+			PARALLEL_ZVAL_DTOR(&garbage);
+		}
+
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_DONE);
+	}
+
+	ZVAL_COPY(return_value, &future->value);
 }
 
-static zend_always_inline void php_parallel_future_value_inline(php_parallel_future_t *future, zval *return_value) {
-    if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_DONE)) {
-        zval garbage = future->value;
+void php_parallel_future_value(php_parallel_future_t *future, zval *return_value)
+{
+	php_parallel_monitor_lock(future->monitor);
 
-        PARALLEL_ZVAL_COPY(
-            &future->value, &garbage, 0);
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_ERROR)) {
+		ZVAL_OBJ(return_value, php_parallel_exceptions_restore(&future->value));
+		php_parallel_monitor_unlock(future->monitor);
+		return;
+	} else if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED | PHP_PARALLEL_CANCELLED)) {
+		ZVAL_NULL(return_value);
+		php_parallel_monitor_unlock(future->monitor);
+		return;
+	}
 
-        if (Z_OPT_REFCOUNTED(garbage)) {
-            PARALLEL_ZVAL_DTOR(&garbage);
-        }
+	php_parallel_future_value_inline(future, return_value);
 
-        php_parallel_monitor_set(future->monitor, PHP_PARALLEL_DONE);
-    }
-
-    ZVAL_COPY(return_value, &future->value);
+	php_parallel_monitor_unlock(future->monitor);
 }
 
-void php_parallel_future_value(php_parallel_future_t *future, zval *return_value) {
-    php_parallel_monitor_lock(future->monitor);
-
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_ERROR)) {
-        ZVAL_OBJ(return_value,
-            php_parallel_exceptions_restore(&future->value));
-        php_parallel_monitor_unlock(future->monitor);
-        return;
-    } else if (php_parallel_monitor_check(future->monitor,
-                PHP_PARALLEL_KILLED|PHP_PARALLEL_CANCELLED)) {
-        ZVAL_NULL(return_value);
-        php_parallel_monitor_unlock(future->monitor);
-        return;
-    }
-
-    php_parallel_future_value_inline(future, return_value);
-
-    php_parallel_monitor_unlock(future->monitor);
-}
-
-bool php_parallel_future_unlock(php_parallel_future_t *future) {
-    return php_parallel_monitor_unlock(future->monitor);
-}
+bool php_parallel_future_unlock(php_parallel_future_t *future) { return php_parallel_monitor_unlock(future->monitor); }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_future_value_arginfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Future, value)
 {
-    php_parallel_future_t *future = php_parallel_future_from(getThis());
-    int32_t state;
+	php_parallel_future_t *future = php_parallel_future_from(getThis());
+	int32_t                state;
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    php_parallel_monitor_lock(future->monitor);
+	php_parallel_monitor_lock(future->monitor);
 
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
-        php_parallel_exception_ex(
-            php_parallel_future_error_cancelled_ce,
-            "cannot retrieve value");
-        php_parallel_monitor_unlock(future->monitor);
-        return;
-    }
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
+		php_parallel_exception_ex(php_parallel_future_error_cancelled_ce, "cannot retrieve value");
+		php_parallel_monitor_unlock(future->monitor);
+		return;
+	}
 
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
-        php_parallel_exception_ex(
-            php_parallel_future_error_killed_ce,
-            "cannot retrieve value");
-        php_parallel_monitor_unlock(future->monitor);
-        return;
-    }
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
+		php_parallel_exception_ex(php_parallel_future_error_killed_ce, "cannot retrieve value");
+		php_parallel_monitor_unlock(future->monitor);
+		return;
+	}
 
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_DONE)) {
-        php_parallel_monitor_unlock(future->monitor);
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_DONE)) {
+		php_parallel_monitor_unlock(future->monitor);
 
-        goto _php_parallel_future_value;
-    } else {
-        state = php_parallel_monitor_wait_locked(future->monitor,
-                    PHP_PARALLEL_READY|
-                    PHP_PARALLEL_FAILURE|
-                    PHP_PARALLEL_ERROR);
-        php_parallel_monitor_unlock(future->monitor);
-    }
+		goto _php_parallel_future_value;
+	} else {
+		state = php_parallel_monitor_wait_locked(future->monitor,
+		                                         PHP_PARALLEL_READY | PHP_PARALLEL_FAILURE | PHP_PARALLEL_ERROR);
+		php_parallel_monitor_unlock(future->monitor);
+	}
 
-    if ((state == FAILURE) || (state & PHP_PARALLEL_FAILURE)) {
-        php_parallel_exception_ex(
-            php_parallel_future_error_ce,
-            "cannot retrieve value");
-        php_parallel_monitor_set(future->monitor,
-            PHP_PARALLEL_READY|PHP_PARALLEL_FAILURE);
-        return;
-    }
+	if ((state == FAILURE) || (state & PHP_PARALLEL_FAILURE)) {
+		php_parallel_exception_ex(php_parallel_future_error_ce, "cannot retrieve value");
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_FAILURE);
+		return;
+	}
 
-    if ((state & PHP_PARALLEL_ERROR)) {
-        zval exception;
+	if ((state & PHP_PARALLEL_ERROR)) {
+		zval exception;
 
-        ZVAL_OBJ(&exception,
-            php_parallel_exceptions_restore(&future->value));
+		ZVAL_OBJ(&exception, php_parallel_exceptions_restore(&future->value));
 
-        php_parallel_monitor_set(future->monitor,
-            PHP_PARALLEL_READY|PHP_PARALLEL_ERROR);
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
 
-        zend_throw_exception_object(&exception);
-        return;
-    }
+		zend_throw_exception_object(&exception);
+		return;
+	}
 
-    php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
+	php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
 
 _php_parallel_future_value:
-    php_parallel_future_value_inline(future, return_value);
+	php_parallel_future_value_inline(future, return_value);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_future_cancel_arginfo, 0, 0, _IS_BOOL, 0)
@@ -147,26 +132,21 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Future, cancel)
 {
-    php_parallel_future_t *future =
-        php_parallel_future_from(getThis());
+	php_parallel_future_t *future = php_parallel_future_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
-        php_parallel_exception_ex(
-            php_parallel_future_error_cancelled_ce,
-            "task was already cancelled");
-        return;
-    }
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
+		php_parallel_exception_ex(php_parallel_future_error_cancelled_ce, "task was already cancelled");
+		return;
+	}
 
-    if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
-        php_parallel_exception_ex(
-            php_parallel_future_error_killed_ce,
-            "runtime executing task was killed");
-        return;
-    }
+	if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
+		php_parallel_exception_ex(php_parallel_future_error_killed_ce, "runtime executing task was killed");
+		return;
+	}
 
-    RETURN_BOOL(php_parallel_scheduler_cancel(future));
+	RETURN_BOOL(php_parallel_scheduler_cancel(future));
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_future_cancelled_arginfo, 0, 0, _IS_BOOL, 0)
@@ -174,12 +154,11 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Future, cancelled)
 {
-    php_parallel_future_t *future =
-        php_parallel_future_from(getThis());
+	php_parallel_future_t *future = php_parallel_future_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    RETURN_BOOL(php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED));
+	RETURN_BOOL(php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED));
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_future_done_arginfo, 0, 0, _IS_BOOL, 0)
@@ -187,10 +166,9 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Future, done)
 {
-    php_parallel_future_t *future =
-        php_parallel_future_from(getThis());
+	php_parallel_future_t *future = php_parallel_future_from(getThis());
 
-    RETURN_BOOL(php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY));
+	RETURN_BOOL(php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY));
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_future_construct_arginfo, 0, 0, 0)
@@ -198,123 +176,117 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Future, __construct)
 {
-    php_parallel_future_t *future = php_parallel_future_from(getThis());
+	php_parallel_future_t *future = php_parallel_future_from(getThis());
 
-    php_parallel_exception_ex(
-        php_parallel_future_error_ce,
-        "construction of Future objects is not allowed");
+	php_parallel_exception_ex(php_parallel_future_error_ce, "construction of Future objects is not allowed");
 
-    php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY|PHP_PARALLEL_DONE);
+	php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_DONE);
 }
 
 zend_function_entry php_parallel_future_methods[] = {
-    PHP_ME(Parallel_Future, __construct, php_parallel_future_construct_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Future, value, php_parallel_future_value_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Future, done, php_parallel_future_done_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Future, cancel, php_parallel_future_cancel_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Future, cancelled, php_parallel_future_cancelled_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+    PHP_ME(Parallel_Future, __construct, php_parallel_future_construct_arginfo,
+           ZEND_ACC_PUBLIC) PHP_ME(Parallel_Future, value, php_parallel_future_value_arginfo, ZEND_ACC_PUBLIC)
+        PHP_ME(Parallel_Future, done, php_parallel_future_done_arginfo, ZEND_ACC_PUBLIC)
+            PHP_ME(Parallel_Future, cancel, php_parallel_future_cancel_arginfo, ZEND_ACC_PUBLIC)
+                PHP_ME(Parallel_Future, cancelled, php_parallel_future_cancelled_arginfo, ZEND_ACC_PUBLIC) PHP_FE_END};
 
-zend_object* php_parallel_future_create(zend_class_entry *type) {
-    php_parallel_future_t *future = ecalloc(1,
-            sizeof(php_parallel_future_t) + zend_object_properties_size(type));
+zend_object *php_parallel_future_create(zend_class_entry *type)
+{
+	php_parallel_future_t *future = ecalloc(1, sizeof(php_parallel_future_t) + zend_object_properties_size(type));
 
-    zend_object_std_init(&future->std, type);
+	zend_object_std_init(&future->std, type);
 
-    future->std.handlers = &php_parallel_future_handlers;
+	future->std.handlers = &php_parallel_future_handlers;
 
-    future->monitor = php_parallel_monitor_create();
+	future->monitor = php_parallel_monitor_create();
 
-    return &future->std;
+	return &future->std;
 }
 
-void php_parallel_future_destroy(zend_object *o) {
-    php_parallel_future_t *future =
-        php_parallel_future_fetch(o);
+void php_parallel_future_destroy(zend_object *o)
+{
+	php_parallel_future_t *future = php_parallel_future_fetch(o);
 
-    php_parallel_monitor_lock(future->monitor);
+	php_parallel_monitor_lock(future->monitor);
 
-    if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY)) {
-        php_parallel_monitor_wait_locked(future->monitor, PHP_PARALLEL_READY);
-    }
+	if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY)) {
+		php_parallel_monitor_wait_locked(future->monitor, PHP_PARALLEL_READY);
+	}
 
-    php_parallel_monitor_unlock(future->monitor);
+	php_parallel_monitor_unlock(future->monitor);
 
-    switch (Z_TYPE(future->value)) {
-        case IS_PTR:
-            php_parallel_exceptions_destroy(Z_PTR(future->value));
-        break;
+	switch (Z_TYPE(future->value)) {
+	case IS_PTR:
+		php_parallel_exceptions_destroy(Z_PTR(future->value));
+		break;
 
-        default:
-            if (Z_OPT_REFCOUNTED(future->value)) {
-                PARALLEL_ZVAL_DTOR(&future->value);
-            }
-    }
+	default:
+		if (Z_OPT_REFCOUNTED(future->value)) {
+			PARALLEL_ZVAL_DTOR(&future->value);
+		}
+	}
 
-    if (future->runtime) {
-       OBJ_RELEASE(&future->runtime->std);
-    }
+	if (future->runtime) {
+		OBJ_RELEASE(&future->runtime->std);
+	}
 
-    php_parallel_monitor_destroy(future->monitor);
+	php_parallel_monitor_destroy(future->monitor);
 
-    zend_object_std_dtor(o);
+	zend_object_std_dtor(o);
 }
 
-static HashTable* php_parallel_future_debug(zend_object *zo, int *temp) {
-    php_parallel_future_t *future = php_parallel_future_fetch(zo);
-    HashTable *debug;
-    zval zdbg;
+static HashTable *php_parallel_future_debug(zend_object *zo, int *temp)
+{
+	php_parallel_future_t *future = php_parallel_future_fetch(zo);
+	HashTable             *debug;
+	zval                   zdbg;
 
-    ALLOC_HASHTABLE(debug);
-    zend_hash_init(debug, 3, NULL, ZVAL_PTR_DTOR, 0);
+	ALLOC_HASHTABLE(debug);
+	zend_hash_init(debug, 3, NULL, ZVAL_PTR_DTOR, 0);
 
-    *temp = 1;
+	*temp = 1;
 
-    GC_ADDREF(&future->runtime->std);
+	GC_ADDREF(&future->runtime->std);
 
-    ZVAL_OBJ(&zdbg, &future->runtime->std);
+	ZVAL_OBJ(&zdbg, &future->runtime->std);
 
-    zend_hash_add(
-        debug,
-        php_parallel_future_string_runtime,
-        &zdbg);
+	zend_hash_add(debug, php_parallel_future_string_runtime, &zdbg);
 
-    return debug;
+	return debug;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_FUTURE)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(&php_parallel_future_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
+	memcpy(&php_parallel_future_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_future_handlers.offset = XtOffsetOf(php_parallel_future_t, std);
-    php_parallel_future_handlers.free_obj = php_parallel_future_destroy;
-    php_parallel_future_handlers.get_debug_info = php_parallel_future_debug;
+	php_parallel_future_handlers.offset = XtOffsetOf(php_parallel_future_t, std);
+	php_parallel_future_handlers.free_obj = php_parallel_future_destroy;
+	php_parallel_future_handlers.get_debug_info = php_parallel_future_debug;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Future", php_parallel_future_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Future", php_parallel_future_methods);
 
-    php_parallel_future_ce = zend_register_internal_class(&ce);
-    php_parallel_future_ce->create_object = php_parallel_future_create;
-    php_parallel_future_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_future_ce = zend_register_internal_class(&ce);
+	php_parallel_future_ce->create_object = php_parallel_future_create;
+	php_parallel_future_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_future_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_future_ce->serialize = zend_class_serialize_deny;
-        php_parallel_future_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_future_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_future_ce->serialize = zend_class_serialize_deny;
+	php_parallel_future_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    php_parallel_future_string_runtime = zend_string_init_interned(ZEND_STRL("runtime"), 1);
+	php_parallel_future_string_runtime = zend_string_init_interned(ZEND_STRL("runtime"), 1);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_FUTURE)
 {
-    zend_string_release(php_parallel_future_string_runtime);
+	zend_string_release(php_parallel_future_string_runtime);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/future.h
+++ b/src/future.h
@@ -18,40 +18,44 @@
 #ifndef HAVE_PARALLEL_FUTURE_H
 #define HAVE_PARALLEL_FUTURE_H
 
-#include "php.h"
 #include "monitor.h"
+#include "php.h"
+#include "runtime.h"
 
 extern zend_class_entry *php_parallel_future_ce;
 
 typedef struct _php_parallel_future_t {
-    php_parallel_monitor_t *monitor;
-    php_parallel_runtime_t *runtime;
-    void *handle;
-    zval value;
-    zend_object std;
+	php_parallel_monitor_t *monitor;
+	php_parallel_runtime_t *runtime;
+	void                   *handle;
+	zval                    value;
+	zend_object             std;
 } php_parallel_future_t;
 
-static zend_always_inline php_parallel_future_t* php_parallel_future_fetch(zend_object *o) {
-    return (php_parallel_future_t*) (((char*) o) - XtOffsetOf(php_parallel_future_t, std));
+static zend_always_inline php_parallel_future_t *php_parallel_future_fetch(zend_object *o)
+{
+	return (php_parallel_future_t *)(((char *)o) - XtOffsetOf(php_parallel_future_t, std));
 }
 
-static zend_always_inline php_parallel_future_t* php_parallel_future_from(zval *z) {
-    return php_parallel_future_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_future_t *php_parallel_future_from(zval *z)
+{
+	return php_parallel_future_fetch(Z_OBJ_P(z));
 }
 
-static zend_always_inline php_parallel_future_t* php_parallel_future_construct(zval *retval) {
-        object_init_ex(retval, php_parallel_future_ce);
+static zend_always_inline php_parallel_future_t *php_parallel_future_construct(zval *retval)
+{
+	object_init_ex(retval, php_parallel_future_ce);
 
-        return php_parallel_future_from(retval);
+	return php_parallel_future_from(retval);
 }
 
-zend_object* php_parallel_future_create(zend_class_entry *);
+zend_object *php_parallel_future_create(zend_class_entry *);
 void         php_parallel_future_destroy(zend_object *);
 
-bool    php_parallel_future_lock(php_parallel_future_t *future);
-bool    php_parallel_future_readable(php_parallel_future_t *future);
+bool         php_parallel_future_lock(php_parallel_future_t *future);
+bool         php_parallel_future_readable(php_parallel_future_t *future);
 void         php_parallel_future_value(php_parallel_future_t *future, zval *value);
-bool    php_parallel_future_unlock(php_parallel_future_t *future);
+bool         php_parallel_future_unlock(php_parallel_future_t *future);
 
 PHP_MINIT_FUNCTION(PARALLEL_FUTURE);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_FUTURE);

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -22,68 +22,56 @@
 
 zend_object_handlers _php_parallel_standard_handlers;
 
-zval* php_parallel_handlers_read_property(zend_object *object, zend_string *member, int type, void **cache_slot, zval *rv) {
-    php_parallel_exception(
-        "%s objects do not support properties",
-        ZSTR_VAL(object->ce->name));
+zval *php_parallel_handlers_read_property(zend_object *object, zend_string *member, int type, void **cache_slot,
+                                          zval *rv)
+{
+	php_parallel_exception("%s objects do not support properties", ZSTR_VAL(object->ce->name));
 
-    return &EG(uninitialized_zval);
+	return &EG(uninitialized_zval);
 }
 
-zval* php_parallel_handlers_write_property(zend_object *object, zend_string *member, zval *value, void **cache_slot) {
-    php_parallel_exception(
-        "%s objects do not support properties",
-        ZSTR_VAL(object->ce->name));
+zval *php_parallel_handlers_write_property(zend_object *object, zend_string *member, zval *value, void **cache_slot)
+{
+	php_parallel_exception("%s objects do not support properties", ZSTR_VAL(object->ce->name));
 
-    return &EG(uninitialized_zval);
+	return &EG(uninitialized_zval);
 }
 
-zval* php_parallel_handlers_read_dimension(zend_object *object, zval *offset, int type, zval *rv) {
-    php_parallel_exception(
-        "%s objects do not support dimensions",
-        ZSTR_VAL(object->ce->name));
+zval *php_parallel_handlers_read_dimension(zend_object *object, zval *offset, int type, zval *rv)
+{
+	php_parallel_exception("%s objects do not support dimensions", ZSTR_VAL(object->ce->name));
 
-    return &EG(uninitialized_zval);
+	return &EG(uninitialized_zval);
 }
 
-void php_parallel_handlers_write_dimension(zend_object *object, zval *offset, zval *value) {
-    php_parallel_exception(
-        "%s objects do not support dimensions",
-        ZSTR_VAL(object->ce->name));
+void php_parallel_handlers_write_dimension(zend_object *object, zval *offset, zval *value)
+{
+	php_parallel_exception("%s objects do not support dimensions", ZSTR_VAL(object->ce->name));
 }
 
-zval* php_parallel_handlers_get_property_ptr_ptr(zend_object *object, zend_string *member, int type, void **cache_slot) {
-    php_parallel_exception(
-        "%s objects do not support properties",
-        ZSTR_VAL(object->ce->name));
+zval *php_parallel_handlers_get_property_ptr_ptr(zend_object *object, zend_string *member, int type, void **cache_slot)
+{
+	php_parallel_exception("%s objects do not support properties", ZSTR_VAL(object->ce->name));
 
-    return &EG(uninitialized_zval);
+	return &EG(uninitialized_zval);
 }
 
-const zend_object_handlers* php_parallel_standard_handlers() {
-    return &_php_parallel_standard_handlers;
-}
+const zend_object_handlers *php_parallel_standard_handlers() { return &_php_parallel_standard_handlers; }
 
 PHP_MINIT_FUNCTION(PARALLEL_HANDLERS)
 {
-    memcpy(
-        &_php_parallel_standard_handlers,
-        zend_get_std_object_handlers(),
-        sizeof(zend_object_handlers));
+	memcpy(&_php_parallel_standard_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    _php_parallel_standard_handlers.read_property = php_parallel_handlers_read_property;
-    _php_parallel_standard_handlers.write_property = php_parallel_handlers_write_property;
-    _php_parallel_standard_handlers.read_dimension = php_parallel_handlers_read_dimension;
-    _php_parallel_standard_handlers.write_dimension = php_parallel_handlers_write_dimension;
-    _php_parallel_standard_handlers.get_property_ptr_ptr = php_parallel_handlers_get_property_ptr_ptr;
+	_php_parallel_standard_handlers.read_property = php_parallel_handlers_read_property;
+	_php_parallel_standard_handlers.write_property = php_parallel_handlers_write_property;
+	_php_parallel_standard_handlers.read_dimension = php_parallel_handlers_read_dimension;
+	_php_parallel_standard_handlers.write_dimension = php_parallel_handlers_write_dimension;
+	_php_parallel_standard_handlers.get_property_ptr_ptr = php_parallel_handlers_get_property_ptr_ptr;
 
-    _php_parallel_standard_handlers.clone_obj = NULL;
+	_php_parallel_standard_handlers.clone_obj = NULL;
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-PHP_MSHUTDOWN_FUNCTION(PARALLEL_HANDLERS)
-{
-    return SUCCESS;
-}
+PHP_MSHUTDOWN_FUNCTION(PARALLEL_HANDLERS) { return SUCCESS; }
 #endif

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -18,7 +18,7 @@
 #ifndef HAVE_PARALLEL_HANDLERS_H
 #define HAVE_PARALLEL_HANDLERS_H
 
-const zend_object_handlers* php_parallel_standard_handlers();
+const zend_object_handlers *php_parallel_standard_handlers();
 
 PHP_MINIT_FUNCTION(PARALLEL_HANDLERS);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_HANDLERS);

--- a/src/input.c
+++ b/src/input.c
@@ -20,105 +20,100 @@
 
 #include "parallel.h"
 
-zend_class_entry* php_parallel_events_input_ce;
+zend_class_entry    *php_parallel_events_input_ce;
 zend_object_handlers php_parallel_events_input_handlers;
 
 typedef struct _php_parallel_events_input_t {
-    HashTable   table;
-    zend_object std;
+	HashTable   table;
+	zend_object std;
 } php_parallel_events_input_t;
 
-static zend_always_inline php_parallel_events_input_t* php_parallel_events_input_fetch(zend_object *o) {
-    return (php_parallel_events_input_t*) (((char*) o) - XtOffsetOf(php_parallel_events_input_t, std));
+static zend_always_inline php_parallel_events_input_t *php_parallel_events_input_fetch(zend_object *o)
+{
+	return (php_parallel_events_input_t *)(((char *)o) - XtOffsetOf(php_parallel_events_input_t, std));
 }
 
-static zend_always_inline php_parallel_events_input_t* php_parallel_events_input_from(zval *z) {
-    return php_parallel_events_input_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_events_input_t *php_parallel_events_input_from(zval *z)
+{
+	return php_parallel_events_input_fetch(Z_OBJ_P(z));
 }
 
-static zend_object* php_parallel_events_input_create(zend_class_entry *type) {
-    php_parallel_events_input_t *input =
-        (php_parallel_events_input_t*)
-            ecalloc(1, sizeof(php_parallel_events_input_t) + zend_object_properties_size(type));
+static zend_object *php_parallel_events_input_create(zend_class_entry *type)
+{
+	php_parallel_events_input_t *input = (php_parallel_events_input_t *)ecalloc(
+	    1, sizeof(php_parallel_events_input_t) + zend_object_properties_size(type));
 
-    zend_object_std_init(&input->std, type);
+	zend_object_std_init(&input->std, type);
 
-    input->std.handlers = &php_parallel_events_input_handlers;
+	input->std.handlers = &php_parallel_events_input_handlers;
 
-    zend_hash_init(&input->table, 32, NULL, ZVAL_PTR_DTOR, 0);
+	zend_hash_init(&input->table, 32, NULL, ZVAL_PTR_DTOR, 0);
 
-    return &input->std;
+	return &input->std;
 }
 
-static void php_parallel_events_input_destroy(zend_object *zo) {
-    php_parallel_events_input_t *input =
-        php_parallel_events_input_fetch(zo);
+static void php_parallel_events_input_destroy(zend_object *zo)
+{
+	php_parallel_events_input_t *input = php_parallel_events_input_fetch(zo);
 
-    zend_hash_destroy(&input->table);
+	zend_hash_destroy(&input->table);
 
-    zend_object_std_dtor(zo);
+	zend_object_std_dtor(zo);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_input_add_arginfo, 0, 2, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
-    ZEND_ARG_INFO(0, value)
+ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
+ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Input, add)
 {
-    php_parallel_events_input_t *input =
-        php_parallel_events_input_from(getThis());
-    zend_string *target;
-    zval        *value;
-    zval        *error;
+	php_parallel_events_input_t *input = php_parallel_events_input_from(getThis());
+	zend_string                 *target;
+	zval                        *value;
+	zval                        *error;
 
-    ZEND_PARSE_PARAMETERS_START(2, 2)
-        Z_PARAM_STR(target)
-        Z_PARAM_ZVAL(value)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+	Z_PARAM_STR(target)
+	Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!PARALLEL_ZVAL_CHECK(value, &error)) {
-        php_parallel_exception_ex(
-            php_parallel_events_input_error_illegal_value_ce,
-            "value of type %s is illegal",
-            Z_TYPE_P(error) == IS_OBJECT ?
-                ZSTR_VAL(Z_OBJCE_P(error)->name) :
-                zend_get_type_by_const(Z_TYPE_P(error)));
-        return;
-    }
+	if (!PARALLEL_ZVAL_CHECK(value, &error)) {
+		php_parallel_exception_ex(php_parallel_events_input_error_illegal_value_ce, "value of type %s is illegal",
+		                          Z_TYPE_P(error) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(error)->name)
+		                                                       : zend_get_type_by_const(Z_TYPE_P(error)));
+		return;
+	}
 
-    target = php_parallel_copy_string_interned(target);
+	target = php_parallel_copy_string_interned(target);
 
-    if (!zend_hash_add(&input->table, target, value)) {
-        php_parallel_exception_ex(
-            php_parallel_events_input_error_existence_ce,
-            "input for target %s exists", ZSTR_VAL(target));
-        return;
-    }
+	if (!zend_hash_add(&input->table, target, value)) {
+		php_parallel_exception_ex(php_parallel_events_input_error_existence_ce, "input for target %s exists",
+		                          ZSTR_VAL(target));
+		return;
+	}
 
-    Z_TRY_ADDREF_P(value);
+	Z_TRY_ADDREF_P(value);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_input_remove_arginfo, 0, 1, IS_VOID, 0)
-    ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, target, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Input, remove)
 {
-    php_parallel_events_input_t *input =
-        php_parallel_events_input_from(getThis());
-    zend_string *target;
+	php_parallel_events_input_t *input = php_parallel_events_input_from(getThis());
+	zend_string                 *target;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_STR(target)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_STR(target)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (zend_hash_del(&input->table, target) != SUCCESS) {
-        php_parallel_exception_ex(
-            php_parallel_events_input_error_existence_ce,
-            "input for target %s does not exist", ZSTR_VAL(target));
-        return;
-    }
+	if (zend_hash_del(&input->table, target) != SUCCESS) {
+		php_parallel_exception_ex(php_parallel_events_input_error_existence_ce, "input for target %s does not exist",
+		                          ZSTR_VAL(target));
+		return;
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_events_input_clear_arginfo, 0, 0, IS_VOID, 0)
@@ -126,87 +121,81 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Input, clear)
 {
-    php_parallel_events_input_t *input =
-        php_parallel_events_input_from(getThis());
+	php_parallel_events_input_t *input = php_parallel_events_input_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    zend_hash_clean(&input->table);
+	zend_hash_clean(&input->table);
 }
 
 zend_function_entry php_parallel_events_input_methods[] = {
     PHP_ME(Parallel_Input, add, php_parallel_events_input_add_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Input, remove, php_parallel_events_input_remove_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Input, clear, php_parallel_events_input_clear_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+        PHP_ME(Parallel_Input, remove, php_parallel_events_input_remove_arginfo, ZEND_ACC_PUBLIC)
+            PHP_ME(Parallel_Input, clear, php_parallel_events_input_clear_arginfo, ZEND_ACC_PUBLIC) PHP_FE_END};
 
-zval* php_parallel_events_input_find(zval *zv, zend_string *target) {
-    php_parallel_events_input_t *input;
+zval *php_parallel_events_input_find(zval *zv, zend_string *target)
+{
+	php_parallel_events_input_t *input;
 
-    if (Z_TYPE_P(zv) != IS_OBJECT) {
-        return NULL;
-    }
+	if (Z_TYPE_P(zv) != IS_OBJECT) {
+		return NULL;
+	}
 
-    input = php_parallel_events_input_from(zv);
+	input = php_parallel_events_input_from(zv);
 
-    return zend_hash_find(&input->table, target);
+	return zend_hash_find(&input->table, target);
 }
 
-bool php_parallel_events_input_exists(zval *zv, zend_string *target) {
-    php_parallel_events_input_t *input;
+bool php_parallel_events_input_exists(zval *zv, zend_string *target)
+{
+	php_parallel_events_input_t *input;
 
-    if (Z_TYPE_P(zv) != IS_OBJECT) {
-        return 0;
-    }
+	if (Z_TYPE_P(zv) != IS_OBJECT) {
+		return 0;
+	}
 
-    input = php_parallel_events_input_from(zv);
+	input = php_parallel_events_input_from(zv);
 
-    return zend_hash_exists(&input->table, target);
+	return zend_hash_exists(&input->table, target);
 }
 
-bool php_parallel_events_input_remove(zval *zv, zend_string *target) {
-    php_parallel_events_input_t *input;
+bool php_parallel_events_input_remove(zval *zv, zend_string *target)
+{
+	php_parallel_events_input_t *input;
 
-    if (Z_TYPE_P(zv) != IS_OBJECT) {
-        return 0;
-    }
+	if (Z_TYPE_P(zv) != IS_OBJECT) {
+		return 0;
+	}
 
-    input = php_parallel_events_input_from(zv);
+	input = php_parallel_events_input_from(zv);
 
-    return zend_hash_del(&input->table, target) == SUCCESS;
+	return zend_hash_del(&input->table, target) == SUCCESS;
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS_INPUT)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(
-        &php_parallel_events_input_handlers,
-        php_parallel_standard_handlers(),
-        sizeof(zend_object_handlers));
+	memcpy(&php_parallel_events_input_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_events_input_handlers.offset = XtOffsetOf(php_parallel_events_input_t, std);
-    php_parallel_events_input_handlers.free_obj = php_parallel_events_input_destroy;
+	php_parallel_events_input_handlers.offset = XtOffsetOf(php_parallel_events_input_t, std);
+	php_parallel_events_input_handlers.free_obj = php_parallel_events_input_destroy;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Input", php_parallel_events_input_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Input", php_parallel_events_input_methods);
 
-    php_parallel_events_input_ce = zend_register_internal_class(&ce);
-    php_parallel_events_input_ce->create_object = php_parallel_events_input_create;
-    php_parallel_events_input_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_events_input_ce = zend_register_internal_class(&ce);
+	php_parallel_events_input_ce->create_object = php_parallel_events_input_create;
+	php_parallel_events_input_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_events_input_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_events_input_ce->serialize = zend_class_serialize_deny;
-        php_parallel_events_input_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_events_input_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_events_input_ce->serialize = zend_class_serialize_deny;
+	php_parallel_events_input_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_INPUT)
-{
-    return SUCCESS;
-}
+PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_INPUT) { return SUCCESS; }
 #endif

--- a/src/input.h
+++ b/src/input.h
@@ -18,11 +18,11 @@
 #ifndef HAVE_PARALLEL_EVENTS_INPUT_H
 #define HAVE_PARALLEL_EVENTS_INPUT_H
 
-extern zend_class_entry* php_parallel_events_input_ce;
+extern zend_class_entry *php_parallel_events_input_ce;
 
-bool php_parallel_events_input_exists(zval *zv, zend_string *target);
-zval*     php_parallel_events_input_find(zval *input, zend_string *target);
-bool php_parallel_events_input_remove(zval *input, zend_string *target);
+bool                     php_parallel_events_input_exists(zval *zv, zend_string *target);
+zval                    *php_parallel_events_input_find(zval *input, zend_string *target);
+bool                     php_parallel_events_input_remove(zval *input, zend_string *target);
 
 PHP_MINIT_FUNCTION(PARALLEL_EVENTS_INPUT);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_EVENTS_INPUT);

--- a/src/link.c
+++ b/src/link.c
@@ -18,426 +18,408 @@
 #ifndef HAVE_PARALLEL_LINK
 #define HAVE_PARALLEL_LINK
 
-#include "parallel.h"
 #include "link.h"
+#include "parallel.h"
 
 #define PHP_PARALLEL_LINK_CLOSURE_BUFFER GC_IMMUTABLE
 
-typedef enum {
-    PHP_PARALLEL_LINK_UNBUFFERED,
-    PHP_PARALLEL_LINK_BUFFERED
-} php_parallel_link_type_t;
+typedef enum { PHP_PARALLEL_LINK_UNBUFFERED, PHP_PARALLEL_LINK_BUFFERED } php_parallel_link_type_t;
 
 typedef struct {
-    pthread_mutex_t m;
-    pthread_mutex_t w;
-    pthread_mutex_t r;
+	pthread_mutex_t m;
+	pthread_mutex_t w;
+	pthread_mutex_t r;
 } php_parallel_link_mutex_t;
 
 typedef struct {
-    pthread_cond_t r;
-    pthread_cond_t w;
+	pthread_cond_t r;
+	pthread_cond_t w;
 } php_parallel_link_cond_t;
 
 typedef struct {
-    uint32_t c;
-    uint32_t r;
-    uint32_t w;
+	uint32_t c;
+	uint32_t r;
+	uint32_t w;
 } php_parallel_link_state_t;
 
 typedef struct _php_parallel_link_queue_t {
-    zend_llist l;
-    zend_long  c;
+	zend_llist l;
+	zend_long  c;
 } php_parallel_link_queue_t;
 
 struct _php_parallel_link_t {
-    php_parallel_link_type_t type;
-    zend_string *name;
+	php_parallel_link_type_t  type;
+	zend_string              *name;
 
-    php_parallel_link_mutex_t m;
-    php_parallel_link_cond_t  c;
-    php_parallel_link_state_t s;
+	php_parallel_link_mutex_t m;
+	php_parallel_link_cond_t  c;
+	php_parallel_link_state_t s;
 
-    union {
-        php_parallel_link_queue_t q;
-        zval                      z;
-    } port;
+	union {
+		php_parallel_link_queue_t q;
+		zval                      z;
+	} port;
 
-    uint32_t refcount;
+	uint32_t refcount;
 };
 
-static zend_string  *php_parallel_link_string_name,
-                    *php_parallel_link_string_type,
-                    *php_parallel_link_string_unbuffered,
-                    *php_parallel_link_string_buffered,
-                    *php_parallel_link_string_capacity,
-                    *php_parallel_link_string_size,
-                    *php_parallel_link_string_infinite;
+static zend_string *php_parallel_link_string_name, *php_parallel_link_string_type, *php_parallel_link_string_unbuffered,
+    *php_parallel_link_string_buffered, *php_parallel_link_string_capacity, *php_parallel_link_string_size,
+    *php_parallel_link_string_infinite;
 
-static zend_always_inline int32_t php_parallel_link_mutex_init(php_parallel_link_mutex_t *mutex) {
-    if (!php_parallel_mutex_init(&mutex->m, 1)) {
-        return FAILURE;
-    }
+static zend_always_inline int32_t php_parallel_link_mutex_init(php_parallel_link_mutex_t *mutex)
+{
+	if (!php_parallel_mutex_init(&mutex->m, 1)) {
+		return FAILURE;
+	}
 
-    if (!php_parallel_mutex_init(&mutex->r, 1)) {
-        php_parallel_mutex_destroy(&mutex->m);
+	if (!php_parallel_mutex_init(&mutex->r, 1)) {
+		php_parallel_mutex_destroy(&mutex->m);
 
-        return FAILURE;
-    }
+		return FAILURE;
+	}
 
-    if (!php_parallel_mutex_init(&mutex->w, 1)) {
-        php_parallel_mutex_destroy(&mutex->m);
-        php_parallel_mutex_destroy(&mutex->r);
+	if (!php_parallel_mutex_init(&mutex->w, 1)) {
+		php_parallel_mutex_destroy(&mutex->m);
+		php_parallel_mutex_destroy(&mutex->r);
 
-        return FAILURE;
-    }
+		return FAILURE;
+	}
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-static zend_always_inline void php_parallel_link_mutex_destroy(php_parallel_link_mutex_t *mutex) {
-    php_parallel_mutex_destroy(&mutex->m);
-    php_parallel_mutex_destroy(&mutex->r);
-    php_parallel_mutex_destroy(&mutex->w);
+static zend_always_inline void php_parallel_link_mutex_destroy(php_parallel_link_mutex_t *mutex)
+{
+	php_parallel_mutex_destroy(&mutex->m);
+	php_parallel_mutex_destroy(&mutex->r);
+	php_parallel_mutex_destroy(&mutex->w);
 }
 
-static zend_always_inline int32_t php_parallel_link_cond_init(php_parallel_link_cond_t *condition) {
-    if (!php_parallel_cond_init(&condition->r)) {
-        return FAILURE;
-    }
+static zend_always_inline int32_t php_parallel_link_cond_init(php_parallel_link_cond_t *condition)
+{
+	if (!php_parallel_cond_init(&condition->r)) {
+		return FAILURE;
+	}
 
-    if (!php_parallel_cond_init(&condition->w)) {
-        php_parallel_cond_destroy(&condition->r);
+	if (!php_parallel_cond_init(&condition->w)) {
+		php_parallel_cond_destroy(&condition->r);
 
-        return FAILURE;
-    }
+		return FAILURE;
+	}
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-static zend_always_inline void php_parallel_link_cond_destroy(php_parallel_link_cond_t *condition) {
-    pthread_cond_destroy(&condition->r);
-    pthread_cond_destroy(&condition->w);
+static zend_always_inline void php_parallel_link_cond_destroy(php_parallel_link_cond_t *condition)
+{
+	pthread_cond_destroy(&condition->r);
+	pthread_cond_destroy(&condition->w);
 }
 
-php_parallel_link_t* php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity) {
-    php_parallel_link_t *link = pecalloc(1, sizeof(php_parallel_link_t), 1);
+php_parallel_link_t *php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity)
+{
+	php_parallel_link_t *link = pecalloc(1, sizeof(php_parallel_link_t), 1);
 
-    if (php_parallel_link_mutex_init(&link->m) != SUCCESS) {
-        pefree(link, 1);
-        return NULL;
-    }
+	if (php_parallel_link_mutex_init(&link->m) != SUCCESS) {
+		pefree(link, 1);
+		return NULL;
+	}
 
-    if (php_parallel_link_cond_init(&link->c) != SUCCESS) {
-        php_parallel_link_mutex_destroy(&link->m);
-        pefree(link, 1);
-        return NULL;
-    }
+	if (php_parallel_link_cond_init(&link->c) != SUCCESS) {
+		php_parallel_link_mutex_destroy(&link->m);
+		pefree(link, 1);
+		return NULL;
+	}
 
-    if (buffered) {
-        link->type = PHP_PARALLEL_LINK_BUFFERED;
-        zend_llist_init(&link->port.q.l,
-            sizeof(zval),
-            (llist_dtor_func_t) PARALLEL_ZVAL_DTOR, 1);
-        link->port.q.c = capacity;
-    } else {
-        link->type = PHP_PARALLEL_LINK_UNBUFFERED;
-    }
-    link->name = php_parallel_copy_string_interned(name);
-    link->refcount = 1;
+	if (buffered) {
+		link->type = PHP_PARALLEL_LINK_BUFFERED;
+		zend_llist_init(&link->port.q.l, sizeof(zval), (llist_dtor_func_t)PARALLEL_ZVAL_DTOR, 1);
+		link->port.q.c = capacity;
+	} else {
+		link->type = PHP_PARALLEL_LINK_UNBUFFERED;
+	}
+	link->name = php_parallel_copy_string_interned(name);
+	link->refcount = 1;
 
-    return link;
+	return link;
 }
 
-void php_parallel_link_destroy(php_parallel_link_t *link) {
-    if (php_parallel_atomic_delref(&link->refcount) == 0) {
-        php_parallel_link_mutex_destroy(&link->m);
-        php_parallel_link_cond_destroy(&link->c);
+void php_parallel_link_destroy(php_parallel_link_t *link)
+{
+	if (php_parallel_atomic_delref(&link->refcount) == 0) {
+		php_parallel_link_mutex_destroy(&link->m);
+		php_parallel_link_cond_destroy(&link->c);
 
-        if (link->type == PHP_PARALLEL_LINK_BUFFERED) {
-            zend_llist_destroy(&link->port.q.l);
-        } else {
-            if (Z_TYPE_FLAGS(link->port.z) == PHP_PARALLEL_LINK_CLOSURE_BUFFER) {
-                PARALLEL_ZVAL_DTOR(&link->port.z);
-            }
-        }
-        pefree(link, 1);
-    }
+		if (link->type == PHP_PARALLEL_LINK_BUFFERED) {
+			zend_llist_destroy(&link->port.q.l);
+		} else {
+			if (Z_TYPE_FLAGS(link->port.z) == PHP_PARALLEL_LINK_CLOSURE_BUFFER) {
+				PARALLEL_ZVAL_DTOR(&link->port.z);
+			}
+		}
+		pefree(link, 1);
+	}
 }
 
-php_parallel_link_t* php_parallel_link_copy(php_parallel_link_t *link) {
-    php_parallel_atomic_addref(&link->refcount);
+php_parallel_link_t *php_parallel_link_copy(php_parallel_link_t *link)
+{
+	php_parallel_atomic_addref(&link->refcount);
 
-    return link;
+	return link;
 }
 
-static zend_always_inline bool php_parallel_link_send_unbuffered(php_parallel_link_t *link, zval *value) {
-    pthread_mutex_lock(&link->m.w);
-    pthread_mutex_lock(&link->m.m);
+static zend_always_inline bool php_parallel_link_send_unbuffered(php_parallel_link_t *link, zval *value)
+{
+	pthread_mutex_lock(&link->m.w);
+	pthread_mutex_lock(&link->m.m);
 
-    if (link->s.c) {
-        pthread_mutex_unlock(&link->m.m);
-        pthread_mutex_unlock(&link->m.w);
-        return 0;
-    }
+	if (link->s.c) {
+		pthread_mutex_unlock(&link->m.m);
+		pthread_mutex_unlock(&link->m.w);
+		return 0;
+	}
 
-    if (PARALLEL_ZVAL_CHECK_CLOSURES(value)) {
-        PARALLEL_ZVAL_COPY(
-            &link->port.z, value, 1);
-        Z_TYPE_FLAGS(link->port.z) =
-            PHP_PARALLEL_LINK_CLOSURE_BUFFER;
-    } else {
-        ZVAL_COPY_VALUE(&link->port.z, value);
+	if (PARALLEL_ZVAL_CHECK_CLOSURES(value)) {
+		PARALLEL_ZVAL_COPY(&link->port.z, value, 1);
+		Z_TYPE_FLAGS(link->port.z) = PHP_PARALLEL_LINK_CLOSURE_BUFFER;
+	} else {
+		ZVAL_COPY_VALUE(&link->port.z, value);
 
-        ZEND_ASSERT(
-            Z_TYPE_FLAGS(link->port.z) != PHP_PARALLEL_LINK_CLOSURE_BUFFER);
-    }
-    link->s.w++;
+		ZEND_ASSERT(Z_TYPE_FLAGS(link->port.z) != PHP_PARALLEL_LINK_CLOSURE_BUFFER);
+	}
+	link->s.w++;
 
-    if (link->s.r) {
-        pthread_cond_signal(&link->c.r);
-    }
+	if (link->s.r) {
+		pthread_cond_signal(&link->c.r);
+	}
 
-    pthread_cond_wait(&link->c.w, &link->m.m);
+	pthread_cond_wait(&link->c.w, &link->m.m);
 
-    pthread_mutex_unlock(&link->m.m);
-    pthread_mutex_unlock(&link->m.w);
+	pthread_mutex_unlock(&link->m.m);
+	pthread_mutex_unlock(&link->m.w);
 
-    return 1;
+	return 1;
 }
 
-static zend_always_inline bool php_parallel_link_send_buffered(php_parallel_link_t *link, zval *value) {
-    zval sent;
+static zend_always_inline bool php_parallel_link_send_buffered(php_parallel_link_t *link, zval *value)
+{
+	zval sent;
 
-    pthread_mutex_lock(&link->m.m);
+	pthread_mutex_lock(&link->m.m);
 
-    while (link->port.q.c &&
-           zend_llist_count(&link->port.q.l) == link->port.q.c) {
-        link->s.w++;
-        pthread_cond_wait(&link->c.w, &link->m.m);
-        link->s.w--;
-    }
+	while (link->port.q.c && zend_llist_count(&link->port.q.l) == link->port.q.c) {
+		link->s.w++;
+		pthread_cond_wait(&link->c.w, &link->m.m);
+		link->s.w--;
+	}
 
-    if (link->s.c) {
-        pthread_mutex_unlock(&link->m.m);
-        return 0;
-    }
+	if (link->s.c) {
+		pthread_mutex_unlock(&link->m.m);
+		return 0;
+	}
 
-    PARALLEL_ZVAL_COPY(&sent, value, 1);
+	PARALLEL_ZVAL_COPY(&sent, value, 1);
 
-    zend_llist_add_element(
-        &link->port.q.l, &sent);
+	zend_llist_add_element(&link->port.q.l, &sent);
 
-    if (link->s.r) {
-        pthread_cond_signal(&link->c.r);
-    }
+	if (link->s.r) {
+		pthread_cond_signal(&link->c.r);
+	}
 
-    pthread_mutex_unlock(&link->m.m);
-    return 1;
+	pthread_mutex_unlock(&link->m.m);
+	return 1;
 }
 
-bool php_parallel_link_send(php_parallel_link_t *link, zval *value) {
-    if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
-        return php_parallel_link_send_unbuffered(link, value);
-    } else {
-        return php_parallel_link_send_buffered(link, value);
-    }
+bool php_parallel_link_send(php_parallel_link_t *link, zval *value)
+{
+	if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
+		return php_parallel_link_send_unbuffered(link, value);
+	} else {
+		return php_parallel_link_send_buffered(link, value);
+	}
 }
 
-static zend_always_inline bool php_parallel_link_recv_unbuffered(php_parallel_link_t *link, zval *value) {
-    pthread_mutex_lock(&link->m.r);
-    pthread_mutex_lock(&link->m.m);
+static zend_always_inline bool php_parallel_link_recv_unbuffered(php_parallel_link_t *link, zval *value)
+{
+	pthread_mutex_lock(&link->m.r);
+	pthread_mutex_lock(&link->m.m);
 
-    while (!link->s.c && !link->s.w) {
-        link->s.r++;
-        pthread_cond_wait(&link->c.r, &link->m.m);
-        link->s.r--;
-    }
+	while (!link->s.c && !link->s.w) {
+		link->s.r++;
+		pthread_cond_wait(&link->c.r, &link->m.m);
+		link->s.r--;
+	}
 
-    if (link->s.c) {
-        pthread_mutex_unlock(&link->m.m);
-        pthread_mutex_unlock(&link->m.r);
-        return 0;
-    }
+	if (link->s.c) {
+		pthread_mutex_unlock(&link->m.m);
+		pthread_mutex_unlock(&link->m.r);
+		return 0;
+	}
 
-    PARALLEL_ZVAL_COPY(
-        value, &link->port.z, 0);
-    if (Z_TYPE_FLAGS(link->port.z) == PHP_PARALLEL_LINK_CLOSURE_BUFFER) {
-        PARALLEL_ZVAL_DTOR(&link->port.z);
-    }
-    ZVAL_UNDEF(&link->port.z);
-    link->s.w--;
+	PARALLEL_ZVAL_COPY(value, &link->port.z, 0);
+	if (Z_TYPE_FLAGS(link->port.z) == PHP_PARALLEL_LINK_CLOSURE_BUFFER) {
+		PARALLEL_ZVAL_DTOR(&link->port.z);
+	}
+	ZVAL_UNDEF(&link->port.z);
+	link->s.w--;
 
-    pthread_cond_signal(&link->c.w);
-    pthread_mutex_unlock(&link->m.m);
-    pthread_mutex_unlock(&link->m.r);
-    return 1;
+	pthread_cond_signal(&link->c.w);
+	pthread_mutex_unlock(&link->m.m);
+	pthread_mutex_unlock(&link->m.r);
+	return 1;
 }
 
-static zend_always_inline int php_parallel_link_queue_delete(void *lhs, void *rhs) {
-    return lhs == rhs;
+static zend_always_inline int  php_parallel_link_queue_delete(void *lhs, void *rhs) { return lhs == rhs; }
+
+static zend_always_inline bool php_parallel_link_recv_buffered(php_parallel_link_t *link, zval *value)
+{
+	zval *head;
+
+	pthread_mutex_lock(&link->m.m);
+
+	while (zend_llist_count(&link->port.q.l) == 0) {
+		if (link->s.c) {
+			pthread_mutex_unlock(&link->m.m);
+			return 0;
+		}
+
+		link->s.r++;
+		pthread_cond_wait(&link->c.r, &link->m.m);
+		link->s.r--;
+	}
+
+	head = zend_llist_get_first(&link->port.q.l);
+
+	PARALLEL_ZVAL_COPY(value, head, 0);
+
+	zend_llist_del_element(&link->port.q.l, head, php_parallel_link_queue_delete);
+
+	if (link->s.w) {
+		pthread_cond_signal(&link->c.w);
+	}
+
+	pthread_mutex_unlock(&link->m.m);
+
+	return 1;
 }
 
-static zend_always_inline bool php_parallel_link_recv_buffered(php_parallel_link_t *link, zval *value) {
-    zval *head;
-
-    pthread_mutex_lock(&link->m.m);
-
-    while (zend_llist_count(&link->port.q.l) == 0) {
-        if (link->s.c) {
-            pthread_mutex_unlock(&link->m.m);
-            return 0;
-        }
-
-        link->s.r++;
-        pthread_cond_wait(&link->c.r, &link->m.m);
-        link->s.r--;
-    }
-
-    head = zend_llist_get_first(&link->port.q.l);
-
-    PARALLEL_ZVAL_COPY(value, head, 0);
-
-    zend_llist_del_element(
-        &link->port.q.l, head, php_parallel_link_queue_delete);
-
-    if (link->s.w) {
-        pthread_cond_signal(&link->c.w);
-    }
-
-    pthread_mutex_unlock(&link->m.m);
-
-    return 1;
+bool php_parallel_link_recv(php_parallel_link_t *link, zval *value)
+{
+	if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
+		return php_parallel_link_recv_unbuffered(link, value);
+	} else {
+		return php_parallel_link_recv_buffered(link, value);
+	}
 }
 
-bool php_parallel_link_recv(php_parallel_link_t *link, zval *value) {
-    if (link->type == PHP_PARALLEL_LINK_UNBUFFERED) {
-        return php_parallel_link_recv_unbuffered(link, value);
-    } else {
-        return php_parallel_link_recv_buffered(link, value);
-    }
+bool php_parallel_link_close(php_parallel_link_t *link)
+{
+	pthread_mutex_lock(&link->m.m);
+
+	if (link->s.c) {
+		pthread_mutex_unlock(&link->m.m);
+		return 0;
+	}
+
+	link->s.c = 1;
+	pthread_cond_broadcast(&link->c.r);
+	pthread_cond_broadcast(&link->c.w);
+	pthread_mutex_unlock(&link->m.m);
+
+	return 1;
 }
 
-bool php_parallel_link_close(php_parallel_link_t *link) {
-    pthread_mutex_lock(&link->m.m);
+bool         php_parallel_link_closed(php_parallel_link_t *link) { return link->s.c; }
 
-    if (link->s.c) {
-        pthread_mutex_unlock(&link->m.m);
-        return 0;
-    }
+zend_string *php_parallel_link_name(php_parallel_link_t *link) { return link->name; }
 
-    link->s.c = 1;
-    pthread_cond_broadcast(&link->c.r);
-    pthread_cond_broadcast(&link->c.w);
-    pthread_mutex_unlock(&link->m.m);
+bool         php_parallel_link_lock(php_parallel_link_t *link) { return pthread_mutex_lock(&link->m.m) == SUCCESS; }
 
-    return 1;
+bool         php_parallel_link_writable(php_parallel_link_t *link)
+{
+	switch (link->type) {
+	case PHP_PARALLEL_LINK_UNBUFFERED:
+		return link->s.r > 0;
+
+	case PHP_PARALLEL_LINK_BUFFERED:
+		return zend_llist_count(&link->port.q.l) < link->port.q.c;
+	}
+
+	return 0;
 }
 
-bool php_parallel_link_closed(php_parallel_link_t *link) {
-    return link->s.c;
+bool php_parallel_link_readable(php_parallel_link_t *link)
+{
+	switch (link->type) {
+	case PHP_PARALLEL_LINK_UNBUFFERED:
+		return link->s.w > 0;
+
+	case PHP_PARALLEL_LINK_BUFFERED:
+		return zend_llist_count(&link->port.q.l) > 0;
+	}
+
+	return 0;
 }
 
-zend_string* php_parallel_link_name(php_parallel_link_t *link) {
-    return link->name;
+void php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug)
+{
+	zval zdbg;
+
+	ZVAL_STR(&zdbg, link->name);
+
+	zend_hash_add(debug, php_parallel_link_string_name, &zdbg);
+
+	switch (link->type) {
+	case PHP_PARALLEL_LINK_UNBUFFERED:
+		ZVAL_STR_COPY(&zdbg, php_parallel_link_string_unbuffered);
+		zend_hash_add(debug, php_parallel_link_string_type, &zdbg);
+		break;
+
+	case PHP_PARALLEL_LINK_BUFFERED:
+		ZVAL_STR_COPY(&zdbg, php_parallel_link_string_buffered);
+		zend_hash_add(debug, php_parallel_link_string_type, &zdbg);
+
+		if (link->port.q.c == -1) {
+			ZVAL_STR_COPY(&zdbg, php_parallel_link_string_infinite);
+			zend_hash_add(debug, php_parallel_link_string_capacity, &zdbg);
+		} else {
+			ZVAL_LONG(&zdbg, link->port.q.c);
+			zend_hash_add(debug, php_parallel_link_string_capacity, &zdbg);
+			if (link->port.q.l.count) {
+				ZVAL_LONG(&zdbg, link->port.q.l.count);
+				zend_hash_add(debug, php_parallel_link_string_size, &zdbg);
+			}
+		}
+		break;
+	}
 }
 
-bool php_parallel_link_lock(php_parallel_link_t *link) {
-    return pthread_mutex_lock(&link->m.m) == SUCCESS;
-}
-
-bool php_parallel_link_writable(php_parallel_link_t *link) {
-    switch (link->type) {
-        case PHP_PARALLEL_LINK_UNBUFFERED:
-            return link->s.r > 0;
-
-        case PHP_PARALLEL_LINK_BUFFERED:
-            return zend_llist_count(&link->port.q.l) < link->port.q.c;
-    }
-
-    return 0;
-}
-
-bool php_parallel_link_readable(php_parallel_link_t *link) {
-    switch (link->type) {
-        case PHP_PARALLEL_LINK_UNBUFFERED:
-            return link->s.w > 0;
-
-        case PHP_PARALLEL_LINK_BUFFERED:
-            return zend_llist_count(&link->port.q.l) > 0;
-    }
-
-    return 0;
-}
-
-void php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug) {
-    zval zdbg;
-
-    ZVAL_STR(&zdbg, link->name);
-
-    zend_hash_add(debug, php_parallel_link_string_name, &zdbg);
-
-    switch (link->type) {
-        case PHP_PARALLEL_LINK_UNBUFFERED:
-            ZVAL_STR_COPY(&zdbg,
-                php_parallel_link_string_unbuffered);
-            zend_hash_add(debug, php_parallel_link_string_type, &zdbg);
-        break;
-
-        case PHP_PARALLEL_LINK_BUFFERED:
-            ZVAL_STR_COPY(&zdbg,
-                php_parallel_link_string_buffered);
-            zend_hash_add(debug, php_parallel_link_string_type, &zdbg);
-
-            if (link->port.q.c == -1) {
-                ZVAL_STR_COPY(&zdbg,
-                    php_parallel_link_string_infinite);
-                zend_hash_add(
-                    debug,
-                    php_parallel_link_string_capacity, &zdbg);
-            } else {
-                ZVAL_LONG(&zdbg, link->port.q.c);
-                zend_hash_add(
-                    debug,
-                    php_parallel_link_string_capacity, &zdbg);
-                if (link->port.q.l.count) {
-                    ZVAL_LONG(&zdbg, link->port.q.l.count);
-                    zend_hash_add(
-                        debug,
-                        php_parallel_link_string_size, &zdbg);
-                }
-            }
-        break;
-    }
-}
-
-bool php_parallel_link_unlock(php_parallel_link_t *link) {
-    return pthread_mutex_unlock(&link->m.m) == SUCCESS;
-}
+bool php_parallel_link_unlock(php_parallel_link_t *link) { return pthread_mutex_unlock(&link->m.m) == SUCCESS; }
 
 PHP_MINIT_FUNCTION(PARALLEL_LINK)
 {
-    php_parallel_link_string_name       = zend_string_init_interned(ZEND_STRL("name"), 1);
-    php_parallel_link_string_type       = zend_string_init_interned(ZEND_STRL("type"), 1);
-    php_parallel_link_string_unbuffered = zend_string_init_interned(ZEND_STRL("unbuffered"), 1);
-    php_parallel_link_string_buffered   = zend_string_init_interned(ZEND_STRL("buffered"), 1);
-    php_parallel_link_string_capacity   = zend_string_init_interned(ZEND_STRL("capacity"), 1);
-    php_parallel_link_string_size       = zend_string_init_interned(ZEND_STRL("size"), 1);
-    php_parallel_link_string_infinite   = zend_string_init_interned(ZEND_STRL("infinite"), 1);
+	php_parallel_link_string_name = zend_string_init_interned(ZEND_STRL("name"), 1);
+	php_parallel_link_string_type = zend_string_init_interned(ZEND_STRL("type"), 1);
+	php_parallel_link_string_unbuffered = zend_string_init_interned(ZEND_STRL("unbuffered"), 1);
+	php_parallel_link_string_buffered = zend_string_init_interned(ZEND_STRL("buffered"), 1);
+	php_parallel_link_string_capacity = zend_string_init_interned(ZEND_STRL("capacity"), 1);
+	php_parallel_link_string_size = zend_string_init_interned(ZEND_STRL("size"), 1);
+	php_parallel_link_string_infinite = zend_string_init_interned(ZEND_STRL("infinite"), 1);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_LINK)
 {
-    zend_string_release(php_parallel_link_string_name);
-    zend_string_release(php_parallel_link_string_type);
-    zend_string_release(php_parallel_link_string_unbuffered);
-    zend_string_release(php_parallel_link_string_buffered);
-    zend_string_release(php_parallel_link_string_capacity);
-    zend_string_release(php_parallel_link_string_size);
-    zend_string_release(php_parallel_link_string_infinite);
+	zend_string_release(php_parallel_link_string_name);
+	zend_string_release(php_parallel_link_string_type);
+	zend_string_release(php_parallel_link_string_unbuffered);
+	zend_string_release(php_parallel_link_string_buffered);
+	zend_string_release(php_parallel_link_string_capacity);
+	zend_string_release(php_parallel_link_string_size);
+	zend_string_release(php_parallel_link_string_infinite);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/link.h
+++ b/src/link.h
@@ -18,23 +18,25 @@
 #ifndef HAVE_PARALLEL_LINK_H
 #define HAVE_PARALLEL_LINK_H
 
+#include "php.h"
+
 typedef struct _php_parallel_link_t php_parallel_link_t;
 
-php_parallel_link_t* php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity);
-zend_string*         php_parallel_link_name(php_parallel_link_t *link);
-php_parallel_link_t* php_parallel_link_copy(php_parallel_link_t *link);
-bool            php_parallel_link_send(php_parallel_link_t *link, zval *value);
-bool            php_parallel_link_recv(php_parallel_link_t *link, zval *value);
-bool            php_parallel_link_close(php_parallel_link_t *link);
-bool            php_parallel_link_closed(php_parallel_link_t *link);
-void                 php_parallel_link_destroy(php_parallel_link_t *link);
+php_parallel_link_t                *php_parallel_link_init(zend_string *name, bool buffered, zend_long capacity);
+zend_string                        *php_parallel_link_name(php_parallel_link_t *link);
+php_parallel_link_t                *php_parallel_link_copy(php_parallel_link_t *link);
+bool                                php_parallel_link_send(php_parallel_link_t *link, zval *value);
+bool                                php_parallel_link_recv(php_parallel_link_t *link, zval *value);
+bool                                php_parallel_link_close(php_parallel_link_t *link);
+bool                                php_parallel_link_closed(php_parallel_link_t *link);
+void                                php_parallel_link_destroy(php_parallel_link_t *link);
 
-bool            php_parallel_link_lock(php_parallel_link_t *link);
-bool            php_parallel_link_writable(php_parallel_link_t *link);
-bool            php_parallel_link_readable(php_parallel_link_t *link);
-bool            php_parallel_link_unlock(php_parallel_link_t *link);
+bool                                php_parallel_link_lock(php_parallel_link_t *link);
+bool                                php_parallel_link_writable(php_parallel_link_t *link);
+bool                                php_parallel_link_readable(php_parallel_link_t *link);
+bool                                php_parallel_link_unlock(php_parallel_link_t *link);
 
-void                 php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug);
+void                                php_parallel_link_debug(php_parallel_link_t *link, HashTable *debug);
 
 PHP_MINIT_FUNCTION(PARALLEL_LINK);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_LINK);

--- a/src/loop.c
+++ b/src/loop.c
@@ -22,91 +22,88 @@
 #include "poll.h"
 
 typedef struct _php_parallel_events_loop_t {
-    zend_object_iterator it;
-    zval events;
-    zval event;
+	zend_object_iterator it;
+	zval                 events;
+	zval                 event;
 } php_parallel_events_loop_t;
 
-static void php_parallel_events_loop_destroy(zend_object_iterator *zo) {
-    php_parallel_events_loop_t *loop =
-        (php_parallel_events_loop_t*) zo;
+static void php_parallel_events_loop_destroy(zend_object_iterator *zo)
+{
+	php_parallel_events_loop_t *loop = (php_parallel_events_loop_t *)zo;
 
-    if (!Z_ISUNDEF(loop->event)) {
-        zval_ptr_dtor(&loop->event);
-    }
+	if (!Z_ISUNDEF(loop->event)) {
+		zval_ptr_dtor(&loop->event);
+	}
 
-    zval_ptr_dtor(&loop->events);
+	zval_ptr_dtor(&loop->events);
 }
 
-static int php_parallel_events_loop_valid(zend_object_iterator *zo) {
-    php_parallel_events_loop_t *loop =
-        (php_parallel_events_loop_t*) zo;
+static int php_parallel_events_loop_valid(zend_object_iterator *zo)
+{
+	php_parallel_events_loop_t *loop = (php_parallel_events_loop_t *)zo;
 
-    return Z_TYPE(loop->event) == IS_OBJECT ? SUCCESS : FAILURE;
+	return Z_TYPE(loop->event) == IS_OBJECT ? SUCCESS : FAILURE;
 }
 
-static void php_parallel_events_loop_poll(zend_object_iterator *zo) {
-    php_parallel_events_loop_t *loop =
-        (php_parallel_events_loop_t*) zo;
-    php_parallel_events_t *events =
-        php_parallel_events_from(&loop->events);
+static void php_parallel_events_loop_poll(zend_object_iterator *zo)
+{
+	php_parallel_events_loop_t *loop = (php_parallel_events_loop_t *)zo;
+	php_parallel_events_t      *events = php_parallel_events_from(&loop->events);
 
-    if (Z_TYPE(loop->event) == IS_OBJECT) {
-        zval_ptr_dtor(&loop->event);
-    }
+	if (Z_TYPE(loop->event) == IS_OBJECT) {
+		zval_ptr_dtor(&loop->event);
+	}
 
-    php_parallel_events_poll(events, &loop->event);
+	php_parallel_events_poll(events, &loop->event);
 }
 
-static zval* php_parallel_events_loop_current(zend_object_iterator *zo) {
-    php_parallel_events_loop_t *loop =
-        (php_parallel_events_loop_t*) zo;
+static zval *php_parallel_events_loop_current(zend_object_iterator *zo)
+{
+	php_parallel_events_loop_t *loop = (php_parallel_events_loop_t *)zo;
 
-    return &loop->event;
+	return &loop->event;
 }
 
 const zend_object_iterator_funcs php_parallel_events_loop_functions = {
-    .dtor               = php_parallel_events_loop_destroy,
-    .valid              = php_parallel_events_loop_valid,
-    .move_forward       = php_parallel_events_loop_poll,
-    .get_current_data   = php_parallel_events_loop_current,
-    .rewind             = php_parallel_events_loop_poll,
+    .dtor = php_parallel_events_loop_destroy,
+    .valid = php_parallel_events_loop_valid,
+    .move_forward = php_parallel_events_loop_poll,
+    .get_current_data = php_parallel_events_loop_current,
+    .rewind = php_parallel_events_loop_poll,
     .invalidate_current = NULL,
-    .get_current_key    = NULL,
+    .get_current_key = NULL,
 };
 
-static zend_always_inline bool php_parallel_events_loop_check(zval *zv) {
-    php_parallel_events_t *events = php_parallel_events_from(zv);
+static zend_always_inline bool php_parallel_events_loop_check(zval *zv)
+{
+	php_parallel_events_t *events = php_parallel_events_from(zv);
 
-    if (events->blocking) {
-        return 1;
-    }
+	if (events->blocking) {
+		return 1;
+	}
 
-    return 0;
+	return 0;
 }
 
-zend_object_iterator* php_parallel_events_loop_create(zend_class_entry *type, zval *events, int by_ref) {
-    php_parallel_events_loop_t *loop;
+zend_object_iterator *php_parallel_events_loop_create(zend_class_entry *type, zval *events, int by_ref)
+{
+	php_parallel_events_loop_t *loop;
 
-    if (!php_parallel_events_loop_check(events)) {
-        php_parallel_exception_ex(
-            php_parallel_events_error_ce,
-            "cannot create iterator for non-blocking event loop");
-        return NULL;
-    }
+	if (!php_parallel_events_loop_check(events)) {
+		php_parallel_exception_ex(php_parallel_events_error_ce, "cannot create iterator for non-blocking event loop");
+		return NULL;
+	}
 
-    loop =
-        (php_parallel_events_loop_t*)
-            ecalloc(1, sizeof(php_parallel_events_loop_t));
+	loop = (php_parallel_events_loop_t *)ecalloc(1, sizeof(php_parallel_events_loop_t));
 
-    zend_iterator_init(&loop->it);
+	zend_iterator_init(&loop->it);
 
-    loop->it.funcs = &php_parallel_events_loop_functions;
+	loop->it.funcs = &php_parallel_events_loop_functions;
 
-    ZVAL_COPY(&loop->events, events);
+	ZVAL_COPY(&loop->events, events);
 
-    ZVAL_UNDEF(&loop->event);
+	ZVAL_UNDEF(&loop->event);
 
-    return &loop->it;
+	return &loop->it;
 }
 #endif

--- a/src/loop.h
+++ b/src/loop.h
@@ -18,6 +18,8 @@
 #ifndef HAVE_PARALLEL_EVENTS_LOOP_H
 #define HAVE_PARALLEL_EVENTS_LOOP_H
 
-zend_object_iterator* php_parallel_events_loop_create(zend_class_entry *type, zval *events, int by_ref);
+#include "php.h"
+
+zend_object_iterator *php_parallel_events_loop_create(zend_class_entry *type, zval *events, int by_ref);
 
 #endif

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -20,103 +20,102 @@
 
 #include "parallel.h"
 
-php_parallel_monitor_t* php_parallel_monitor_create(void) {
-    php_parallel_monitor_t *monitor =
-        (php_parallel_monitor_t*)
-            calloc(1, sizeof(php_parallel_monitor_t));
+php_parallel_monitor_t *php_parallel_monitor_create(void)
+{
+	php_parallel_monitor_t *monitor = (php_parallel_monitor_t *)calloc(1, sizeof(php_parallel_monitor_t));
 
-    php_parallel_mutex_init(&monitor->mutex, 1);
-    php_parallel_cond_init(&monitor->condition);
+	php_parallel_mutex_init(&monitor->mutex, 1);
+	php_parallel_cond_init(&monitor->condition);
 
-    return monitor;
+	return monitor;
 }
 
-int php_parallel_monitor_lock(php_parallel_monitor_t *monitor) {
-    return pthread_mutex_lock(&monitor->mutex);
+int     php_parallel_monitor_lock(php_parallel_monitor_t *monitor) { return pthread_mutex_lock(&monitor->mutex); }
+
+int32_t php_parallel_monitor_check(php_parallel_monitor_t *monitor, int32_t state)
+{
+	return (monitor->state & (state));
 }
 
-int32_t php_parallel_monitor_check(php_parallel_monitor_t *monitor, int32_t state) {
-    return (monitor->state & (state));
+int     php_parallel_monitor_unlock(php_parallel_monitor_t *monitor) { return pthread_mutex_unlock(&monitor->mutex); }
+
+int32_t php_parallel_monitor_wait(php_parallel_monitor_t *monitor, int32_t state)
+{
+	int32_t changed = FAILURE;
+	int     rc = SUCCESS;
+
+	if (pthread_mutex_lock(&monitor->mutex) != SUCCESS) {
+		return FAILURE;
+	}
+
+	while (!(changed = (monitor->state & state))) {
+
+		if ((rc = pthread_cond_wait(&monitor->condition, &monitor->mutex)) != SUCCESS) {
+			pthread_mutex_unlock(&monitor->mutex);
+
+			return FAILURE;
+		}
+	}
+
+	monitor->state ^= changed;
+
+	if (pthread_mutex_unlock(&monitor->mutex) != SUCCESS) {
+		return FAILURE;
+	}
+
+	return changed;
 }
 
-int php_parallel_monitor_unlock(php_parallel_monitor_t *monitor) {
-    return pthread_mutex_unlock(&monitor->mutex);
+int32_t php_parallel_monitor_wait_locked(php_parallel_monitor_t *monitor, int32_t state)
+{
+	int32_t changed = FAILURE;
+	int     rc = SUCCESS;
+
+	while (!(changed = (monitor->state & state))) {
+		if ((rc = pthread_cond_wait(&monitor->condition, &monitor->mutex)) != SUCCESS) {
+			return FAILURE;
+		}
+	}
+
+	monitor->state ^= changed;
+
+	return changed;
 }
 
-int32_t php_parallel_monitor_wait(php_parallel_monitor_t *monitor, int32_t state) {
-    int32_t changed = FAILURE;
-    int      rc      = SUCCESS;
+void php_parallel_monitor_set(php_parallel_monitor_t *monitor, int32_t state)
+{
+	pthread_mutex_lock(&monitor->mutex);
 
-    if (pthread_mutex_lock(&monitor->mutex) != SUCCESS) {
-        return FAILURE;
-    }
+	monitor->state |= state;
 
-    while (!(changed = (monitor->state & state))) {
+	pthread_cond_signal(&monitor->condition);
 
-        if ((rc = pthread_cond_wait(
-                &monitor->condition, &monitor->mutex)) != SUCCESS) {
-            pthread_mutex_unlock(&monitor->mutex);
-
-            return FAILURE;
-        }
-    }
-
-    monitor->state ^= changed;
-
-    if (pthread_mutex_unlock(&monitor->mutex) != SUCCESS) {
-        return FAILURE;
-    }
-
-    return changed;
+	pthread_mutex_unlock(&monitor->mutex);
 }
 
-int32_t php_parallel_monitor_wait_locked(php_parallel_monitor_t *monitor, int32_t state) {
-    int32_t changed = FAILURE;
-    int      rc      = SUCCESS;
+void php_parallel_monitor_add(php_parallel_monitor_t *monitor, int32_t state)
+{
+	pthread_mutex_lock(&monitor->mutex);
 
-    while (!(changed = (monitor->state & state))) {
-        if ((rc = pthread_cond_wait(
-                &monitor->condition, &monitor->mutex)) != SUCCESS) {
-            return FAILURE;
-        }
-    }
+	monitor->state |= state;
 
-    monitor->state ^= changed;
-
-    return changed;
+	pthread_mutex_unlock(&monitor->mutex);
 }
 
-void php_parallel_monitor_set(php_parallel_monitor_t *monitor, int32_t state) {
-    pthread_mutex_lock(&monitor->mutex);
+void php_parallel_monitor_remove(php_parallel_monitor_t *monitor, int32_t state)
+{
+	pthread_mutex_lock(&monitor->mutex);
 
-    monitor->state |= state;
+	monitor->state &= ~state;
 
-    pthread_cond_signal(
-        &monitor->condition);
-
-    pthread_mutex_unlock(&monitor->mutex);
+	pthread_mutex_unlock(&monitor->mutex);
 }
 
-void php_parallel_monitor_add(php_parallel_monitor_t *monitor, int32_t state) {
-    pthread_mutex_lock(&monitor->mutex);
+void php_parallel_monitor_destroy(php_parallel_monitor_t *monitor)
+{
+	php_parallel_mutex_destroy(&monitor->mutex);
+	php_parallel_cond_destroy(&monitor->condition);
 
-    monitor->state |= state;
-
-    pthread_mutex_unlock(&monitor->mutex);
-}
-
-void php_parallel_monitor_remove(php_parallel_monitor_t *monitor, int32_t state) {
-    pthread_mutex_lock(&monitor->mutex);
-
-    monitor->state &= ~state;
-
-    pthread_mutex_unlock(&monitor->mutex);
-}
-
-void php_parallel_monitor_destroy(php_parallel_monitor_t *monitor) {
-    php_parallel_mutex_destroy(&monitor->mutex);
-    php_parallel_cond_destroy(&monitor->condition);
-
-    free(monitor);
+	free(monitor);
 }
 #endif

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -19,33 +19,34 @@
 #define HAVE_PARALLEL_MONITOR_H
 
 #include <pthread.h>
+#include <stdint.h>
 
 typedef struct _php_parallel_monitor_t {
-    pthread_mutex_t  mutex;
-    pthread_cond_t   condition;
-    volatile int32_t state;
+	pthread_mutex_t  mutex;
+	pthread_cond_t   condition;
+	volatile int32_t state;
 } php_parallel_monitor_t;
 
-#define PHP_PARALLEL_READY     (1<<0)
-#define PHP_PARALLEL_EXEC      (1<<1)
-#define PHP_PARALLEL_CLOSE     (1<<2)
-#define PHP_PARALLEL_CLOSED    (1<<3)
-#define PHP_PARALLEL_KILLED    (1<<4)
-#define PHP_PARALLEL_ERROR     (1<<5)
-#define PHP_PARALLEL_DONE      (1<<6)
-#define PHP_PARALLEL_CANCELLED (1<<7)
-#define PHP_PARALLEL_RUNNING   (1<<8)
+#define PHP_PARALLEL_READY (1 << 0)
+#define PHP_PARALLEL_EXEC (1 << 1)
+#define PHP_PARALLEL_CLOSE (1 << 2)
+#define PHP_PARALLEL_CLOSED (1 << 3)
+#define PHP_PARALLEL_KILLED (1 << 4)
+#define PHP_PARALLEL_ERROR (1 << 5)
+#define PHP_PARALLEL_DONE (1 << 6)
+#define PHP_PARALLEL_CANCELLED (1 << 7)
+#define PHP_PARALLEL_RUNNING (1 << 8)
 
-#define PHP_PARALLEL_FAILURE   (1<<12)
+#define PHP_PARALLEL_FAILURE (1 << 12)
 
-php_parallel_monitor_t* php_parallel_monitor_create(void);
-int php_parallel_monitor_lock(php_parallel_monitor_t *m);
-int32_t php_parallel_monitor_check(php_parallel_monitor_t *m, int32_t state);
-int php_parallel_monitor_unlock(php_parallel_monitor_t *m);
-int32_t php_parallel_monitor_wait(php_parallel_monitor_t *m, int32_t state);
-int32_t php_parallel_monitor_wait_locked(php_parallel_monitor_t *m, int32_t state);
-void php_parallel_monitor_set(php_parallel_monitor_t *monitor, int32_t state);
-void php_parallel_monitor_add(php_parallel_monitor_t *monitor, int32_t state);
-void php_parallel_monitor_remove(php_parallel_monitor_t *monitor, int32_t state);
-void php_parallel_monitor_destroy(php_parallel_monitor_t *);
+php_parallel_monitor_t *php_parallel_monitor_create(void);
+int                     php_parallel_monitor_lock(php_parallel_monitor_t *m);
+int32_t                 php_parallel_monitor_check(php_parallel_monitor_t *m, int32_t state);
+int                     php_parallel_monitor_unlock(php_parallel_monitor_t *m);
+int32_t                 php_parallel_monitor_wait(php_parallel_monitor_t *m, int32_t state);
+int32_t                 php_parallel_monitor_wait_locked(php_parallel_monitor_t *m, int32_t state);
+void                    php_parallel_monitor_set(php_parallel_monitor_t *monitor, int32_t state);
+void                    php_parallel_monitor_add(php_parallel_monitor_t *monitor, int32_t state);
+void                    php_parallel_monitor_remove(php_parallel_monitor_t *monitor, int32_t state);
+void                    php_parallel_monitor_destroy(php_parallel_monitor_t *);
 #endif

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -24,9 +24,9 @@
 TSRM_TLS HashTable php_parallel_runtimes;
 
 static struct {
-    pthread_mutex_t     mutex;
-    zend_string        *bootstrap;
-    volatile zend_ulong running;
+	pthread_mutex_t     mutex;
+	zend_string        *bootstrap;
+	volatile zend_ulong running;
 } php_parallel_globals;
 
 #define PCG(e) php_parallel_globals.e
@@ -34,213 +34,206 @@ static struct {
 
 /* {{{ */
 typedef int (*php_sapi_deactivate_t)(void);
-typedef size_t (*php_sapi_output_t)(const char*, size_t);
+typedef size_t (*php_sapi_output_t)(const char *, size_t);
 
 static php_sapi_deactivate_t php_sapi_deactivate_function;
 static php_sapi_output_t     php_sapi_output_function;
 
-static pthread_mutex_t php_parallel_output_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t       php_parallel_output_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-static size_t php_parallel_output_function(const char *str, size_t len) {
-    size_t result;
+static size_t                php_parallel_output_function(const char *str, size_t len)
+{
+	size_t result;
 
-    pthread_mutex_lock(&php_parallel_output_mutex);
-    result =
-        php_sapi_output_function(str, len);
-    pthread_mutex_unlock(&php_parallel_output_mutex);
+	pthread_mutex_lock(&php_parallel_output_mutex);
+	result = php_sapi_output_function(str, len);
+	pthread_mutex_unlock(&php_parallel_output_mutex);
 
-    return result;
+	return result;
 } /* }}} */
 
 /* {{{ */
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_bootstrap_arginfo, 0, 0, 1)
-    ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, file, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 static PHP_NAMED_FUNCTION(php_parallel_bootstrap)
 {
-    zend_string *bootstrap;
+	zend_string *bootstrap;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_PATH_STR(bootstrap)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_PATH_STR(bootstrap)
+	ZEND_PARSE_PARAMETERS_END();
 
-    pthread_mutex_lock(&PCG(mutex));
+	pthread_mutex_lock(&PCG(mutex));
 
-    if (PCG(bootstrap)) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_bootstrap_ce,
-            "\\parallel\\bootstrap already set to %s",
-            ZSTR_VAL(PCG(bootstrap)));
-        pthread_mutex_unlock(&PCG(mutex));
-        return;
-    }
+	if (PCG(bootstrap)) {
+		php_parallel_exception_ex(php_parallel_runtime_error_bootstrap_ce, "\\parallel\\bootstrap already set to %s",
+		                          ZSTR_VAL(PCG(bootstrap)));
+		pthread_mutex_unlock(&PCG(mutex));
+		return;
+	}
 
-    if (PCG(running)) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_bootstrap_ce,
-            "\\parallel\\bootstrap should be called once, "
-            "before any calls to \\parallel\\run");
-        pthread_mutex_unlock(&PCG(mutex));
-        return;
-    }
+	if (PCG(running)) {
+		php_parallel_exception_ex(php_parallel_runtime_error_bootstrap_ce,
+		                          "\\parallel\\bootstrap should be called once, "
+		                          "before any calls to \\parallel\\run");
+		pthread_mutex_unlock(&PCG(mutex));
+		return;
+	}
 
-    PCG(bootstrap) =
-        php_parallel_copy_string_interned(bootstrap);
-    pthread_mutex_unlock(&PCG(mutex));
+	PCG(bootstrap) = php_parallel_copy_string_interned(bootstrap);
+	pthread_mutex_unlock(&PCG(mutex));
 } /* }}} */
 
 // This will return an idle runtime (aka thread) or spawn a new one, bootstap it
 // and return that. This method is solely called by the userlands
 // `\parallel\run()` function call.
 /* {{{ */
-static zend_always_inline php_parallel_runtime_t* php_parallel_runtimes_fetch() {
-    php_parallel_runtime_t *runtime;
+static zend_always_inline php_parallel_runtime_t *php_parallel_runtimes_fetch()
+{
+	php_parallel_runtime_t *runtime;
 
-    ZEND_HASH_FOREACH_PTR(&php_parallel_runtimes, runtime) {
-        if (!php_parallel_scheduler_busy(runtime)) {
-            return runtime;
-        }
-    } ZEND_HASH_FOREACH_END();
+	ZEND_HASH_FOREACH_PTR(&php_parallel_runtimes, runtime)
+	{
+		if (!php_parallel_scheduler_busy(runtime)) {
+			return runtime;
+		}
+	}
+	ZEND_HASH_FOREACH_END();
 
-    if (!(runtime = php_parallel_runtime_construct(PCG(bootstrap)))) {
-        return NULL;
-    }
+	if (!(runtime = php_parallel_runtime_construct(PCG(bootstrap)))) {
+		return NULL;
+	}
 
-    pthread_mutex_lock(&PCG(mutex));
-    PCG(running)++;
-    pthread_mutex_unlock(&PCG(mutex));
+	pthread_mutex_lock(&PCG(mutex));
+	PCG(running)++;
+	pthread_mutex_unlock(&PCG(mutex));
 
-    return zend_hash_next_index_insert_ptr(&php_parallel_runtimes, runtime);
+	return zend_hash_next_index_insert_ptr(&php_parallel_runtimes, runtime);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_parallel_run_arginfo, 0, 1, \\parallel\\Future, 1)
-    ZEND_ARG_OBJ_INFO(0, task, Closure, 0)
-    ZEND_ARG_TYPE_INFO(0, argv, IS_ARRAY, 0)
+ZEND_ARG_OBJ_INFO(0, task, Closure, 0)
+ZEND_ARG_TYPE_INFO(0, argv, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 static PHP_NAMED_FUNCTION(php_parallel_run)
 {
-    php_parallel_runtime_t *runtime;
-    zval *closure = NULL;
-    zval *argv = NULL;
+	php_parallel_runtime_t *runtime;
+	zval                   *closure = NULL;
+	zval                   *argv = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 2)
-        Z_PARAM_OBJECT_OF_CLASS(closure, zend_ce_closure)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_ARRAY(argv)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+	Z_PARAM_OBJECT_OF_CLASS(closure, zend_ce_closure)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_ARRAY(argv)
+	ZEND_PARSE_PARAMETERS_END();
 
-    runtime = php_parallel_runtimes_fetch();
+	runtime = php_parallel_runtimes_fetch();
 
-    if (!EG(exception)) {
-        php_parallel_scheduler_push(
-            runtime, closure, argv, return_value);
-    }
+	if (!EG(exception)) {
+		php_parallel_scheduler_push(runtime, closure, argv, return_value);
+	}
 } /* }}} */
 
 #ifdef ZEND_DEBUG
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_count_arginfo, 0, 0, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-PHP_NAMED_FUNCTION(php_parallel_count)
-{
-    RETURN_LONG(zend_hash_num_elements(&php_parallel_runtimes));
-}
+PHP_NAMED_FUNCTION(php_parallel_count) { RETURN_LONG(zend_hash_num_elements(&php_parallel_runtimes)); }
 #endif
 
 /* {{{ */
 zend_function_entry php_parallel_functions[] = {
-	ZEND_NS_FENTRY("parallel", bootstrap, php_parallel_bootstrap, php_parallel_bootstrap_arginfo, 0)
-	ZEND_NS_FENTRY("parallel", run,       php_parallel_run,       php_parallel_run_arginfo, 0)
+    ZEND_NS_FENTRY("parallel", bootstrap, php_parallel_bootstrap, php_parallel_bootstrap_arginfo, 0)
+        ZEND_NS_FENTRY("parallel", run, php_parallel_run, php_parallel_run_arginfo, 0)
 #ifdef ZEND_DEBUG
-	ZEND_NS_FENTRY("parallel", count,     php_parallel_count,     php_parallel_count_arginfo, 0)
+            ZEND_NS_FENTRY("parallel", count, php_parallel_count, php_parallel_count_arginfo, 0)
 #endif
-    PHP_FE_END
-}; /* }}} */
+                PHP_FE_END}; /* }}} */
 
 PHP_MINIT_FUNCTION(PARALLEL_CORE)
 {
-    if (strncmp(sapi_module.name, "cli", sizeof("cli")-1) == SUCCESS) {
-        php_sapi_deactivate_function = sapi_module.deactivate;
+	if (strncmp(sapi_module.name, "cli", sizeof("cli") - 1) == SUCCESS) {
+		php_sapi_deactivate_function = sapi_module.deactivate;
 
-        sapi_module.deactivate = NULL;
-    }
+		sapi_module.deactivate = NULL;
+	}
 
-    memset(&php_parallel_globals, 0, sizeof(php_parallel_globals));
+	memset(&php_parallel_globals, 0, sizeof(php_parallel_globals));
 
-    php_sapi_output_function = sapi_module.ub_write;
+	php_sapi_output_function = sapi_module.ub_write;
 
-    sapi_module.ub_write = php_parallel_output_function;
+	sapi_module.ub_write = php_parallel_output_function;
 
-    PHP_MINIT(PARALLEL_HANDLERS)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_EXCEPTIONS)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_SCHEDULER)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_CHANNEL)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_EVENTS)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MINIT(PARALLEL_SYNC)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_HANDLERS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_EXCEPTIONS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_SCHEDULER)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_CHANNEL)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_EVENTS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_SYNC)(INIT_FUNC_ARGS_PASSTHRU);
 
-    php_parallel_mutex_init(&PCG(mutex), 1);
-    PCG(running) = 0;
-    PCG(bootstrap) = NULL;
+	php_parallel_mutex_init(&PCG(mutex), 1);
+	PCG(running) = 0;
+	PCG(bootstrap) = NULL;
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_CORE)
 {
-    PHP_MSHUTDOWN(PARALLEL_SYNC)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_EVENTS)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_CHANNEL)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_SCHEDULER)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_EXCEPTIONS)(INIT_FUNC_ARGS_PASSTHRU);
-    PHP_MSHUTDOWN(PARALLEL_HANDLERS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_SYNC)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_EVENTS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_CHANNEL)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_SCHEDULER)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_EXCEPTIONS)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_HANDLERS)(INIT_FUNC_ARGS_PASSTHRU);
 
-    php_parallel_mutex_destroy(&PCG(mutex));
+	php_parallel_mutex_destroy(&PCG(mutex));
 
-    if (strncmp(sapi_module.name, "cli", sizeof("cli")-1) == SUCCESS) {
-        sapi_module.deactivate = php_sapi_deactivate_function;
-    }
+	if (strncmp(sapi_module.name, "cli", sizeof("cli") - 1) == SUCCESS) {
+		sapi_module.deactivate = php_sapi_deactivate_function;
+	}
 
-    sapi_module.ub_write = php_sapi_output_function;
+	sapi_module.ub_write = php_sapi_output_function;
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-static void php_parallel_runtimes_release(zval *zv) {
-    php_parallel_runtime_t *runtime =
-        (php_parallel_runtime_t*) Z_PTR_P(zv);
+static void php_parallel_runtimes_release(zval *zv)
+{
+	php_parallel_runtime_t *runtime = (php_parallel_runtime_t *)Z_PTR_P(zv);
 
-    OBJ_RELEASE(&runtime->std);
-    pthread_mutex_lock(&PCG(mutex));
-    PCG(running)--;
-    pthread_mutex_unlock(&PCG(mutex));
+	OBJ_RELEASE(&runtime->std);
+	pthread_mutex_lock(&PCG(mutex));
+	PCG(running)--;
+	pthread_mutex_unlock(&PCG(mutex));
 }
 
 PHP_RINIT_FUNCTION(PARALLEL_CORE)
 {
-    PHP_RINIT(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RINIT(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
 
-    zend_hash_init(
-        &php_parallel_runtimes, 16, NULL, php_parallel_runtimes_release, 0);
+	zend_hash_init(&php_parallel_runtimes, 16, NULL, php_parallel_runtimes_release, 0);
 
 	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(PARALLEL_CORE)
 {
-    zend_hash_destroy(&php_parallel_runtimes);
+	zend_hash_destroy(&php_parallel_runtimes);
 
-    PHP_RSHUTDOWN(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_RSHUTDOWN(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
 
-    // In case of a `zend_bailout()` this mutex could still be locked, so we
-    // unlock it just in case.
-    // See https://github.com/krakjoe/parallel/issues/313 for more details
-    if (UNEXPECTED(CG(unclean_shutdown) == 1)) {
-        pthread_mutex_unlock(&php_parallel_output_mutex);
-    }
+	// In case of a `zend_bailout()` this mutex could still be locked, so we
+	// unlock it just in case.
+	// See https://github.com/krakjoe/parallel/issues/313 for more details
+	if (UNEXPECTED(CG(unclean_shutdown) == 1)) {
+		pthread_mutex_unlock(&php_parallel_output_mutex);
+	}
 
 	return SUCCESS;
 }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -18,106 +18,103 @@
 #ifndef HAVE_PARALLEL_PARALLEL_H
 #define HAVE_PARALLEL_PARALLEL_H
 
-#include "php.h"
 #include "monitor.h"
+#include "php.h"
 #include "pthread.h"
 
-#include "exceptions.h"
-#include "handlers.h"
-#include "runtime.h"
-#include "future.h"
-#include "scheduler.h"
 #include "channel.h"
-#include "events.h"
 #include "event.h"
+#include "events.h"
+#include "exceptions.h"
+#include "future.h"
+#include "handlers.h"
 #include "input.h"
+#include "runtime.h"
+#include "scheduler.h"
 #include "sync.h"
 
 #include "SAPI.h"
 #include "php_main.h"
 #include "zend_closures.h"
+#include "zend_exceptions.h"
 #include "zend_gc.h"
 #include "zend_interfaces.h"
-#include "zend_exceptions.h"
 #include "zend_vm.h"
 
 typedef union _php_parallel_platform_align_test {
-    void *v;
-    double d;
-    zend_long l;
+	void     *v;
+	double    d;
+	zend_long l;
 } php_parallel_platform_align_test;
 
 #if ZEND_GCC_VERSION >= 2000
-# define PARALLEL_PLATFORM_ALIGNMENT \
-    (__alignof__(php_parallel_platform_align_test) < 8 ? \
-        8 : __alignof__(php_parallel_platform_align_test))
+#define PARALLEL_PLATFORM_ALIGNMENT                                                                                    \
+	(__alignof__(php_parallel_platform_align_test) < 8 ? 8 : __alignof__(php_parallel_platform_align_test))
 #else
-# define PARALLEL_PLATFORM_ALIGNMENT \
-    (sizeof(php_parallel_platform_align_test))
+#define PARALLEL_PLATFORM_ALIGNMENT (sizeof(php_parallel_platform_align_test))
 #endif
-#define PARALLEL_PLATFORM_ALIGNED(size) \
-    ZEND_MM_ALIGNED_SIZE_EX(size, PARALLEL_PLATFORM_ALIGNMENT)
+#define PARALLEL_PLATFORM_ALIGNED(size) ZEND_MM_ALIGNED_SIZE_EX(size, PARALLEL_PLATFORM_ALIGNMENT)
 
-#include "dependencies.h"
 #include "cache.h"
-#include "copy.h"
 #include "check.h"
+#include "copy.h"
+#include "dependencies.h"
 
-#define PARALLEL_PARAMETERS_NONE(r) \
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 0) \
-    ZEND_PARSE_PARAMETERS_END()
+#define PARALLEL_PARAMETERS_NONE(r)                                                                                    \
+	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 0)                                                      \
+	ZEND_PARSE_PARAMETERS_END()
 
-static zend_always_inline bool php_parallel_mutex_init(pthread_mutex_t *mutex, bool recursive) {
-    if (recursive) {
-        bool result = 0;
-        pthread_mutexattr_t attributes;
+static zend_always_inline bool php_parallel_mutex_init(pthread_mutex_t *mutex, bool recursive)
+{
+	if (recursive) {
+		bool                result = 0;
+		pthread_mutexattr_t attributes;
 
-        pthread_mutexattr_init(&attributes);
+		pthread_mutexattr_init(&attributes);
 #if defined(PTHREAD_MUTEX_RECURSIVE) || defined(__FreeBSD__)
-        pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE);
 #else
-        pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE_NP);
+		pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE_NP);
 #endif
-        if (pthread_mutex_init(mutex, &attributes) == SUCCESS) {
-            result = 1;
-        }
+		if (pthread_mutex_init(mutex, &attributes) == SUCCESS) {
+			result = 1;
+		}
 
-        pthread_mutexattr_destroy(&attributes);
-        return result;
-    }
+		pthread_mutexattr_destroy(&attributes);
+		return result;
+	}
 
-    return (pthread_mutex_init(mutex, NULL) == SUCCESS);
+	return (pthread_mutex_init(mutex, NULL) == SUCCESS);
 }
 
-static zend_always_inline void php_parallel_mutex_destroy(pthread_mutex_t *mutex) {
-    pthread_mutex_destroy(mutex);
+static zend_always_inline void php_parallel_mutex_destroy(pthread_mutex_t *mutex) { pthread_mutex_destroy(mutex); }
+
+static zend_always_inline bool php_parallel_cond_init(pthread_cond_t *cond)
+{
+	return (pthread_cond_init(cond, NULL) == SUCCESS);
 }
 
-static zend_always_inline bool php_parallel_cond_init(pthread_cond_t *cond) {
-    return (pthread_cond_init(cond, NULL) == SUCCESS);
-}
+static zend_always_inline void php_parallel_cond_destroy(pthread_cond_t *cond) { pthread_cond_destroy(cond); }
 
-static zend_always_inline void php_parallel_cond_destroy(pthread_cond_t *cond) {
-    pthread_cond_destroy(cond);
-}
-
-static zend_always_inline void php_parallel_atomic_addref(uint32_t *refcount) {
+static zend_always_inline void php_parallel_atomic_addref(uint32_t *refcount)
+{
 #ifdef _WIN32
-    InterlockedAdd(refcount, 1);
+	InterlockedAdd(refcount, 1);
 #elif defined(HAVE_BUILTIN_ATOMIC_CPP11)
-    __atomic_add_fetch(refcount, 1, __ATOMIC_SEQ_CST);
+	__atomic_add_fetch(refcount, 1, __ATOMIC_SEQ_CST);
 #else
-    __sync_add_and_fetch(refcount, 1);
+	__sync_add_and_fetch(refcount, 1);
 #endif
 }
 
-static zend_always_inline uint32_t php_parallel_atomic_delref(uint32_t *refcount) {
+static zend_always_inline uint32_t php_parallel_atomic_delref(uint32_t *refcount)
+{
 #ifdef _WIN32
-    return InterlockedAdd(refcount, -1);
+	return InterlockedAdd(refcount, -1);
 #elif defined(HAVE_BUILTIN_ATOMIC_CPP11)
-    return __atomic_sub_fetch(refcount, 1, __ATOMIC_SEQ_CST);
+	return __atomic_sub_fetch(refcount, 1, __ATOMIC_SEQ_CST);
 #else
-    return __sync_sub_and_fetch(refcount, 1);
+	return __sync_sub_and_fetch(refcount, 1);
 #endif
 }
 

--- a/src/poll.c
+++ b/src/poll.c
@@ -27,336 +27,295 @@
 #endif
 
 typedef struct _php_parallel_events_poll_t {
-    uint32_t       try;
-    struct timeval stop;
-    struct {
-        zend_fcall_info       fci;
-        zend_fcall_info_cache fcc;
-        zval                  ival;
-    } block;
-    php_parallel_events_state_t state;
+	uint32_t       try;
+	struct timeval stop;
+	struct {
+		zend_fcall_info       fci;
+		zend_fcall_info_cache fcc;
+		zval                  ival;
+	} block;
+	php_parallel_events_state_t state;
 } php_parallel_events_poll_t;
 
-static zend_always_inline php_parallel_events_poll_t* php_parallel_events_poll_init(php_parallel_events_t *events) {
-    if (events->targets.nNumUsed == 0) {
-        return NULL;
-    }
+static zend_always_inline php_parallel_events_poll_t *php_parallel_events_poll_init(php_parallel_events_t *events)
+{
+	if (events->targets.nNumUsed == 0) {
+		return NULL;
+	}
 
-    php_parallel_events_poll_t *poll = (php_parallel_events_poll_t*) 
-        pecalloc(1, sizeof(php_parallel_events_poll_t), 1);
+	php_parallel_events_poll_t *poll = (php_parallel_events_poll_t *)pecalloc(1, sizeof(php_parallel_events_poll_t), 1);
 
-    if (events->timeout > -1) {
-        if (gettimeofday(&poll->stop, NULL) == SUCCESS) {
-            poll->stop.tv_sec += (events->timeout / 1000000L);
-            poll->stop.tv_sec += (poll->stop.tv_usec + (events->timeout % 1000000L)) / 1000000L;
-            poll->stop.tv_usec = (poll->stop.tv_usec + (events->timeout % 1000000L)) % 1000000L;
-        }
-        /* return 0 ? */
-    }
+	if (events->timeout > -1) {
+		if (gettimeofday(&poll->stop, NULL) == SUCCESS) {
+			poll->stop.tv_sec += (events->timeout / 1000000L);
+			poll->stop.tv_sec += (poll->stop.tv_usec + (events->timeout % 1000000L)) / 1000000L;
+			poll->stop.tv_usec = (poll->stop.tv_usec + (events->timeout % 1000000L)) % 1000000L;
+		}
+		/* return 0 ? */
+	}
 
-    if (!Z_ISUNDEF(events->blocker)) {
-        zend_fcall_info_init(&events->blocker, 0, 
-            &poll->block.fci, &poll->block.fcc, NULL, NULL);
-        poll->block.fci.retval = &poll->block.ival;
-    } else {
-        memset(&poll->block, 0, sizeof(poll->block));
-    }
+	if (!Z_ISUNDEF(events->blocker)) {
+		zend_fcall_info_init(&events->blocker, 0, &poll->block.fci, &poll->block.fcc, NULL, NULL);
+		poll->block.fci.retval = &poll->block.ival;
+	} else {
+		memset(&poll->block, 0, sizeof(poll->block));
+	}
 
-    return poll;
+	return poll;
 }
 
-static zend_always_inline void php_parallel_events_poll_free(php_parallel_events_poll_t *poll) {
-    pefree(poll, 1);
+static zend_always_inline void php_parallel_events_poll_free(php_parallel_events_poll_t *poll) { pefree(poll, 1); }
+
+static zend_always_inline void php_parallel_events_poll_end(php_parallel_events_poll_t *poll)
+{
+	if (poll->state.type == PHP_PARALLEL_EVENTS_LINK) {
+		php_parallel_channel_t *channel = php_parallel_channel_fetch(poll->state.object);
+
+		php_parallel_link_unlock(channel->link);
+	} else {
+		php_parallel_future_t *future = php_parallel_future_fetch(poll->state.object);
+
+		php_parallel_future_unlock(future);
+	}
+
+	php_parallel_events_poll_free(poll);
 }
 
-static zend_always_inline void php_parallel_events_poll_end(php_parallel_events_poll_t *poll) {
-    if (poll->state.type == PHP_PARALLEL_EVENTS_LINK) {
-        php_parallel_channel_t *channel =
-            php_parallel_channel_fetch(
-                poll->state.object);
+static zend_always_inline bool php_parallel_events_poll_timeout(php_parallel_events_poll_t *poll,
+                                                                php_parallel_events_t      *events)
+{
+	struct timeval now;
 
-        php_parallel_link_unlock(channel->link);
-    } else {
-        php_parallel_future_t *future =
-            php_parallel_future_fetch(
-                poll->state.object);
-        
-        php_parallel_future_unlock(future);
-    }
+	if (events->timeout > -1 && gettimeofday(&now, NULL) == SUCCESS) {
+		if (now.tv_sec >= poll->stop.tv_sec && now.tv_usec >= poll->stop.tv_usec) {
+			php_parallel_exception_ex(php_parallel_events_error_timeout_ce, "timeout occured");
+			return 1;
+		}
+	}
 
-    php_parallel_events_poll_free(poll);
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_timeout(php_parallel_events_poll_t *poll, php_parallel_events_t *events) {
-    struct timeval now;
+static zend_always_inline bool php_parallel_events_poll_random(php_parallel_events_t *events, zend_string **name,
+                                                               zend_object **object)
+{
+	uint32_t  size = events->targets.nNumUsed;
+	zend_long random = php_mt_rand_range(0, (zend_long)size - 1);
 
-    if (events->timeout > -1 && gettimeofday(&now, NULL) == SUCCESS) {
-         if (now.tv_sec >= poll->stop.tv_sec &&
-             now.tv_usec >= poll->stop.tv_usec) {
-             php_parallel_exception_ex(
-                php_parallel_events_error_timeout_ce,
-                "timeout occured");
-            return 1;
-         }
-    }
+	do {
+		Bucket *bucket = &events->targets.arData[random];
 
-    return 0;
+		if (!Z_ISUNDEF(bucket->val)) {
+			*name = bucket->key;
+			*object = Z_OBJ(bucket->val);
+
+			return 1;
+		}
+
+		random = php_mt_rand_range(0, (zend_long)size - 1);
+	} while (1);
+
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_random(php_parallel_events_t *events, zend_string **name, zend_object **object) {
-    uint32_t  size = events->targets.nNumUsed;
-    zend_long random =
-        php_mt_rand_range(0, (zend_long) size - 1);
+static zend_always_inline bool php_parallel_events_poll_begin_link(php_parallel_events_t       *events,
+                                                                   php_parallel_events_state_t *state,
+                                                                   zend_string *name, zend_object *object)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(object);
 
-    do {
-        Bucket *bucket = &events->targets.arData[random];
+	php_parallel_link_lock(channel->link);
 
-        if (!Z_ISUNDEF(bucket->val)) {
-            *name   = bucket->key;
-            *object = Z_OBJ(bucket->val);
+	if (php_parallel_link_closed(channel->link)) {
+		state->closed = 1;
+	} else {
+		if (php_parallel_events_input_exists(&events->input, name)) {
+			state->writable = php_parallel_link_writable(channel->link);
+		} else {
+			state->readable = php_parallel_link_readable(channel->link);
+		}
+	}
 
-            return 1;
-        }
+	if (state->readable || state->writable || state->closed) {
+		state->type = PHP_PARALLEL_EVENTS_LINK;
+		state->name = name;
+		state->object = object;
 
-        random = php_mt_rand_range(0, (zend_long) size - 1);
-    } while(1);
+		return 1;
+	}
 
-    return 0;
+	php_parallel_link_unlock(channel->link);
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_begin_link(
-                                        php_parallel_events_t *events,
-                                        php_parallel_events_state_t *state,
-                                        zend_string *name,
-                                        zend_object *object) {
-    php_parallel_channel_t *channel =
-        php_parallel_channel_fetch(object);
+static zend_always_inline bool php_parallel_events_poll_begin_future(php_parallel_events_t       *events,
+                                                                     php_parallel_events_state_t *state,
+                                                                     zend_string *name, zend_object *object)
+{
+	php_parallel_future_t *future = php_parallel_future_fetch(object);
 
-    php_parallel_link_lock(channel->link);
+	php_parallel_future_lock(future);
 
-    if (php_parallel_link_closed(channel->link)) {
-        state->closed = 1;
-    } else {
-        if (php_parallel_events_input_exists(&events->input, name)) {
-            state->writable = php_parallel_link_writable(channel->link);
-        } else {
-            state->readable = php_parallel_link_readable(channel->link);
-        }
-    }
+	state->readable = php_parallel_future_readable(future);
 
-    if (state->readable || state->writable || state->closed) {
-        state->type     = PHP_PARALLEL_EVENTS_LINK;
-        state->name     = name;
-        state->object   = object;
+	if (state->readable) {
+		state->type = PHP_PARALLEL_EVENTS_FUTURE;
+		state->name = name;
+		state->object = object;
 
-        return 1;
-    }
+		return 1;
+	}
 
-    php_parallel_link_unlock(channel->link);
-    return 0;
+	php_parallel_future_unlock(future);
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_begin_future(
-                            php_parallel_events_t *events,
-                            php_parallel_events_state_t *state,
-                            zend_string *name,
-                            zend_object *object) {
-    php_parallel_future_t *future =
-        php_parallel_future_fetch(object);
+static zend_always_inline bool php_parallel_events_poll_begin(php_parallel_events_t       *events,
+                                                              php_parallel_events_state_t *state)
+{
+	zend_string *name;
+	zend_object *object;
 
-    php_parallel_future_lock(future);
+	if (!php_parallel_events_poll_random(events, &name, &object)) {
+		return 0;
+	}
 
-    state->readable = php_parallel_future_readable(future);
+	memset(state, 0, sizeof(php_parallel_events_state_t));
 
-    if (state->readable) {
-        state->type     = PHP_PARALLEL_EVENTS_FUTURE;
-        state->name     = name;
-        state->object   = object;
+	if (instanceof_function(object->ce, php_parallel_channel_ce)) {
+		return php_parallel_events_poll_begin_link(events, state, name, object);
+	} else {
+		return php_parallel_events_poll_begin_future(events, state, name, object);
+	}
 
-        return 1;
-    }
-
-    php_parallel_future_unlock(future);
-    return 0;
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_begin(php_parallel_events_t *events, php_parallel_events_state_t *state) {
-    zend_string *name;
-    zend_object *object;
+static zend_always_inline bool php_parallel_events_poll_link(php_parallel_events_t       *events,
+                                                             php_parallel_events_state_t *state, zval *retval)
+{
+	php_parallel_channel_t *channel = php_parallel_channel_fetch(state->object);
+	zval                   *input;
 
-    if (!php_parallel_events_poll_random(events, &name, &object)) {
-        return 0;
-    }
+	if (state->closed) {
+		php_parallel_events_event_construct(events, PHP_PARALLEL_EVENTS_EVENT_CLOSE, state->name, state->object, NULL,
+		                                    retval);
 
-    memset(state, 0, sizeof(php_parallel_events_state_t));
+		return 1;
+	} else {
+		if ((input = php_parallel_events_input_find(&events->input, state->name))) {
 
-    if (instanceof_function(object->ce, php_parallel_channel_ce)) {
-        return php_parallel_events_poll_begin_link(events, state, name, object);
-    } else {
-        return php_parallel_events_poll_begin_future(events, state, name, object);
-    }
+			if (state->writable) {
 
-    return 0;
+				if (php_parallel_link_send(channel->link, input)) {
+
+					php_parallel_events_event_construct(events, PHP_PARALLEL_EVENTS_EVENT_WRITE, state->name,
+					                                    state->object, NULL, retval);
+
+					return 1;
+				}
+			}
+		} else {
+			if (state->readable) {
+				zval read;
+
+				if (php_parallel_link_recv(channel->link, &read)) {
+
+					php_parallel_events_event_construct(events, PHP_PARALLEL_EVENTS_EVENT_READ, state->name,
+					                                    state->object, &read, retval);
+
+					return 1;
+				}
+			}
+		}
+	}
+
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_link(
-                            php_parallel_events_t *events,
-                            php_parallel_events_state_t *state,
-                            zval *retval) {
-    php_parallel_channel_t *channel =
-        php_parallel_channel_fetch(state->object);
-    zval *input;
+static zend_always_inline bool php_parallel_events_poll_future(php_parallel_events_t       *events,
+                                                               php_parallel_events_state_t *state, zval *retval)
+{
+	if (state->readable) {
+		zval                             read;
+		php_parallel_events_event_type_t type = PHP_PARALLEL_EVENTS_EVENT_READ;
+		php_parallel_future_t           *future = php_parallel_future_fetch(state->object);
 
-    if (state->closed) {
-        php_parallel_events_event_construct(
-            events,
-            PHP_PARALLEL_EVENTS_EVENT_CLOSE,
-            state->name,
-            state->object,
-            NULL,
-            retval);
+		ZVAL_NULL(&read);
 
-        return 1;
-    } else {
-        if ((input = php_parallel_events_input_find(&events->input, state->name))) {
+		if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
+			type = PHP_PARALLEL_EVENTS_EVENT_KILL;
+		} else if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
+			type = PHP_PARALLEL_EVENTS_EVENT_CANCEL;
+		} else {
+			if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_ERROR)) {
+				type = PHP_PARALLEL_EVENTS_EVENT_ERROR;
+			}
 
-            if (state->writable) {
+			php_parallel_future_value(future, &read);
+		}
 
-                if (php_parallel_link_send(channel->link, input)) {
+		php_parallel_events_event_construct(events, type, state->name, state->object, &read, retval);
 
-                    php_parallel_events_event_construct(
-                        events,
-                        PHP_PARALLEL_EVENTS_EVENT_WRITE,
-                        state->name,
-                        state->object,
-                        NULL,
-                        retval);
+		return 1;
+	}
 
-                    return 1;
-                }
-            }
-        } else {
-            if (state->readable) {
-                zval read;
-
-                if (php_parallel_link_recv(channel->link, &read)) {
-
-                    php_parallel_events_event_construct(
-                        events,
-                        PHP_PARALLEL_EVENTS_EVENT_READ,
-                        state->name,
-                        state->object,
-                        &read,
-                        retval);
-
-                    return 1;
-                }
-            }
-        }
-    }
-
-    return 0;
+	return 0;
 }
 
-static zend_always_inline bool php_parallel_events_poll_future(
-                            php_parallel_events_t *events,
-                            php_parallel_events_state_t *state,
-                            zval *retval) {
-    if (state->readable) {
-        zval read;
-        php_parallel_events_event_type_t type = PHP_PARALLEL_EVENTS_EVENT_READ;
-        php_parallel_future_t *future =
-            php_parallel_future_fetch(state->object);
+void php_parallel_events_poll(php_parallel_events_t *events, zval *retval)
+{
+	php_parallel_events_poll_t *poll;
 
-        ZVAL_NULL(&read);
+	if (!(poll = php_parallel_events_poll_init(events))) {
+		ZVAL_NULL(retval);
+		return;
+	}
 
-        if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_KILLED)) {
-            type = PHP_PARALLEL_EVENTS_EVENT_KILL;
-        } else if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
-            type = PHP_PARALLEL_EVENTS_EVENT_CANCEL;
-        } else {
-            if (php_parallel_monitor_check(future->monitor, PHP_PARALLEL_ERROR)) {
-                type = PHP_PARALLEL_EVENTS_EVENT_ERROR;
-            }
+	do {
+		if (!php_parallel_events_poll_begin(events, &poll->state)) {
+			if (!events->blocking) {
+				php_parallel_events_poll_free(poll);
+				return;
+			}
 
-            php_parallel_future_value(future, &read);
-        }
+			if (poll->block.fci.size) {
+				zend_call_function(&poll->block.fci, &poll->block.fcc);
 
-        php_parallel_events_event_construct(
-            events,
-            type,
-            state->name,
-            state->object,
-            &read,
-            retval);
+				if (zend_is_true(&poll->block.ival)) {
+					zval_ptr_dtor(&poll->block.ival);
+					php_parallel_events_poll_free(poll);
+					return;
+				}
 
-        return 1;
-    }
+				zval_ptr_dtor(&poll->block.ival);
+			} else {
+				if ((poll->try++ % 10) == 0) {
+					usleep(1);
+				}
+			}
 
-    return 0;
-}
+			if (php_parallel_events_poll_timeout(poll, events)) {
+				php_parallel_events_poll_free(poll);
+				return;
+			}
 
-void php_parallel_events_poll(php_parallel_events_t *events, zval *retval) {
-    php_parallel_events_poll_t  *poll;
+			continue;
+		}
 
-    if (!(poll = php_parallel_events_poll_init(events))) {
-        ZVAL_NULL(retval);
-        return;
-    }
+		if (poll->state.type == PHP_PARALLEL_EVENTS_LINK) {
+			if (php_parallel_events_poll_link(events, &poll->state, retval)) {
+				break;
+			}
+		} else {
+			if (php_parallel_events_poll_future(events, &poll->state, retval)) {
+				break;
+			}
+		}
 
-    do {
-        if (!php_parallel_events_poll_begin(events, &poll->state)) {
-            if (!events->blocking) {
-                php_parallel_events_poll_free(poll);
-                return;
-            }
+		php_parallel_events_poll_end(poll);
+	} while (1);
 
-            if (poll->block.fci.size) {
-                zend_call_function(
-                    &poll->block.fci, &poll->block.fcc);
-
-                if (zend_is_true(&poll->block.ival)) {
-                    zval_ptr_dtor(
-                        &poll->block.ival);
-                    php_parallel_events_poll_free(poll);
-                    return;
-                }
-
-                zval_ptr_dtor(
-                    &poll->block.ival);
-            } else {
-                if ((poll->try++ % 10) == 0) {
-                    usleep(1);
-                }
-            }
-
-            if (php_parallel_events_poll_timeout(poll, events)) {
-                php_parallel_events_poll_free(poll);
-                return;
-            }
-
-            continue;
-        }
-
-        if (poll->state.type == PHP_PARALLEL_EVENTS_LINK) {
-            if (php_parallel_events_poll_link(
-                    events,
-                    &poll->state,
-                    retval)) {
-                break;
-            }
-        } else {
-            if (php_parallel_events_poll_future(
-                    events,
-                    &poll->state,
-                    retval)) {
-                break;
-            }
-        }
-
-        php_parallel_events_poll_end(poll);
-    } while (1);
-
-    php_parallel_events_poll_end(poll);
+	php_parallel_events_poll_end(poll);
 }
 #endif

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -20,70 +20,68 @@
 
 #include "parallel.h"
 
-zend_class_entry *php_parallel_runtime_ce;
-zend_object_handlers php_parallel_runtime_handlers;
+zend_class_entry       *php_parallel_runtime_ce;
+zend_object_handlers    php_parallel_runtime_handlers;
 
-php_parallel_runtime_t* php_parallel_runtime_construct(zend_string *bootstrap) {
-    zval rt;
-    php_parallel_runtime_t *runtime;
+php_parallel_runtime_t *php_parallel_runtime_construct(zend_string *bootstrap)
+{
+	zval                    rt;
+	php_parallel_runtime_t *runtime;
 
-    object_init_ex(&rt, php_parallel_runtime_ce);
+	object_init_ex(&rt, php_parallel_runtime_ce);
 
-    runtime = 
-        php_parallel_runtime_from(&rt);
+	runtime = php_parallel_runtime_from(&rt);
 
-    php_parallel_scheduler_start(runtime, bootstrap);
+	php_parallel_scheduler_start(runtime, bootstrap);
 
-    if (!EG(exception)) {
-        return runtime;
-    }
+	if (!EG(exception)) {
+		return runtime;
+	}
 
-    zval_ptr_dtor(&rt);
-    return NULL;
+	zval_ptr_dtor(&rt);
+	return NULL;
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_runtime_construct_arginfo, 0, 0, 0)
-    ZEND_ARG_TYPE_INFO(0, bootstrap, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO(0, bootstrap, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Runtime, __construct)
 {
-    php_parallel_runtime_t *runtime = php_parallel_runtime_from(getThis());
-    zend_string            *bootstrap = NULL;
+	php_parallel_runtime_t *runtime = php_parallel_runtime_from(getThis());
+	zend_string            *bootstrap = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(0, 1)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_STR(bootstrap)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_STR(bootstrap)
+	ZEND_PARSE_PARAMETERS_END();
 
-    php_parallel_scheduler_start(runtime, bootstrap);
+	php_parallel_scheduler_start(runtime, bootstrap);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(php_parallel_runtime_run_arginfo, 0, 1, \\parallel\\Future, 1)
-    ZEND_ARG_OBJ_INFO(0, task, Closure, 0)
-    ZEND_ARG_TYPE_INFO(0, argv, IS_ARRAY, 0)
+ZEND_ARG_OBJ_INFO(0, task, Closure, 0)
+ZEND_ARG_TYPE_INFO(0, argv, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Runtime, run)
 {
-    php_parallel_runtime_t  *runtime = php_parallel_runtime_from(getThis());
-    zval *closure = NULL;
-    zval *argv = NULL;
+	php_parallel_runtime_t *runtime = php_parallel_runtime_from(getThis());
+	zval                   *closure = NULL;
+	zval                   *argv = NULL;
 
-    ZEND_PARSE_PARAMETERS_START(1, 2)
-        Z_PARAM_OBJECT_OF_CLASS(closure, zend_ce_closure)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_ARRAY(argv)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+	Z_PARAM_OBJECT_OF_CLASS(closure, zend_ce_closure)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_ARRAY(argv)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_closed_ce,
-            "Runtime closed");
-        return;
-    }
+	if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
+		php_parallel_exception_ex(php_parallel_runtime_error_closed_ce, "Runtime closed");
+		return;
+	}
 
-    php_parallel_scheduler_push(runtime, closure, argv, return_value);
+	php_parallel_scheduler_push(runtime, closure, argv, return_value);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_runtime_close_or_kill_arginfo, 0, 0, IS_VOID, 0)
@@ -91,91 +89,87 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Runtime, close)
 {
-    php_parallel_runtime_t *runtime =
-        php_parallel_runtime_from(getThis());
+	php_parallel_runtime_t *runtime = php_parallel_runtime_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    php_parallel_scheduler_join(runtime, 0);
+	php_parallel_scheduler_join(runtime, 0);
 }
 
 PHP_METHOD(Parallel_Runtime, kill)
 {
-    php_parallel_runtime_t *runtime =
-        php_parallel_runtime_from(getThis());
+	php_parallel_runtime_t *runtime = php_parallel_runtime_from(getThis());
 
-    PARALLEL_PARAMETERS_NONE(return);
+	PARALLEL_PARAMETERS_NONE(return);
 
-    php_parallel_scheduler_join(runtime, 1);
+	php_parallel_scheduler_join(runtime, 1);
 }
 
 zend_function_entry php_parallel_runtime_methods[] = {
     PHP_ME(Parallel_Runtime, __construct, php_parallel_runtime_construct_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Runtime, run, php_parallel_runtime_run_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Runtime, close, php_parallel_runtime_close_or_kill_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Runtime, kill, php_parallel_runtime_close_or_kill_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+        PHP_ME(Parallel_Runtime, run, php_parallel_runtime_run_arginfo, ZEND_ACC_PUBLIC)
+            PHP_ME(Parallel_Runtime, close, php_parallel_runtime_close_or_kill_arginfo, ZEND_ACC_PUBLIC)
+                PHP_ME(Parallel_Runtime, kill, php_parallel_runtime_close_or_kill_arginfo, ZEND_ACC_PUBLIC) PHP_FE_END};
 
-zend_object* php_parallel_runtime_create(zend_class_entry *type) {
-    php_parallel_runtime_t *runtime = ecalloc(1,
-            sizeof(php_parallel_runtime_t) + zend_object_properties_size(type));
+zend_object *php_parallel_runtime_create(zend_class_entry *type)
+{
+	php_parallel_runtime_t *runtime = ecalloc(1, sizeof(php_parallel_runtime_t) + zend_object_properties_size(type));
 
-    zend_object_std_init(&runtime->std, type);
+	zend_object_std_init(&runtime->std, type);
 
-    runtime->std.handlers = &php_parallel_runtime_handlers;
+	runtime->std.handlers = &php_parallel_runtime_handlers;
 
-    php_parallel_scheduler_init(runtime);
+	php_parallel_scheduler_init(runtime);
 
-    runtime->parent.server = SG(server_context);
-    runtime->parent.argc = SG(request_info).argc;
-    runtime->parent.argv = SG(request_info).argv;
+	runtime->parent.server = SG(server_context);
+	runtime->parent.argc = SG(request_info).argc;
+	runtime->parent.argv = SG(request_info).argv;
 
-    return &runtime->std;
+	return &runtime->std;
 }
 
-void php_parallel_runtime_destroy(zend_object *o) {
-    php_parallel_runtime_t *runtime =
-        php_parallel_runtime_fetch(o);
+void php_parallel_runtime_destroy(zend_object *o)
+{
+	php_parallel_runtime_t *runtime = php_parallel_runtime_fetch(o);
 
-    php_parallel_scheduler_stop(runtime);
+	php_parallel_scheduler_stop(runtime);
 
-    php_parallel_scheduler_destroy(runtime);
+	php_parallel_scheduler_destroy(runtime);
 
-    zend_object_std_dtor(o);
+	zend_object_std_dtor(o);
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_RUNTIME)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(&php_parallel_runtime_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
+	memcpy(&php_parallel_runtime_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_runtime_handlers.offset = XtOffsetOf(php_parallel_runtime_t, std);
-    php_parallel_runtime_handlers.free_obj = php_parallel_runtime_destroy;
+	php_parallel_runtime_handlers.offset = XtOffsetOf(php_parallel_runtime_t, std);
+	php_parallel_runtime_handlers.free_obj = php_parallel_runtime_destroy;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Runtime", php_parallel_runtime_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Runtime", php_parallel_runtime_methods);
 
-    php_parallel_runtime_ce = zend_register_internal_class(&ce);
-    php_parallel_runtime_ce->create_object = php_parallel_runtime_create;
-    php_parallel_runtime_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_runtime_ce = zend_register_internal_class(&ce);
+	php_parallel_runtime_ce->create_object = php_parallel_runtime_create;
+	php_parallel_runtime_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_runtime_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_runtime_ce->serialize = zend_class_serialize_deny;
-        php_parallel_runtime_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_runtime_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_runtime_ce->serialize = zend_class_serialize_deny;
+	php_parallel_runtime_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    PHP_MINIT(PARALLEL_FUTURE)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_FUTURE)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_RUNTIME)
 {
-    PHP_MSHUTDOWN(PARALLEL_FUTURE)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_FUTURE)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -19,37 +19,39 @@
 #define HAVE_PARALLEL_RUNTIME_H
 
 #if PHP_VERSION_ID < 80200
-# define zend_atomic_bool bool
-# define zend_atomic_bool_store(dest, value) (*(dest) = value)
+#define zend_atomic_bool bool
+#define zend_atomic_bool_store(dest, value) (*(dest) = value)
 #endif
 
 typedef struct _php_parallel_runtime_t {
-    pthread_t                        thread;
-    php_parallel_monitor_t          *monitor;
-    zend_string                     *bootstrap;
-    struct {
-        zend_atomic_bool                   *interrupt;
-    } child;
-    struct {
-        void                        *server;
-        int                          argc;
-        char                       **argv;
-    } parent;
-    zend_llist                       schedule;
-    zend_object                      std;
+	pthread_t               thread;
+	php_parallel_monitor_t *monitor;
+	zend_string            *bootstrap;
+	struct {
+		zend_atomic_bool *interrupt;
+	} child;
+	struct {
+		void  *server;
+		int    argc;
+		char **argv;
+	} parent;
+	zend_llist  schedule;
+	zend_object std;
 } php_parallel_runtime_t;
 
-static zend_always_inline php_parallel_runtime_t* php_parallel_runtime_fetch(zend_object *o) {
-    return (php_parallel_runtime_t*) (((char*) o) - XtOffsetOf(php_parallel_runtime_t, std));
+static zend_always_inline php_parallel_runtime_t *php_parallel_runtime_fetch(zend_object *o)
+{
+	return (php_parallel_runtime_t *)(((char *)o) - XtOffsetOf(php_parallel_runtime_t, std));
 }
 
-static zend_always_inline php_parallel_runtime_t* php_parallel_runtime_from(zval *z) {
-    return php_parallel_runtime_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_runtime_t *php_parallel_runtime_from(zval *z)
+{
+	return php_parallel_runtime_fetch(Z_OBJ_P(z));
 }
 
-extern zend_class_entry* php_parallel_runtime_ce;
+extern zend_class_entry *php_parallel_runtime_ce;
 
-php_parallel_runtime_t* php_parallel_runtime_construct(zend_string *bootstrap);
+php_parallel_runtime_t  *php_parallel_runtime_construct(zend_string *bootstrap);
 
 PHP_MINIT_FUNCTION(PARALLEL_RUNTIME);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_RUNTIME);

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -18,721 +18,677 @@
 #ifndef HAVE_PARALLEL_SCHEDULER
 #define HAVE_PARALLEL_SCHEDULER
 
-#include "parallel.h"
 #include "../php_parallel.h"
+#include "parallel.h"
 #include "zend_types.h"
 
-TSRM_TLS php_parallel_runtime_t* php_parallel_scheduler_context = NULL;
-TSRM_TLS php_parallel_future_t* php_parallel_scheduler_future = NULL;
+TSRM_TLS php_parallel_runtime_t *php_parallel_scheduler_context = NULL;
+TSRM_TLS php_parallel_future_t  *php_parallel_scheduler_future = NULL;
 
-void (*zend_interrupt_handler)(zend_execute_data*) = NULL;
+void (*zend_interrupt_handler)(zend_execute_data *) = NULL;
 
-static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void *rhs) {
-    return lhs == rhs;
-}
+static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void *rhs) { return lhs == rhs; }
 
-static void php_parallel_schedule_free_function(zend_function *function) {
-    if (function->op_array.static_variables) {
-        php_parallel_copy_hash_dtor(function->op_array.static_variables, 1);
-        ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
-        function->op_array.static_variables = NULL;
-    }
+static void                   php_parallel_schedule_free_function(zend_function *function)
+{
+	if (function->op_array.static_variables) {
+		php_parallel_copy_hash_dtor(function->op_array.static_variables, 1);
+		ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
+		function->op_array.static_variables = NULL;
+	}
 
 #if PHP_VERSION_ID >= 80100
-    if (function->op_array.num_dynamic_func_defs) {
-        uint32_t it = 0;
+	if (function->op_array.num_dynamic_func_defs) {
+		uint32_t it = 0;
 
-        while (it < function->op_array.num_dynamic_func_defs) {
-            php_parallel_schedule_free_function(
-                (zend_function*) function->op_array.dynamic_func_defs[it]);
-            it++;
-        }
-    }
+		while (it < function->op_array.num_dynamic_func_defs) {
+			php_parallel_schedule_free_function((zend_function *)function->op_array.dynamic_func_defs[it]);
+			it++;
+		}
+	}
 #endif
 }
 
-static void php_parallel_schedule_free(void *scheduleed) {
-    php_parallel_schedule_el_t *el =
-        (php_parallel_schedule_el_t*) scheduleed;
-    zval *slot = (zval*) ZEND_CALL_ARG(el->frame, 1),
-         *end = slot + ZEND_CALL_NUM_ARGS(el->frame);
+static void php_parallel_schedule_free(void *scheduleed)
+{
+	php_parallel_schedule_el_t *el = (php_parallel_schedule_el_t *)scheduleed;
+	zval                       *slot = (zval *)ZEND_CALL_ARG(el->frame, 1), *end = slot + ZEND_CALL_NUM_ARGS(el->frame);
 
-    while (slot < end) {
-        PARALLEL_ZVAL_DTOR(slot);
-        slot++;
-    }
+	while (slot < end) {
+		PARALLEL_ZVAL_DTOR(slot);
+		slot++;
+	}
 
-    if (el->frame->func) {
-        php_parallel_schedule_free_function(
-            el->frame->func);
-        pefree(el->frame->func, 1);
-    }
+	if (el->frame->func) {
+		php_parallel_schedule_free_function(el->frame->func);
+		pefree(el->frame->func, 1);
+	}
 
-    pefree(el->frame, 1);
+	pefree(el->frame, 1);
 }
 
-void php_parallel_scheduler_init(php_parallel_runtime_t *runtime) {
-    zend_llist_init(&runtime->schedule, sizeof(php_parallel_schedule_el_t), php_parallel_schedule_free, 1);
+void php_parallel_scheduler_init(php_parallel_runtime_t *runtime)
+{
+	zend_llist_init(&runtime->schedule, sizeof(php_parallel_schedule_el_t), php_parallel_schedule_free, 1);
 }
 
-void php_parallel_scheduler_destroy(php_parallel_runtime_t *runtime) {
-    zend_llist_destroy(&runtime->schedule);
-}
+void php_parallel_scheduler_destroy(php_parallel_runtime_t *runtime) { zend_llist_destroy(&runtime->schedule); }
 
-static zend_always_inline php_parallel_runtime_t* php_parallel_scheduler_setup(php_parallel_runtime_t *runtime) {
-    php_parallel_scheduler_context = runtime;
+static zend_always_inline php_parallel_runtime_t *php_parallel_scheduler_setup(php_parallel_runtime_t *runtime)
+{
+	php_parallel_scheduler_context = runtime;
 
-    ts_resource(0);
+	ts_resource(0);
 
-    TSRMLS_CACHE_UPDATE();
+	TSRMLS_CACHE_UPDATE();
 
-    SG(server_context) = runtime->parent.server;
-    SG(request_info).argc = runtime->parent.argc;
-    SG(request_info).argv = runtime->parent.argv;
+	SG(server_context) = runtime->parent.server;
+	SG(request_info).argc = runtime->parent.argc;
+	SG(request_info).argv = runtime->parent.argv;
 
-    runtime->child.interrupt = &EG(vm_interrupt);
+	runtime->child.interrupt = &EG(vm_interrupt);
 
-    PG(expose_php)       = 0;
-    PG(auto_globals_jit) = 1;
+	PG(expose_php) = 0;
+	PG(auto_globals_jit) = 1;
 #if PHP_VERSION_ID >= 80100
-    PG(enable_dl)        = false;
+	PG(enable_dl) = false;
 #else
-    PG(enable_dl)        = 0;
+	PG(enable_dl) = 0;
 #endif
 
-    php_request_startup();
+	php_request_startup();
 
-    PG(during_request_startup)  = 0;
-    SG(sapi_started)            = 0;
-    SG(headers_sent)            = 1;
-    SG(request_info).no_headers = 1;
+	PG(during_request_startup) = 0;
+	SG(sapi_started) = 0;
+	SG(headers_sent) = 1;
+	SG(request_info).no_headers = 1;
 
-    return runtime;
+	return runtime;
 }
 
-static zend_always_inline void php_parallel_scheduler_exit(php_parallel_runtime_t *runtime) {
-    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE);
+static zend_always_inline void php_parallel_scheduler_exit(php_parallel_runtime_t *runtime)
+{
+	php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE);
 
-    php_request_shutdown(NULL);
+	php_request_shutdown(NULL);
 
-    ts_free_thread();
+	ts_free_thread();
 
-    pthread_exit(NULL);
+	pthread_exit(NULL);
 }
 
-static zend_always_inline void php_parallel_scheduler_add(
-            php_parallel_runtime_t *runtime,
-            const zend_function *function,
-            zval *argv,
-            php_parallel_future_t *future) {
-    php_parallel_schedule_el_t el;
-    uint32_t argc = argv && Z_TYPE_P(argv) == IS_ARRAY ?
-                        zend_hash_num_elements(Z_ARRVAL_P(argv)) : 0;
+static zend_always_inline void php_parallel_scheduler_add(php_parallel_runtime_t *runtime,
+                                                          const zend_function *function, zval *argv,
+                                                          php_parallel_future_t *future)
+{
+	php_parallel_schedule_el_t el;
+	uint32_t                   argc = argv && Z_TYPE_P(argv) == IS_ARRAY ? zend_hash_num_elements(Z_ARRVAL_P(argv)) : 0;
 
-    zend_execute_data *frame =
-        (zend_execute_data*)
-            pecalloc(1, zend_vm_calc_used_stack(argc, (zend_function*) function), 1);
+	zend_execute_data         *frame =
+	    (zend_execute_data *)pecalloc(1, zend_vm_calc_used_stack(argc, (zend_function *)function), 1);
 
-    frame->func =
-        php_parallel_cache_closure(function, NULL);
+	frame->func = php_parallel_cache_closure(function, NULL);
 
-    php_parallel_dependencies_store(frame->func);
+	php_parallel_dependencies_store(frame->func);
 
-    if (argv && Z_TYPE_P(argv) == IS_ARRAY) {
-        zval *slot = ZEND_CALL_ARG(frame, 1);
-        zval *param;
-        uint32_t argc = 0;
-        php_parallel_copy_context_t *context, *restore;
+	if (argv && Z_TYPE_P(argv) == IS_ARRAY) {
+		zval                        *slot = ZEND_CALL_ARG(frame, 1);
+		zval                        *param;
+		uint32_t                     argc = 0;
+		php_parallel_copy_context_t *context, *restore;
 
-        context = php_parallel_copy_context_start(
-            PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
-            &restore);
+		context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_PERSISTENT, &restore);
 
-        ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(argv), param) {
-            PARALLEL_ZVAL_COPY(slot, param, 1);
-            slot++;
-            argc++;
-        } ZEND_HASH_FOREACH_END();
+		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(argv), param)
+		{
+			PARALLEL_ZVAL_COPY(slot, param, 1);
+			slot++;
+			argc++;
+		}
+		ZEND_HASH_FOREACH_END();
 
-        ZEND_CALL_NUM_ARGS(frame) = argc;
+		ZEND_CALL_NUM_ARGS(frame) = argc;
 
-        php_parallel_copy_context_end(context, restore);
-    } else {
-        ZEND_CALL_NUM_ARGS(frame) = 0;
-    }
+		php_parallel_copy_context_end(context, restore);
+	} else {
+		ZEND_CALL_NUM_ARGS(frame) = 0;
+	}
 
-    if (future) {
-        frame->return_value =
-                &future->value;
-        Z_PTR(frame->This) =
-                future;
-    }
+	if (future) {
+		frame->return_value = &future->value;
+		Z_PTR(frame->This) = future;
+	}
 
-    el.frame   = frame;
+	el.frame = frame;
 
-    zend_llist_add_element(&runtime->schedule, &el);
+	zend_llist_add_element(&runtime->schedule, &el);
 
-    if (future) {
-        future->runtime = runtime;
-        future->handle =
-            runtime->schedule.tail->data;
-        GC_ADDREF(&runtime->std);
-    }
+	if (future) {
+		future->runtime = runtime;
+		future->handle = runtime->schedule.tail->data;
+		GC_ADDREF(&runtime->std);
+	}
 }
 
-static zend_always_inline bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime) {
-    return !zend_llist_count(&runtime->schedule);
+static zend_always_inline bool php_parallel_scheduler_empty(php_parallel_runtime_t *runtime)
+{
+	return !zend_llist_count(&runtime->schedule);
 }
 
-bool php_parallel_scheduler_busy(php_parallel_runtime_t *runtime) {
-    bool busy = 1;
+bool php_parallel_scheduler_busy(php_parallel_runtime_t *runtime)
+{
+	bool busy = 1;
 
-    php_parallel_monitor_lock(runtime->monitor);
-    if (php_parallel_scheduler_empty(runtime)) {
-        if (!php_parallel_monitor_check(
-                runtime->monitor, PHP_PARALLEL_RUNNING)) {
-            busy = 0;
-        }
-    }
-    php_parallel_monitor_unlock(runtime->monitor);
+	php_parallel_monitor_lock(runtime->monitor);
+	if (php_parallel_scheduler_empty(runtime)) {
+		if (!php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_RUNNING)) {
+			busy = 0;
+		}
+	}
+	php_parallel_monitor_unlock(runtime->monitor);
 
-    return busy;
+	return busy;
 }
 
-static void php_parallel_scheduler_pull(zend_function *function) {
-    if (function->op_array.static_variables) {
-        HashTable *statics =
-            function->op_array.static_variables;
+static void php_parallel_scheduler_pull(zend_function *function)
+{
+	if (function->op_array.static_variables) {
+		HashTable *statics = function->op_array.static_variables;
 
-        function->op_array.static_variables =
-            php_parallel_copy_hash_ctor(statics, 0);
+		function->op_array.static_variables = php_parallel_copy_hash_ctor(statics, 0);
 
 #if PHP_VERSION_ID >= 80200
-        ZEND_MAP_PTR_INIT(
-            function->op_array.static_variables_ptr,
-            function->op_array.static_variables);
+		ZEND_MAP_PTR_INIT(function->op_array.static_variables_ptr, function->op_array.static_variables);
 #else
-        ZEND_MAP_PTR_INIT(
-            function->op_array.static_variables_ptr,
-            &function->op_array.static_variables);
+		ZEND_MAP_PTR_INIT(function->op_array.static_variables_ptr, &function->op_array.static_variables);
 #endif
 
-        if (GC_FLAGS(statics) & IS_ARRAY_PERSISTENT) {
-            php_parallel_copy_hash_dtor(statics, 1);
-        }
-    }
+		if (GC_FLAGS(statics) & IS_ARRAY_PERSISTENT) {
+			php_parallel_copy_hash_dtor(statics, 1);
+		}
+	}
 
 #if PHP_VERSION_ID < 80200
-    ZEND_MAP_PTR_NEW(function->op_array.run_time_cache);
+	ZEND_MAP_PTR_NEW(function->op_array.run_time_cache);
 #else
-    ZEND_MAP_PTR_INIT(function->op_array.run_time_cache, NULL);
+	ZEND_MAP_PTR_INIT(function->op_array.run_time_cache, NULL);
 #endif
 
 #if PHP_VERSION_ID >= 80100
-    if (function->op_array.num_dynamic_func_defs) {
-    	uint32_t it = 0;
+	if (function->op_array.num_dynamic_func_defs) {
+		uint32_t it = 0;
 
-    	while (it < function->op_array.num_dynamic_func_defs) {
-    	    php_parallel_scheduler_pull(
-               (zend_function*) function->op_array.dynamic_func_defs[it]);
-            it++;
-    	}
-    }
+		while (it < function->op_array.num_dynamic_func_defs) {
+			php_parallel_scheduler_pull((zend_function *)function->op_array.dynamic_func_defs[it]);
+			it++;
+		}
+	}
 #endif
 }
 
-static void php_parallel_scheduler_clean(zend_function *function) {
-    if (function->op_array.static_variables) {
-        HashTable *statics =
-            ZEND_MAP_PTR_GET(
-                function->op_array.static_variables_ptr);
+static void php_parallel_scheduler_clean(zend_function *function)
+{
+	if (function->op_array.static_variables) {
+		HashTable *statics = ZEND_MAP_PTR_GET(function->op_array.static_variables_ptr);
 
-        if (!(GC_FLAGS(statics) & IS_ARRAY_IMMUTABLE)) {
-            zend_array_destroy(statics);
-            ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
-            function->op_array.static_variables = NULL;
-        }
-    }
+		if (!(GC_FLAGS(statics) & IS_ARRAY_IMMUTABLE)) {
+			zend_array_destroy(statics);
+			ZEND_MAP_PTR_SET(function->op_array.static_variables_ptr, NULL);
+			function->op_array.static_variables = NULL;
+		}
+	}
 
 #if PHP_VERSION_ID >= 80100
-    if (function->op_array.num_dynamic_func_defs) {
-    	uint32_t it = 0;
+	if (function->op_array.num_dynamic_func_defs) {
+		uint32_t it = 0;
 
-    	while (it < function->op_array.num_dynamic_func_defs) {
-    	    php_parallel_scheduler_clean(
-              (zend_function*) function->op_array.dynamic_func_defs[it]);
-          pefree(function->op_array.dynamic_func_defs[it], 1);
-          it++;
-    	}
-        /* Free the dynamic_func_defs array itself */
-        pefree(function->op_array.dynamic_func_defs, 1);
-        function->op_array.dynamic_func_defs = NULL;
-    }
+		while (it < function->op_array.num_dynamic_func_defs) {
+			php_parallel_scheduler_clean((zend_function *)function->op_array.dynamic_func_defs[it]);
+			pefree(function->op_array.dynamic_func_defs[it], 1);
+			it++;
+		}
+		/* Free the dynamic_func_defs array itself */
+		pefree(function->op_array.dynamic_func_defs, 1);
+		function->op_array.dynamic_func_defs = NULL;
+	}
 #endif
 }
 
-static zend_always_inline bool php_parallel_scheduler_pop(php_parallel_runtime_t *runtime, php_parallel_schedule_el_t *el) {
-    php_parallel_schedule_el_t *head;
-    zend_class_entry *scope = NULL;
-    zend_function    *function = NULL;
+static zend_always_inline bool php_parallel_scheduler_pop(php_parallel_runtime_t     *runtime,
+                                                          php_parallel_schedule_el_t *el)
+{
+	php_parallel_schedule_el_t *head;
+	zend_class_entry           *scope = NULL;
+	zend_function              *function = NULL;
 
-    if (zend_llist_count(&runtime->schedule) == 0) {
-        return 0;
-    }
+	if (zend_llist_count(&runtime->schedule) == 0) {
+		return 0;
+	}
 
-    head = zend_llist_get_first(&runtime->schedule);
-    function =
-        head->frame->func;
-    head->frame->func = NULL;
+	head = zend_llist_get_first(&runtime->schedule);
+	function = head->frame->func;
+	head->frame->func = NULL;
 
-    if (function->op_array.scope &&
-        function->op_array.scope->type == ZEND_USER_CLASS) {
-        scope =
-            php_parallel_copy_scope(
-                function->op_array.scope);
-    }
+	if (function->op_array.scope && function->op_array.scope->type == ZEND_USER_CLASS) {
+		scope = php_parallel_copy_scope(function->op_array.scope);
+	}
 
-    el->frame = zend_vm_stack_push_call_frame(
-        ZEND_CALL_TOP_FUNCTION,
-        php_parallel_copy_function(function, 0),
-        ZEND_CALL_NUM_ARGS(head->frame),
-        scope);
+	el->frame = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION, php_parallel_copy_function(function, 0),
+	                                          ZEND_CALL_NUM_ARGS(head->frame), scope);
 
-    if (scope != function->op_array.scope) {
-        el->frame->func->op_array.scope = scope;
-    }
+	if (scope != function->op_array.scope) {
+		el->frame->func->op_array.scope = scope;
+	}
 
-    php_parallel_scheduler_pull(el->frame->func);
+	php_parallel_scheduler_pull(el->frame->func);
 
-    if (ZEND_CALL_NUM_ARGS(head->frame)) {
-        zval *slot = (zval*) ZEND_CALL_ARG(head->frame, 1),
-             *end  = slot + ZEND_CALL_NUM_ARGS(head->frame);
-        zval *param = ZEND_CALL_ARG(el->frame, 1);
+	if (ZEND_CALL_NUM_ARGS(head->frame)) {
+		zval *slot = (zval *)ZEND_CALL_ARG(head->frame, 1), *end = slot + ZEND_CALL_NUM_ARGS(head->frame);
+		zval *param = ZEND_CALL_ARG(el->frame, 1);
 
-        php_parallel_copy_context_t *context, *restore;
+		php_parallel_copy_context_t *context, *restore;
 
-        context = php_parallel_copy_context_start(
-            PHP_PARALLEL_COPY_DIRECTION_THREAD,
-            &restore);
+		context = php_parallel_copy_context_start(PHP_PARALLEL_COPY_DIRECTION_THREAD, &restore);
 
-        while (slot < end) {
-            PARALLEL_ZVAL_COPY(param, slot, 0);
-            slot++;
-            param++;
-        }
+		while (slot < end) {
+			PARALLEL_ZVAL_COPY(param, slot, 0);
+			slot++;
+			param++;
+		}
 
-        php_parallel_copy_context_end(context, restore);
-    }
+		php_parallel_copy_context_end(context, restore);
+	}
 
-    zend_init_func_execute_data(
-        el->frame,
-        &el->frame->func->op_array,
-        head->frame->return_value);
+	zend_init_func_execute_data(el->frame, &el->frame->func->op_array, head->frame->return_value);
 
-    php_parallel_scheduler_future = Z_PTR(head->frame->This);
+	php_parallel_scheduler_future = Z_PTR(head->frame->This);
 
-    zend_llist_del_element(
-        &runtime->schedule,
-        head,
-        php_parallel_scheduler_list_delete);
+	zend_llist_del_element(&runtime->schedule, head, php_parallel_scheduler_list_delete);
 
-    return 1;
+	return 1;
 }
 
-static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_execute_data *frame) {
-    php_parallel_future_t *future = php_parallel_scheduler_future;
+static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_execute_data *frame)
+{
+	php_parallel_future_t *future = php_parallel_scheduler_future;
 
-    zend_first_try {
-        zend_try {
-            zend_execute_ex(frame);
+	zend_first_try
+	{
+		zend_try
+		{
+			zend_execute_ex(frame);
 
-            if (UNEXPECTED(EG(exception))) {
-                if (future) {
-                    php_parallel_exceptions_save(
-                        frame->return_value, EG(exception));
+			if (UNEXPECTED(EG(exception))) {
+				if (future) {
+					php_parallel_exceptions_save(frame->return_value, EG(exception));
 
-                    php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
-                } else {
-                    zend_throw_exception_internal(NULL);
-                }
-            }
-        } zend_catch {
-            if (future) {
-                php_parallel_monitor_lock(future->monitor);
-                if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
-                    php_parallel_monitor_set(future->monitor, PHP_PARALLEL_KILLED);
-                }
-                php_parallel_monitor_unlock(future->monitor);
-            }
-        } zend_end_try();
+					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+				} else {
+					zend_throw_exception_internal(NULL);
+				}
+			}
+		}
+		zend_catch
+		{
+			if (future) {
+				php_parallel_monitor_lock(future->monitor);
+				if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
+					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_KILLED);
+				}
+				php_parallel_monitor_unlock(future->monitor);
+			}
+		}
+		zend_end_try();
 
-         if (frame->return_value  && !Z_ISUNDEF_P(frame->return_value)) {
-            zval garbage = *frame->return_value;
+		if (frame->return_value && !Z_ISUNDEF_P(frame->return_value)) {
+			zval garbage = *frame->return_value;
 
-            if (Z_OPT_REFCOUNTED(garbage)) {
-                PARALLEL_ZVAL_COPY(
-                    frame->return_value, &garbage, 1);
+			if (Z_OPT_REFCOUNTED(garbage)) {
+				PARALLEL_ZVAL_COPY(frame->return_value, &garbage, 1);
 
-                zval_ptr_dtor(&garbage);
-            }
-        }
+				zval_ptr_dtor(&garbage);
+			}
+		}
 
-        php_parallel_scheduler_clean(frame->func);
+		php_parallel_scheduler_clean(frame->func);
 
-        pefree(frame->func, 1);
+		pefree(frame->func, 1);
 
-        zend_vm_stack_free_call_frame(frame);
-    } zend_end_try ();
+		zend_vm_stack_free_call_frame(frame);
+	}
+	zend_end_try();
 
-    if (future) {
-        php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
-    }
+	if (future) {
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
+	}
 
-    php_parallel_scheduler_future = NULL;
+	php_parallel_scheduler_future = NULL;
 }
 
-static void php_parallel_scheduler_killed(void *scheduled) {
-    php_parallel_schedule_el_t *el =
-        (php_parallel_schedule_el_t*) scheduled;
-    php_parallel_future_t *future = Z_PTR(el->frame->This);
+static void php_parallel_scheduler_killed(void *scheduled)
+{
+	php_parallel_schedule_el_t *el = (php_parallel_schedule_el_t *)scheduled;
+	php_parallel_future_t      *future = Z_PTR(el->frame->This);
 
-    if (future) {
-        php_parallel_monitor_set(future->monitor,
-            PHP_PARALLEL_READY|PHP_PARALLEL_KILLED);
-    }
+	if (future) {
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_KILLED);
+	}
 }
 
-static zend_always_inline void php_parallel_scheduler_kill(php_parallel_runtime_t *runtime) {
-    zend_llist_apply(&runtime->schedule, php_parallel_scheduler_killed);
-    zend_llist_clean(&runtime->schedule);
+static zend_always_inline void php_parallel_scheduler_kill(php_parallel_runtime_t *runtime)
+{
+	zend_llist_apply(&runtime->schedule, php_parallel_scheduler_killed);
+	zend_llist_clean(&runtime->schedule);
 }
 
-static zend_always_inline int php_parallel_thread_bootstrap(zend_string *file) {
-    zend_file_handle fh;
-    zend_op_array *ops;
-    zval rv;
-    int result;
+static zend_always_inline int php_parallel_thread_bootstrap(zend_string *file)
+{
+	zend_file_handle fh;
+	zend_op_array   *ops;
+	zval             rv;
+	int              result;
 
-    if (!file) {
-        return SUCCESS;
-    }
+	if (!file) {
+		return SUCCESS;
+	}
 
 #if PHP_VERSION_ID >= 80100
-    zend_stream_init_filename_ex(&fh, file);
+	zend_stream_init_filename_ex(&fh, file);
 
-    result = php_stream_open_for_zend_ex(&fh, USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE);
+	result = php_stream_open_for_zend_ex(&fh, USE_PATH | REPORT_ERRORS | STREAM_OPEN_FOR_INCLUDE);
 #else
-    result = php_stream_open_for_zend_ex(ZSTR_VAL(file), &fh, USE_PATH|REPORT_ERRORS|STREAM_OPEN_FOR_INCLUDE);
+	result = php_stream_open_for_zend_ex(ZSTR_VAL(file), &fh, USE_PATH | REPORT_ERRORS | STREAM_OPEN_FOR_INCLUDE);
 #endif
 
-    if (result != SUCCESS) {
-        return FAILURE;
-    }
+	if (result != SUCCESS) {
+		return FAILURE;
+	}
 
-    zend_hash_add_empty_element(&EG(included_files),
-                                    fh.opened_path ?
-                                        fh.opened_path : file);
+	zend_hash_add_empty_element(&EG(included_files), fh.opened_path ? fh.opened_path : file);
 
-    ops = zend_compile_file(&fh, ZEND_REQUIRE);
+	ops = zend_compile_file(&fh, ZEND_REQUIRE);
 
-    zend_destroy_file_handle(&fh);
+	zend_destroy_file_handle(&fh);
 
-    if (ops) {
-        ZVAL_UNDEF(&rv);
-        zend_execute(ops, &rv);
-        destroy_op_array(ops);
-        efree(ops);
+	if (ops) {
+		ZVAL_UNDEF(&rv);
+		zend_execute(ops, &rv);
+		destroy_op_array(ops);
+		efree(ops);
 
-        if (EG(exception)) {
-            zend_clear_exception();
-            return FAILURE;
-        }
+		if (EG(exception)) {
+			zend_clear_exception();
+			return FAILURE;
+		}
 
-        zval_ptr_dtor(&rv);
-        return SUCCESS;
-    }
+		zval_ptr_dtor(&rv);
+		return SUCCESS;
+	}
 
-    if (EG(exception)) {
-        zend_clear_exception();
-    }
+	if (EG(exception)) {
+		zend_clear_exception();
+	}
 
-    return FAILURE;
+	return FAILURE;
 }
 
 // Implements the thread main loop. This bootstraps the thread by including the
 // bootstrap PHP file in case one was specified and afterwards set the runtimes
 // monitor to ready and running (and with this unblocking the calling
 // `php_parallel_scheduler_start()` function).
-static void* php_parallel_thread(void *arg) {
-    int32_t state = 0;
+static void *php_parallel_thread(void *arg)
+{
+	int32_t                 state = 0;
 
-    php_parallel_runtime_t *runtime =
-        php_parallel_scheduler_setup(
-            (php_parallel_runtime_t*) arg);
+	php_parallel_runtime_t *runtime = php_parallel_scheduler_setup((php_parallel_runtime_t *)arg);
 
-    if (php_parallel_thread_bootstrap(runtime->bootstrap) != SUCCESS) {
-        php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_FAILURE);
+	if (php_parallel_thread_bootstrap(runtime->bootstrap) != SUCCESS) {
+		php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_FAILURE);
 
-        goto _php_parallel_thread_exit;
-    }
+		goto _php_parallel_thread_exit;
+	}
 
-    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_READY|PHP_PARALLEL_RUNNING);
+	php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_RUNNING);
 
-    do {
-        php_parallel_schedule_el_t el;
+	do {
+		php_parallel_schedule_el_t el;
 
-        if (php_parallel_monitor_lock(runtime->monitor) != SUCCESS) {
-            break;
-        }
+		if (php_parallel_monitor_lock(runtime->monitor) != SUCCESS) {
+			break;
+		}
 
-        if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_KILLED)) {
-_php_parallel_thread_killed:
-            php_parallel_scheduler_kill(runtime);
+		if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_KILLED)) {
+		_php_parallel_thread_killed:
+			php_parallel_scheduler_kill(runtime);
 
-            php_parallel_monitor_unlock(runtime->monitor);
-            goto _php_parallel_thread_exit;
-        }
+			php_parallel_monitor_unlock(runtime->monitor);
+			goto _php_parallel_thread_exit;
+		}
 
-        while (!php_parallel_scheduler_pop(runtime, &el)) {
-            php_parallel_monitor_remove(runtime->monitor, PHP_PARALLEL_RUNNING);
+		while (!php_parallel_scheduler_pop(runtime, &el)) {
+			php_parallel_monitor_remove(runtime->monitor, PHP_PARALLEL_RUNNING);
 
-            if (!(state & PHP_PARALLEL_CLOSE)) {
-                state = php_parallel_monitor_wait_locked(
-                        runtime->monitor,
-                        PHP_PARALLEL_EXEC|PHP_PARALLEL_CLOSE|PHP_PARALLEL_KILLED);
-            }
+			if (!(state & PHP_PARALLEL_CLOSE)) {
+				state = php_parallel_monitor_wait_locked(runtime->monitor,
+				                                         PHP_PARALLEL_EXEC | PHP_PARALLEL_CLOSE | PHP_PARALLEL_KILLED);
+			}
 
-            if ((state & (PHP_PARALLEL_CLOSE|PHP_PARALLEL_KILLED))) {
-                if ((state & PHP_PARALLEL_KILLED)) {
-                    goto _php_parallel_thread_killed;
-                }
+			if ((state & (PHP_PARALLEL_CLOSE | PHP_PARALLEL_KILLED))) {
+				if ((state & PHP_PARALLEL_KILLED)) {
+					goto _php_parallel_thread_killed;
+				}
 
-                if (php_parallel_scheduler_empty(runtime)) {
-                    php_parallel_monitor_unlock(runtime->monitor);
-                    goto _php_parallel_thread_exit;
-                }
-            }
-        }
+				if (php_parallel_scheduler_empty(runtime)) {
+					php_parallel_monitor_unlock(runtime->monitor);
+					goto _php_parallel_thread_exit;
+				}
+			}
+		}
 
-        php_parallel_monitor_add(runtime->monitor, PHP_PARALLEL_RUNNING);
+		php_parallel_monitor_add(runtime->monitor, PHP_PARALLEL_RUNNING);
 
-        php_parallel_monitor_unlock(runtime->monitor);
+		php_parallel_monitor_unlock(runtime->monitor);
 
-        php_parallel_scheduler_run(runtime, el.frame);
-    } while (1);
+		php_parallel_scheduler_run(runtime, el.frame);
+	} while (1);
 
 _php_parallel_thread_exit:
-    php_parallel_scheduler_exit(runtime);
+	php_parallel_scheduler_exit(runtime);
 
-    return NULL;
+	return NULL;
 }
 
 // Creates a monitor for the `runtime` and spawns a new thread. After spawning
 // blocks until the newly created thread enters either the ready or the failure
 // state. Throws a userland exception in case the thread creation failed.
-void php_parallel_scheduler_start(php_parallel_runtime_t *runtime, zend_string *bootstrap) {
-    uint32_t state = SUCCESS;
+void php_parallel_scheduler_start(php_parallel_runtime_t *runtime, zend_string *bootstrap)
+{
+	uint32_t state = SUCCESS;
 
-    if (bootstrap) {
-        runtime->bootstrap = php_parallel_copy_string_interned(bootstrap);
-    }
+	if (bootstrap) {
+		runtime->bootstrap = php_parallel_copy_string_interned(bootstrap);
+	}
 
-    runtime->monitor = php_parallel_monitor_create();
+	runtime->monitor = php_parallel_monitor_create();
 
-    if (pthread_create(&runtime->thread, NULL, php_parallel_thread, runtime) != SUCCESS) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_ce,
-            "cannot create thread %s", strerror(errno));
-        php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_FAILURE);
-        php_parallel_scheduler_stop(runtime);
-        return;
-    }
+	if (pthread_create(&runtime->thread, NULL, php_parallel_thread, runtime) != SUCCESS) {
+		php_parallel_exception_ex(php_parallel_runtime_error_ce, "cannot create thread %s", strerror(errno));
+		php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_FAILURE);
+		php_parallel_scheduler_stop(runtime);
+		return;
+	}
 
-    state = php_parallel_monitor_wait(runtime->monitor, PHP_PARALLEL_READY|PHP_PARALLEL_FAILURE);
+	state = php_parallel_monitor_wait(runtime->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_FAILURE);
 
-    if ((state == FAILURE) || (state & PHP_PARALLEL_FAILURE)) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_bootstrap_ce,
-            "bootstrapping failed with %s", ZSTR_VAL(runtime->bootstrap));
-        php_parallel_scheduler_stop(runtime);
-    }
+	if ((state == FAILURE) || (state & PHP_PARALLEL_FAILURE)) {
+		php_parallel_exception_ex(php_parallel_runtime_error_bootstrap_ce, "bootstrapping failed with %s",
+		                          ZSTR_VAL(runtime->bootstrap));
+		php_parallel_scheduler_stop(runtime);
+	}
 }
 
-void php_parallel_scheduler_stop(php_parallel_runtime_t *runtime) {
-    if (!runtime->monitor) {
-        return;
-    }
+void php_parallel_scheduler_stop(php_parallel_runtime_t *runtime)
+{
+	if (!runtime->monitor) {
+		return;
+	}
 
-    php_parallel_monitor_lock(runtime->monitor);
+	php_parallel_monitor_lock(runtime->monitor);
 
-    if (!php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
-        php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSE);
+	if (!php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
+		php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSE);
 
-        if (!php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_FAILURE)) {
-            php_parallel_monitor_wait_locked(
-                runtime->monitor,
-                PHP_PARALLEL_DONE);
-        }
+		if (!php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_FAILURE)) {
+			php_parallel_monitor_wait_locked(runtime->monitor, PHP_PARALLEL_DONE);
+		}
 
-        php_parallel_monitor_unlock(runtime->monitor);
+		php_parallel_monitor_unlock(runtime->monitor);
 
-        pthread_join(runtime->thread, NULL);
-    } else {
-        php_parallel_monitor_unlock(runtime->monitor);
-    }
+		pthread_join(runtime->thread, NULL);
+	} else {
+		php_parallel_monitor_unlock(runtime->monitor);
+	}
 
-    php_parallel_monitor_destroy(runtime->monitor);
+	php_parallel_monitor_destroy(runtime->monitor);
 
-    runtime->monitor = NULL;
+	runtime->monitor = NULL;
 }
 
 /// Adds the task in `closure` to the thread referenced by `runtime`. In case
 /// the task returns anything it also creates the future to return.
-void php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value) {
-    zend_execute_data      *caller = EG(current_execute_data)->prev_execute_data;
-    const zend_function    *function = zend_get_closure_method_def(Z_OBJ_P(closure));
-    bool               returns = 0;
-    php_parallel_future_t  *future = NULL;
+void php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value)
+{
+	zend_execute_data     *caller = EG(current_execute_data)->prev_execute_data;
+	const zend_function   *function = zend_get_closure_method_def(Z_OBJ_P(closure));
+	bool                   returns = 0;
+	php_parallel_future_t *future = NULL;
 
-    php_parallel_monitor_lock(runtime->monitor);
+	php_parallel_monitor_lock(runtime->monitor);
 
-    if (!php_parallel_check_task(runtime, caller, function, argv, &returns)) {
-        php_parallel_monitor_unlock(runtime->monitor);
-        return;
-    }
+	if (!php_parallel_check_task(runtime, caller, function, argv, &returns)) {
+		php_parallel_monitor_unlock(runtime->monitor);
+		return;
+	}
 
-    if (returns) {
-        future = php_parallel_future_construct(return_value);
-    }
+	if (returns) {
+		future = php_parallel_future_construct(return_value);
+	}
 
-    php_parallel_scheduler_add(runtime, function, argv, future);
+	php_parallel_scheduler_add(runtime, function, argv, future);
 
-    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_EXEC);
-    php_parallel_monitor_unlock(runtime->monitor);
+	php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_EXEC);
+	php_parallel_monitor_unlock(runtime->monitor);
 }
 
-void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill) {
-    php_parallel_monitor_lock(runtime->monitor);
+void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill)
+{
+	php_parallel_monitor_lock(runtime->monitor);
 
-    if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
-        php_parallel_exception_ex(
-            php_parallel_runtime_error_closed_ce,
-            "Runtime closed");
-        php_parallel_monitor_unlock(runtime->monitor);
-        return;
-    }
+	if (php_parallel_monitor_check(runtime->monitor, PHP_PARALLEL_CLOSED)) {
+		php_parallel_exception_ex(php_parallel_runtime_error_closed_ce, "Runtime closed");
+		php_parallel_monitor_unlock(runtime->monitor);
+		return;
+	}
 
-    if (kill){
-        php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_KILLED);
+	if (kill) {
+		php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_KILLED);
 
-        zend_atomic_bool_store(runtime->child.interrupt, true);
-    } else {
-        php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSE);
-    }
+		zend_atomic_bool_store(runtime->child.interrupt, true);
+	} else {
+		php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSE);
+	}
 
-    php_parallel_monitor_wait_locked(runtime->monitor, PHP_PARALLEL_DONE);
+	php_parallel_monitor_wait_locked(runtime->monitor, PHP_PARALLEL_DONE);
 
-    php_parallel_monitor_unlock(runtime->monitor);
+	php_parallel_monitor_unlock(runtime->monitor);
 
-    php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSED);
+	php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_CLOSED);
 
-    pthread_join(runtime->thread, NULL);
+	pthread_join(runtime->thread, NULL);
 }
 
-bool php_parallel_scheduler_cancel(php_parallel_future_t *future) {
-    size_t in, out = 0;
+bool php_parallel_scheduler_cancel(php_parallel_future_t *future)
+{
+	size_t in, out = 0;
 
-    php_parallel_monitor_lock(future->runtime->monitor);
+	php_parallel_monitor_lock(future->runtime->monitor);
 
-    in = zend_llist_count(&future->runtime->schedule);
+	in = zend_llist_count(&future->runtime->schedule);
 
-    zend_llist_del_element(
-        &future->runtime->schedule,
-        future->handle,
-        php_parallel_scheduler_list_delete);
+	zend_llist_del_element(&future->runtime->schedule, future->handle, php_parallel_scheduler_list_delete);
 
-    out = zend_llist_count(&future->runtime->schedule);
+	out = zend_llist_count(&future->runtime->schedule);
 
-    php_parallel_monitor_unlock(future->runtime->monitor);
+	php_parallel_monitor_unlock(future->runtime->monitor);
 
-    if (in == out) {
-        bool cancelled = 0;
+	if (in == out) {
+		bool cancelled = 0;
 
-        php_parallel_monitor_lock(future->monitor);
+		php_parallel_monitor_lock(future->monitor);
 
-        if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY)) {
-            zend_atomic_bool_store(future->runtime->child.interrupt, true);
+		if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_READY)) {
+			zend_atomic_bool_store(future->runtime->child.interrupt, true);
 
-            php_parallel_monitor_set(future->monitor, PHP_PARALLEL_CANCELLED);
-            php_parallel_monitor_wait_locked(future->monitor, PHP_PARALLEL_READY);
-            php_parallel_monitor_set(future->monitor,
-                PHP_PARALLEL_READY|PHP_PARALLEL_DONE);
+			php_parallel_monitor_set(future->monitor, PHP_PARALLEL_CANCELLED);
+			php_parallel_monitor_wait_locked(future->monitor, PHP_PARALLEL_READY);
+			php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_DONE);
 
-            cancelled = 1;
-        }
+			cancelled = 1;
+		}
 
-        php_parallel_monitor_unlock(future->monitor);
+		php_parallel_monitor_unlock(future->monitor);
 
-        return cancelled;
-    } else {
-        php_parallel_monitor_set(future->monitor,
-            PHP_PARALLEL_READY|
-            PHP_PARALLEL_DONE|
-            PHP_PARALLEL_CANCELLED);
+		return cancelled;
+	} else {
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_DONE | PHP_PARALLEL_CANCELLED);
 
-        return 1;
-    }
+		return 1;
+	}
 }
 
-PARALLEL_API bool php_parallel_is_parallel_worker_thread(void) {
-    return php_parallel_scheduler_context != NULL;
-}
+PARALLEL_API bool php_parallel_is_parallel_worker_thread(void) { return php_parallel_scheduler_context != NULL; }
 
-static void php_parallel_scheduler_interrupt(zend_execute_data *execute_data) {
-    if (php_parallel_scheduler_context) {
-        php_parallel_monitor_lock(php_parallel_scheduler_context->monitor);
-        if (php_parallel_monitor_check(
-            php_parallel_scheduler_context->monitor,
-            PHP_PARALLEL_KILLED)) {
-            php_parallel_monitor_unlock(php_parallel_scheduler_context->monitor);
-            zend_bailout();
-        }
-        php_parallel_monitor_unlock(php_parallel_scheduler_context->monitor);
+static void       php_parallel_scheduler_interrupt(zend_execute_data *execute_data)
+{
+	if (php_parallel_scheduler_context) {
+		php_parallel_monitor_lock(php_parallel_scheduler_context->monitor);
+		if (php_parallel_monitor_check(php_parallel_scheduler_context->monitor, PHP_PARALLEL_KILLED)) {
+			php_parallel_monitor_unlock(php_parallel_scheduler_context->monitor);
+			zend_bailout();
+		}
+		php_parallel_monitor_unlock(php_parallel_scheduler_context->monitor);
 
-        if (php_parallel_scheduler_future) {
-            php_parallel_monitor_lock(php_parallel_scheduler_future->monitor);
-            if (php_parallel_monitor_check(
-                php_parallel_scheduler_future->monitor,
-                PHP_PARALLEL_CANCELLED)) {
-                php_parallel_monitor_unlock(
-                    php_parallel_scheduler_future->monitor);
-                zend_bailout();
-            }
-            php_parallel_monitor_unlock(php_parallel_scheduler_future->monitor);
-        }
-    }
+		if (php_parallel_scheduler_future) {
+			php_parallel_monitor_lock(php_parallel_scheduler_future->monitor);
+			if (php_parallel_monitor_check(php_parallel_scheduler_future->monitor, PHP_PARALLEL_CANCELLED)) {
+				php_parallel_monitor_unlock(php_parallel_scheduler_future->monitor);
+				zend_bailout();
+			}
+			php_parallel_monitor_unlock(php_parallel_scheduler_future->monitor);
+		}
+	}
 
-    if (zend_interrupt_handler) {
-        zend_interrupt_handler(execute_data);
-    }
+	if (zend_interrupt_handler) {
+		zend_interrupt_handler(execute_data);
+	}
 }
 
 PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER)
 {
-    zend_interrupt_handler = zend_interrupt_function;
-    zend_interrupt_function = php_parallel_scheduler_interrupt;
+	zend_interrupt_handler = zend_interrupt_function;
+	zend_interrupt_function = php_parallel_scheduler_interrupt;
 
-    PHP_MINIT(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MINIT(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SCHEDULER)
 {
-    zend_interrupt_function = zend_interrupt_handler;
+	zend_interrupt_function = zend_interrupt_handler;
 
-    PHP_MSHUTDOWN(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
+	PHP_MSHUTDOWN(PARALLEL_RUNTIME)(INIT_FUNC_ARGS_PASSTHRU);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 #endif

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -19,18 +19,18 @@
 #define HAVE_PARALLEL_SCHEDULER_H
 
 typedef struct _php_parallel_schedule_el_t {
-    zend_execute_data          *frame;
+	zend_execute_data *frame;
 } php_parallel_schedule_el_t;
 
-void               php_parallel_scheduler_init(php_parallel_runtime_t *runtime);
-void               php_parallel_scheduler_start(php_parallel_runtime_t *runtime, zend_string *bootstrap);
-void               php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value);
-void               php_parallel_scheduler_stop(php_parallel_runtime_t *runtime);
-void               php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill);
-bool          php_parallel_scheduler_busy(php_parallel_runtime_t *runtime);
-void               php_parallel_scheduler_destroy(php_parallel_runtime_t *runtime);
+void php_parallel_scheduler_init(php_parallel_runtime_t *runtime);
+void php_parallel_scheduler_start(php_parallel_runtime_t *runtime, zend_string *bootstrap);
+void php_parallel_scheduler_push(php_parallel_runtime_t *runtime, zval *closure, zval *argv, zval *return_value);
+void php_parallel_scheduler_stop(php_parallel_runtime_t *runtime);
+void php_parallel_scheduler_join(php_parallel_runtime_t *runtime, bool kill);
+bool php_parallel_scheduler_busy(php_parallel_runtime_t *runtime);
+void php_parallel_scheduler_destroy(php_parallel_runtime_t *runtime);
 
-bool          php_parallel_scheduler_cancel(php_parallel_future_t *future);
+bool php_parallel_scheduler_cancel(php_parallel_future_t *future);
 
 PHP_MINIT_FUNCTION(PARALLEL_SCHEDULER);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SCHEDULER);

--- a/src/sync.c
+++ b/src/sync.c
@@ -20,180 +20,170 @@
 
 #include "parallel.h"
 
-zend_class_entry *php_parallel_sync_ce;
+zend_class_entry    *php_parallel_sync_ce;
 zend_object_handlers php_parallel_sync_handlers;
 
-static zend_string *php_parallel_sync_string_value;
+static zend_string  *php_parallel_sync_string_value;
 
-#define PARALLEL_SYNC_IS_SCALAR(zv) \
-    ((Z_TYPE_P(zv) != IS_OBJECT) && \
-     (Z_TYPE_P(zv) != IS_ARRAY) && \
-     (Z_TYPE_P(zv) != IS_RESOURCE))
+#define PARALLEL_SYNC_IS_SCALAR(zv)                                                                                    \
+	((Z_TYPE_P(zv) != IS_OBJECT) && (Z_TYPE_P(zv) != IS_ARRAY) && (Z_TYPE_P(zv) != IS_RESOURCE))
 
-static zend_always_inline php_parallel_sync_t* php_parallel_sync_fetch(zend_object *o) {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_fetch(o);
+static zend_always_inline php_parallel_sync_t *php_parallel_sync_fetch(zend_object *o)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(o);
 
-    return object->sync;
+	return object->sync;
 }
 
-static zend_always_inline php_parallel_sync_t* php_parallel_sync_from(zval *z) {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_from(z);
+static zend_always_inline php_parallel_sync_t *php_parallel_sync_from(zval *z)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(z);
 
-    return object->sync;
+	return object->sync;
 }
 
-static zend_always_inline php_parallel_sync_t* php_parallel_sync_create(zval *zv) {
-    php_parallel_sync_t *sync =
-        (php_parallel_sync_t*) pecalloc(1, sizeof(php_parallel_sync_t), 1);
+static zend_always_inline php_parallel_sync_t *php_parallel_sync_create(zval *zv)
+{
+	php_parallel_sync_t *sync = (php_parallel_sync_t *)pecalloc(1, sizeof(php_parallel_sync_t), 1);
 
-    php_parallel_mutex_init(&sync->mutex, 1);
-    php_parallel_cond_init(&sync->condition);
+	php_parallel_mutex_init(&sync->mutex, 1);
+	php_parallel_cond_init(&sync->condition);
 
-    if (zv) {
-        PARALLEL_ZVAL_COPY(
-            &sync->value, zv, 1);
-    }
+	if (zv) {
+		PARALLEL_ZVAL_COPY(&sync->value, zv, 1);
+	}
 
-    sync->refcount = 1;
+	sync->refcount = 1;
 
-    return sync;
+	return sync;
 }
 
-php_parallel_sync_t* php_parallel_sync_copy(php_parallel_sync_t *sync) {
-    php_parallel_atomic_addref(&sync->refcount);
+php_parallel_sync_t *php_parallel_sync_copy(php_parallel_sync_t *sync)
+{
+	php_parallel_atomic_addref(&sync->refcount);
 
-    return sync;
+	return sync;
 }
 
-void php_parallel_sync_release(php_parallel_sync_t *sync) {
-    if (!sync) {
-        return;
-    }
+void php_parallel_sync_release(php_parallel_sync_t *sync)
+{
+	if (!sync) {
+		return;
+	}
 
-    if (php_parallel_atomic_delref(&sync->refcount) == 0) {
-        if (Z_TYPE(sync->value) == IS_STRING) {
-            PARALLEL_ZVAL_DTOR(&sync->value);
-        }
+	if (php_parallel_atomic_delref(&sync->refcount) == 0) {
+		if (Z_TYPE(sync->value) == IS_STRING) {
+			PARALLEL_ZVAL_DTOR(&sync->value);
+		}
 
-        php_parallel_mutex_destroy(&sync->mutex);
-        php_parallel_cond_destroy(&sync->condition);
-        pefree(sync, 1);
-    }
+		php_parallel_mutex_destroy(&sync->mutex);
+		php_parallel_cond_destroy(&sync->condition);
+		pefree(sync, 1);
+	}
 }
 
-static zend_object* php_parallel_sync_object_create(zend_class_entry *ce) {
-    php_parallel_sync_object_t *object =
-        (php_parallel_sync_object_t*)
-            ecalloc(1, sizeof(php_parallel_sync_object_t) + zend_object_properties_size(ce));
+static zend_object *php_parallel_sync_object_create(zend_class_entry *ce)
+{
+	php_parallel_sync_object_t *object =
+	    (php_parallel_sync_object_t *)ecalloc(1, sizeof(php_parallel_sync_object_t) + zend_object_properties_size(ce));
 
-    zend_object_std_init(&object->std, ce);
+	zend_object_std_init(&object->std, ce);
 
-    object->std.handlers = &php_parallel_sync_handlers;
+	object->std.handlers = &php_parallel_sync_handlers;
 
-    return &object->std;
+	return &object->std;
 }
 
-static void php_parallel_sync_object_destroy(zend_object *o) {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_fetch(o);
+static void php_parallel_sync_object_destroy(zend_object *o)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(o);
 
-    php_parallel_sync_release(object->sync);
+	php_parallel_sync_release(object->sync);
 
-    zend_object_std_dtor(o);
+	zend_object_std_dtor(o);
 }
 
-static HashTable* php_parallel_sync_object_debug(zend_object *o, int *temp) {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_fetch(o);
-    HashTable *debug;
-    zval zv;
+static HashTable *php_parallel_sync_object_debug(zend_object *o, int *temp)
+{
+	php_parallel_sync_object_t *object = php_parallel_sync_object_fetch(o);
+	HashTable                  *debug;
+	zval                        zv;
 
-    *temp = 1;
+	*temp = 1;
 
-    pthread_mutex_lock(&object->sync->mutex);
+	pthread_mutex_lock(&object->sync->mutex);
 
-    ALLOC_HASHTABLE(debug);
-    zend_hash_init(debug, 1, NULL, ZVAL_PTR_DTOR, 0);
+	ALLOC_HASHTABLE(debug);
+	zend_hash_init(debug, 1, NULL, ZVAL_PTR_DTOR, 0);
 
-    if (!Z_ISUNDEF(object->sync->value)) {
-        PARALLEL_ZVAL_COPY(
-            &zv, &object->sync->value, 0);
+	if (!Z_ISUNDEF(object->sync->value)) {
+		PARALLEL_ZVAL_COPY(&zv, &object->sync->value, 0);
 
-        zend_hash_add(debug, php_parallel_sync_string_value, &zv);
-    }
+		zend_hash_add(debug, php_parallel_sync_string_value, &zv);
+	}
 
-    pthread_mutex_unlock(&object->sync->mutex);
+	pthread_mutex_unlock(&object->sync->mutex);
 
-    return debug;
+	return debug;
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_sync_construct_arginfo, 0, 0, 0)
-    ZEND_ARG_INFO(0, value)
+ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, __construct)
 {
-    php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
-    zval *value = NULL;
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
+	zval                       *value = NULL;
 
-    if (ZEND_NUM_ARGS()) {
-      ZEND_PARSE_PARAMETERS_START(0, 1)
-          Z_PARAM_OPTIONAL
-          Z_PARAM_ZVAL(value)
-      ZEND_PARSE_PARAMETERS_END();
-    }
+	if (ZEND_NUM_ARGS()) {
+		ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(value)
+		ZEND_PARSE_PARAMETERS_END();
+	}
 
-    if (value) {
-        if (!PARALLEL_SYNC_IS_SCALAR(value)) {
-            php_parallel_exception_ex(
-                php_parallel_sync_error_illegal_value_ce,
-                "sync cannot contain non-scalar %s",
-                Z_TYPE_P(value) == IS_OBJECT ?
-                    ZSTR_VAL(Z_OBJCE_P(value)->name) :
-                    zend_get_type_by_const(Z_TYPE_P(value)));
-            return;
-        }
-    }
+	if (value) {
+		if (!PARALLEL_SYNC_IS_SCALAR(value)) {
+			php_parallel_exception_ex(php_parallel_sync_error_illegal_value_ce, "sync cannot contain non-scalar %s",
+			                          Z_TYPE_P(value) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(value)->name)
+			                                                       : zend_get_type_by_const(Z_TYPE_P(value)));
+			return;
+		}
+	}
 
-    object->sync = php_parallel_sync_create(value);
+	object->sync = php_parallel_sync_create(value);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_sync_set_arginfo, 0, 0, 1)
-    ZEND_ARG_INFO(0, value)
+ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, set)
 {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_from(getThis());
-    zval *value;
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
+	zval                       *value;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ZVAL(value)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
 
-    if (!PARALLEL_SYNC_IS_SCALAR(value)) {
-        php_parallel_exception_ex(
-            php_parallel_sync_error_illegal_value_ce,
-            "sync cannot contain non-scalar %s",
-            Z_TYPE_P(value) == IS_OBJECT ?
-                ZSTR_VAL(Z_OBJCE_P(value)->name) :
-                zend_get_type_by_const(Z_TYPE_P(value)));
-        return;
-    }
+	if (!PARALLEL_SYNC_IS_SCALAR(value)) {
+		php_parallel_exception_ex(php_parallel_sync_error_illegal_value_ce, "sync cannot contain non-scalar %s",
+		                          Z_TYPE_P(value) == IS_OBJECT ? ZSTR_VAL(Z_OBJCE_P(value)->name)
+		                                                       : zend_get_type_by_const(Z_TYPE_P(value)));
+		return;
+	}
 
-    pthread_mutex_lock(&object->sync->mutex);
+	pthread_mutex_lock(&object->sync->mutex);
 
-    if (Z_TYPE(object->sync->value) == IS_STRING) {
-        PARALLEL_ZVAL_DTOR(&object->sync->value);
-    }
+	if (Z_TYPE(object->sync->value) == IS_STRING) {
+		PARALLEL_ZVAL_DTOR(&object->sync->value);
+	}
 
-    PARALLEL_ZVAL_COPY(
-        &object->sync->value, value, 1);
+	PARALLEL_ZVAL_COPY(&object->sync->value, value, 1);
 
-    pthread_mutex_unlock(&object->sync->mutex);
+	pthread_mutex_unlock(&object->sync->mutex);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_sync_get_arginfo, 0, 0, 0)
@@ -201,42 +191,39 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, get)
 {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_from(getThis());
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
 
-    pthread_mutex_lock(&object->sync->mutex);
+	pthread_mutex_lock(&object->sync->mutex);
 
-    if (Z_TYPE(object->sync->value) != IS_UNDEF) {
-        PARALLEL_ZVAL_COPY(
-          return_value, &object->sync->value, 0);
-    }
+	if (Z_TYPE(object->sync->value) != IS_UNDEF) {
+		PARALLEL_ZVAL_COPY(return_value, &object->sync->value, 0);
+	}
 
-    pthread_mutex_unlock(&object->sync->mutex);
+	pthread_mutex_unlock(&object->sync->mutex);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(php_parallel_sync_invoke_arginfo, 0, 0, 1)
-    ZEND_ARG_TYPE_INFO(0, block, IS_CALLABLE, 0)
+ZEND_ARG_TYPE_INFO(0, block, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, __invoke)
 {
-    php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
-    zend_fcall_info fci;
-    zend_fcall_info_cache fcc;
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
+	zend_fcall_info             fci;
+	zend_fcall_info_cache       fcc;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_FUNC(fci, fcc)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+	Z_PARAM_FUNC(fci, fcc)
+	ZEND_PARSE_PARAMETERS_END();
 
-    pthread_mutex_lock(&object->sync->mutex);
+	pthread_mutex_lock(&object->sync->mutex);
 
-    fci.retval = return_value;
+	fci.retval = return_value;
 
-    zend_try {
-        zend_call_function(&fci, &fcc);
-    } zend_end_try();
+	zend_try { zend_call_function(&fci, &fcc); }
+	zend_end_try();
 
-    pthread_mutex_unlock(&object->sync->mutex);
+	pthread_mutex_unlock(&object->sync->mutex);
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_sync_wait_arginfo, 0, 0, _IS_BOOL, 0)
@@ -244,88 +231,79 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, wait)
 {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_from(getThis());
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
 
-    switch (pthread_cond_wait(&object->sync->condition, &object->sync->mutex)) {
-        case SUCCESS:
-            RETURN_TRUE;
+	switch (pthread_cond_wait(&object->sync->condition, &object->sync->mutex)) {
+	case SUCCESS:
+		RETURN_TRUE;
 
-        /* LCOV_EXCL_START */
-        default:
-            RETURN_FALSE;
-        /* LCOV_EXCL_STOP */
-    }
+	/* LCOV_EXCL_START */
+	default:
+		RETURN_FALSE;
+		/* LCOV_EXCL_STOP */
+	}
 }
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(php_parallel_sync_notify_arginfo, 0, 0, _IS_BOOL, 0)
-    ZEND_ARG_TYPE_INFO(0, all, _IS_BOOL, 0)
+ZEND_ARG_TYPE_INFO(0, all, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Parallel_Sync, notify)
 {
-    php_parallel_sync_object_t *object =
-        php_parallel_sync_object_from(getThis());
-    bool all = 0;
+	php_parallel_sync_object_t *object = php_parallel_sync_object_from(getThis());
+	bool                        all = 0;
 
-    ZEND_PARSE_PARAMETERS_START(0, 1)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_BOOL(all)
-    ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+	Z_PARAM_OPTIONAL
+	Z_PARAM_BOOL(all)
+	ZEND_PARSE_PARAMETERS_END();
 
-    switch (all ?
-        pthread_cond_broadcast(&object->sync->condition) :
-        pthread_cond_signal(&object->sync->condition)) {
-        case SUCCESS:
-            RETURN_TRUE;
+	switch (all ? pthread_cond_broadcast(&object->sync->condition) : pthread_cond_signal(&object->sync->condition)) {
+	case SUCCESS:
+		RETURN_TRUE;
 
-        /* LCOV_EXCL_START */
-        default:
-            RETURN_FALSE;
-        /* LCOV_EXCL_STOP */
-    }
+	/* LCOV_EXCL_START */
+	default:
+		RETURN_FALSE;
+		/* LCOV_EXCL_STOP */
+	}
 }
 
 static zend_function_entry php_parallel_sync_methods[] = {
     PHP_ME(Parallel_Sync, __construct, php_parallel_sync_construct_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Sync, set, php_parallel_sync_set_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Sync, get, php_parallel_sync_get_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Sync, wait, php_parallel_sync_wait_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Sync, notify, php_parallel_sync_notify_arginfo, ZEND_ACC_PUBLIC)
-    PHP_ME(Parallel_Sync, __invoke,    php_parallel_sync_invoke_arginfo, ZEND_ACC_PUBLIC)
-    PHP_FE_END
-};
+        PHP_ME(Parallel_Sync, set, php_parallel_sync_set_arginfo, ZEND_ACC_PUBLIC)
+            PHP_ME(Parallel_Sync, get, php_parallel_sync_get_arginfo, ZEND_ACC_PUBLIC)
+                PHP_ME(Parallel_Sync, wait, php_parallel_sync_wait_arginfo, ZEND_ACC_PUBLIC)
+                    PHP_ME(Parallel_Sync, notify, php_parallel_sync_notify_arginfo, ZEND_ACC_PUBLIC)
+                        PHP_ME(Parallel_Sync, __invoke, php_parallel_sync_invoke_arginfo, ZEND_ACC_PUBLIC) PHP_FE_END};
 
 PHP_MINIT_FUNCTION(PARALLEL_SYNC)
 {
-    zend_class_entry ce;
+	zend_class_entry ce;
 
-    memcpy(&php_parallel_sync_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
+	memcpy(&php_parallel_sync_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-    php_parallel_sync_handlers.offset = XtOffsetOf(php_parallel_sync_object_t, std);
-    php_parallel_sync_handlers.free_obj = php_parallel_sync_object_destroy;
-    php_parallel_sync_handlers.get_debug_info = php_parallel_sync_object_debug;
+	php_parallel_sync_handlers.offset = XtOffsetOf(php_parallel_sync_object_t, std);
+	php_parallel_sync_handlers.free_obj = php_parallel_sync_object_destroy;
+	php_parallel_sync_handlers.get_debug_info = php_parallel_sync_object_debug;
 
-    INIT_NS_CLASS_ENTRY(ce, "parallel", "Sync", php_parallel_sync_methods);
+	INIT_NS_CLASS_ENTRY(ce, "parallel", "Sync", php_parallel_sync_methods);
 
-    php_parallel_sync_ce = zend_register_internal_class(&ce);
-    php_parallel_sync_ce->create_object = php_parallel_sync_object_create;
-    php_parallel_sync_ce->ce_flags |= ZEND_ACC_FINAL;
+	php_parallel_sync_ce = zend_register_internal_class(&ce);
+	php_parallel_sync_ce->create_object = php_parallel_sync_object_create;
+	php_parallel_sync_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    #ifdef ZEND_ACC_NOT_SERIALIZABLE
-        php_parallel_sync_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
-    #else
-        php_parallel_sync_ce->serialize = zend_class_serialize_deny;
-        php_parallel_sync_ce->unserialize = zend_class_unserialize_deny;
-    #endif
+#ifdef ZEND_ACC_NOT_SERIALIZABLE
+	php_parallel_sync_ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+#else
+	php_parallel_sync_ce->serialize = zend_class_serialize_deny;
+	php_parallel_sync_ce->unserialize = zend_class_unserialize_deny;
+#endif
 
-    php_parallel_sync_string_value = zend_string_init_interned(ZEND_STRL("value"), 1);
+	php_parallel_sync_string_value = zend_string_init_interned(ZEND_STRL("value"), 1);
 
-    return SUCCESS;
+	return SUCCESS;
 }
 
-PHP_MSHUTDOWN_FUNCTION(PARALLEL_SYNC)
-{
-    return SUCCESS;
-}
+PHP_MSHUTDOWN_FUNCTION(PARALLEL_SYNC) { return SUCCESS; }
 #endif

--- a/src/sync.h
+++ b/src/sync.h
@@ -21,27 +21,29 @@
 extern zend_class_entry *php_parallel_sync_ce;
 
 typedef struct _php_parallel_sync_t {
-    pthread_mutex_t mutex;
-    pthread_cond_t  condition;
-    zval            value;
-    uint32_t        refcount;
+	pthread_mutex_t mutex;
+	pthread_cond_t  condition;
+	zval            value;
+	uint32_t        refcount;
 } php_parallel_sync_t;
 
 typedef struct _php_parallel_sync_object_t {
-    php_parallel_sync_t *sync;
-    zend_object std;
+	php_parallel_sync_t *sync;
+	zend_object          std;
 } php_parallel_sync_object_t;
 
-static zend_always_inline php_parallel_sync_object_t* php_parallel_sync_object_fetch(zend_object *o) {
-    return (php_parallel_sync_object_t*) (((char*) o) - XtOffsetOf(php_parallel_sync_object_t, std));
+static zend_always_inline php_parallel_sync_object_t *php_parallel_sync_object_fetch(zend_object *o)
+{
+	return (php_parallel_sync_object_t *)(((char *)o) - XtOffsetOf(php_parallel_sync_object_t, std));
 }
 
-static zend_always_inline php_parallel_sync_object_t* php_parallel_sync_object_from(zval *z) {
-    return php_parallel_sync_object_fetch(Z_OBJ_P(z));
+static zend_always_inline php_parallel_sync_object_t *php_parallel_sync_object_from(zval *z)
+{
+	return php_parallel_sync_object_fetch(Z_OBJ_P(z));
 }
 
-php_parallel_sync_t*   php_parallel_sync_copy(php_parallel_sync_t *sync);
-void                   php_parallel_sync_release(php_parallel_sync_t *sync);
+php_parallel_sync_t *php_parallel_sync_copy(php_parallel_sync_t *sync);
+void                 php_parallel_sync_release(php_parallel_sync_t *sync);
 
 PHP_MINIT_FUNCTION(PARALLEL_SYNC);
 PHP_MSHUTDOWN_FUNCTION(PARALLEL_SYNC);


### PR DESCRIPTION
Most notably this PR adds a `.clang-format` file, applies it using `clang-format -i --style=file` for all files and adds a GitHub workflow to enforce it in the future. The coding style is based in PHPs internal code style

https://github.com/krakjoe/parallel/blob/108da3aef362306bcca0ea8890c84cff1923adda/.clang-format#L1-L14


