### PR TITLE
Fix array literal corruption in threads with explicit storage types

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -80,7 +80,8 @@ static zend_always_inline HashTable *php_parallel_cache_statics(HashTable *stati
 		return cached;
 	}
 
-	cached = php_parallel_copy_hash_persistent(statics, php_parallel_copy_string_interned, php_parallel_cache_copy_mem);
+	cached = php_parallel_copy_hash_persistent(statics, php_parallel_copy_string_interned, php_parallel_cache_copy_mem,
+	                                           PHP_PARALLEL_COPY_STORAGE_CACHE_POOL);
 
 	return zend_hash_index_update_ptr(&PCG(table), (zend_ulong)statics, cached);
 } /* }}} */
@@ -207,7 +208,8 @@ static zend_op_array *php_parallel_cache_create(const zend_function *source, boo
 
 			if (Z_TYPE_P(literal) == IS_ARRAY) {
 				ZVAL_ARR(slot, php_parallel_copy_hash_persistent(Z_ARRVAL_P(literal), php_parallel_copy_string_interned,
-				                                                 php_parallel_cache_copy_mem));
+				                                                 php_parallel_cache_copy_mem,
+				                                                 PHP_PARALLEL_COPY_STORAGE_CACHE_POOL));
 			} else if (Z_TYPE_P(literal) == IS_STRING) {
 				ZVAL_STR(slot, php_parallel_copy_string_interned(Z_STR_P(literal)));
 			} else {

--- a/src/copy.c
+++ b/src/copy.c
@@ -42,7 +42,9 @@ zend_class_entry *php_parallel_copy_object_unavailable_ce;
 
 static void           php_parallel_copy_zval_persistent(zval *dest, zval *source,
                                                         zend_string *(*php_parallel_copy_string_func)(zend_string *),
-                                                        void *(*php_parallel_copy_memory_func)(void *source, zend_long size));
+                                                        void *(*php_parallel_copy_memory_func)(void *source, zend_long size),
+                                                        php_parallel_copy_storage_t storage);
+static void          *php_parallel_copy_mem_persistent(void *source, zend_long size);
 
 static const uint32_t php_parallel_copy_uninitialized_bucket[-HT_MIN_MASK] = {HT_INVALID_IDX, HT_INVALID_IDX};
 
@@ -162,10 +164,9 @@ static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resourc
 	return -1;
 }
 
-static zend_always_inline HashTable *
-php_parallel_copy_hash_persistent_inline(HashTable *source,
-                                         zend_string *(*php_parallel_copy_string_func)(zend_string *),
-                                         void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+static zend_always_inline HashTable *php_parallel_copy_hash_persistent_inline(
+    HashTable *source, zend_string *(*php_parallel_copy_string_func)(zend_string *),
+    void *(*php_parallel_copy_memory_func)(void *source, zend_long size), php_parallel_copy_storage_t storage)
 {
 	HashTable                   *ht;
 	uint32_t                     idx;
@@ -183,9 +184,27 @@ php_parallel_copy_hash_persistent_inline(HashTable *source,
 		php_parallel_copy_context_insert(context, source, ht);
 	}
 
-	// see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
-	// TODO: needs fixing
-	GC_SET_REFCOUNT(ht, 2);
+	switch (storage) {
+	case PHP_PARALLEL_COPY_STORAGE_CACHE_POOL:
+		/*
+		 * Cache pool arrays are shared across all threads. Since
+		 * IS_TYPE_REFCOUNTED is cleared on cached zvals, the VM won't
+		 * manage the refcount. We set refcount=2 so that when the VM
+		 * checks "should I separate this array?", it sees refcount > 1
+		 * and triggers copy-on-write, preventing corruption of shared data.
+		 */
+		GC_SET_REFCOUNT(ht, 2);
+		break;
+
+	case PHP_PARALLEL_COPY_STORAGE_PERSISTENT:
+		/*
+		 * Per-instance persistent arrays (e.g., closure static variables)
+		 * are private and freed via destructor. Use standard refcount=1
+		 * for proper lifetime management.
+		 */
+		GC_SET_REFCOUNT(ht, 1);
+		break;
+	}
 	GC_SET_PERSISTENT_TYPE(ht, GC_ARRAY);
 	GC_ADD_FLAGS(ht, IS_ARRAY_IMMUTABLE);
 
@@ -214,7 +233,8 @@ php_parallel_copy_hash_persistent_inline(HashTable *source,
 				continue;
 
 			if (Z_OPT_REFCOUNTED_P(zv)) {
-				php_parallel_copy_zval_persistent(zv, zv, php_parallel_copy_string_func, php_parallel_copy_memory_func);
+				php_parallel_copy_zval_persistent(zv, zv, php_parallel_copy_string_func, php_parallel_copy_memory_func,
+				                                  storage);
 			}
 		}
 		ht->nNextFreeElement = ht->nNumUsed;
@@ -242,7 +262,7 @@ php_parallel_copy_hash_persistent_inline(HashTable *source,
 
 		if (Z_OPT_REFCOUNTED(p->val)) {
 			php_parallel_copy_zval_persistent(&p->val, &p->val, php_parallel_copy_string_func,
-			                                  php_parallel_copy_memory_func);
+			                                  php_parallel_copy_memory_func, storage);
 		}
 	}
 	php_parallel_copy_context_end(context, restore);
@@ -340,24 +360,24 @@ HashTable *php_parallel_copy_hash_ctor(HashTable *source, bool persistent)
 {
 	if (persistent) {
 		return php_parallel_copy_hash_persistent_inline(source, php_parallel_copy_string_persistent,
-		                                                php_parallel_copy_mem_persistent);
+		                                                php_parallel_copy_mem_persistent,
+		                                                PHP_PARALLEL_COPY_STORAGE_PERSISTENT);
 	}
 	return php_parallel_copy_hash_thread(source);
 }
 
 HashTable *php_parallel_copy_hash_persistent(HashTable *source,
                                              zend_string *(*php_parallel_copy_string_func)(zend_string *),
-                                             void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+                                             void *(*php_parallel_copy_memory_func)(void *source, zend_long size),
+                                             php_parallel_copy_storage_t storage)
 {
 	return php_parallel_copy_hash_persistent_inline(source, php_parallel_copy_string_func,
-	                                                php_parallel_copy_memory_func);
+	                                                php_parallel_copy_memory_func, storage);
 }
 
 void php_parallel_copy_hash_dtor(HashTable *table, bool persistent)
 {
-	// see https://github.com/krakjoe/parallel/issues/306#issuecomment-2414687880
-	// TODO: needs fixing
-	if (GC_DELREF(table) == (persistent ? 1 : 0)) {
+	if (GC_DELREF(table) == 0) {
 		if (!persistent) {
 			GC_REMOVE_FROM_BUFFER(table);
 			GC_TYPE_INFO(table) =
@@ -932,11 +952,12 @@ void php_parallel_copy_zval_dtor(zval *zv)
 
 static void php_parallel_copy_zval_persistent(zval *dest, zval *source,
                                               zend_string *(*php_parallel_copy_string_func)(zend_string *),
-                                              void *(*php_parallel_copy_memory_func)(void *source, zend_long size))
+                                              void *(*php_parallel_copy_memory_func)(void *source, zend_long size),
+                                              php_parallel_copy_storage_t storage)
 {
 	if (Z_TYPE_P(source) == IS_ARRAY) {
 		ZVAL_ARR(dest, php_parallel_copy_hash_persistent(Z_ARRVAL_P(source), php_parallel_copy_string_func,
-		                                                 php_parallel_copy_memory_func));
+		                                                 php_parallel_copy_memory_func, storage));
 	} else if (Z_TYPE_P(source) == IS_REFERENCE) {
 		ZVAL_REF(dest, php_parallel_copy_reference_persistent(Z_REF_P(source)));
 	} else if (Z_TYPE_P(source) == IS_STRING) {

--- a/src/copy.h
+++ b/src/copy.h
@@ -56,26 +56,48 @@ static zend_always_inline void *php_parallel_copy_mem(void *source, size_t size,
 	return destination;
 }
 
-zend_function    *php_parallel_copy_function(const zend_function *function, bool persistent);
+zend_function *php_parallel_copy_function(const zend_function *function, bool persistent);
 
-zend_string      *php_parallel_copy_string_interned(zend_string *source);
-zend_string      *php_parallel_copy_string(zend_string *source, bool persistent);
-
-HashTable        *php_parallel_copy_hash_ctor(HashTable *source, bool persistent);
-void              php_parallel_copy_hash_dtor(HashTable *table, bool persistent);
-
-HashTable        *php_parallel_copy_hash_persistent(HashTable *source, zend_string *(*)(zend_string *),
-                                                    void *(*)(void *, zend_long));
-
-void              php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent);
-void              php_parallel_copy_zval_dtor(zval *zv);
-
-zend_class_entry *php_parallel_copy_scope(zend_class_entry *);
+zend_string   *php_parallel_copy_string_interned(zend_string *source);
+zend_string   *php_parallel_copy_string(zend_string *source, bool persistent);
 
 typedef enum _php_parallel_copy_direction_t {
 	PHP_PARALLEL_COPY_DIRECTION_PERSISTENT,
 	PHP_PARALLEL_COPY_DIRECTION_THREAD,
 } php_parallel_copy_direction_t;
+
+typedef enum _php_parallel_copy_storage_t {
+	/*
+	 * Array is stored in the global cache pool.
+	 * - Shared across ALL threads (read-only from their perspective)
+	 * - Never individually freed (pool freed at module shutdown)
+	 * - Requires refcount > 1 to force copy-on-write when threads modify
+	 *
+	 * Since IS_TYPE_REFCOUNTED is cleared on cached zvals, the VM won't
+	 * touch the refcount. We set refcount=2 so separation checks see
+	 * refcount > 1 and trigger copy-on-write.
+	 */
+	PHP_PARALLEL_COPY_STORAGE_CACHE_POOL,
+
+	/*
+	 * Array is stored in per-instance persistent memory (pemalloc).
+	 * - Private to a specific closure instance
+	 * - Freed via destructor with standard refcount semantics
+	 * - Uses refcount=1 for proper lifetime management
+	 */
+	PHP_PARALLEL_COPY_STORAGE_PERSISTENT,
+} php_parallel_copy_storage_t;
+
+HashTable        *php_parallel_copy_hash_ctor(HashTable *source, bool persistent);
+void              php_parallel_copy_hash_dtor(HashTable *table, bool persistent);
+
+HashTable        *php_parallel_copy_hash_persistent(HashTable *source, zend_string *(*)(zend_string *),
+                                                    void *(*)(void *, zend_long), php_parallel_copy_storage_t storage);
+
+void              php_parallel_copy_zval_ctor(zval *dest, zval *source, bool persistent);
+void              php_parallel_copy_zval_dtor(zval *zv);
+
+zend_class_entry *php_parallel_copy_scope(zend_class_entry *);
 
 typedef struct _php_parallel_copy_context_t {
 	php_parallel_copy_direction_t direction;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -193,6 +193,14 @@ static zend_always_inline void php_parallel_scheduler_exit(php_parallel_runtime_
 {
 	php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE);
 
+	/*
+	 * Force cycle collection before shutdown to clean up self-referential
+	 * closures created inside the thread (e.g., recursive closures using
+	 * `use (&$self)`). These create cycles that won't be freed by normal
+	 * refcount decrement.
+	 */
+	gc_collect_cycles();
+
 	php_request_shutdown(NULL);
 
 	ts_free_thread();

--- a/tests/base/071.phpt
+++ b/tests/base/071.phpt
@@ -47,5 +47,3 @@ var_dump($future->value());
 --EXPECT--
 int(55)
 int(55)
---XFAIL--
-REASON: no cyclic reference collector implemented yet

--- a/tests/base/072.phpt
+++ b/tests/base/072.phpt
@@ -38,5 +38,3 @@ var_dump($future->value());
 --EXPECT--
 int(55)
 int(55)
---XFAIL--
-REASON: no cyclic reference collector implemented yet


### PR DESCRIPTION
Array literals in closures could be corrupted when multiple threads modified them simultaneously. This was "fixed" by just setting the refcount to 2, triggering copy-on-write in PHP.

This PR introduces `php_parallel_copy_storage_t` enum to explicitly declare array storage intent:

- `CACHE_POOL`: Shared literals in the opcode cache → refcount=2 (forces COW)
- `PERSISTENT`: Per-closure static variables → refcount=1 (normal destruction)