### PR TITLE
Fix segfault: dangling CE pointer in persistent object dtor

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -743,6 +743,14 @@ static zend_always_inline zend_object *php_parallel_copy_object_persistent(zend_
 		dest->handlers = zend_get_std_object_handlers();
 	}
 
+	/*
+	 * Store default_properties_count in dest->handle so the dtor can free
+	 * properties_table entries without dereferencing dest->ce, which may
+	 * become a dangling pointer after the source thread exits (e.g. when
+	 * this object is part of a persistently copied exception trace).
+	 */
+	dest->handle = source->ce->default_properties_count;
+
 	if (ce->default_properties_count) {
 		zval *property = source->properties_table, *slot = dest->properties_table,
 		     *end = property + source->ce->default_properties_count;
@@ -847,19 +855,34 @@ static zend_always_inline void php_parallel_copy_object_dtor(zend_object *source
 		return;
 	}
 
-	if (instanceof_function(source->ce, php_parallel_sync_ce)) {
-		php_parallel_copy_sync_dtor(source, persistent);
-		return;
-	}
-
 	if (!persistent) {
+		if (instanceof_function(source->ce, php_parallel_sync_ce)) {
+			php_parallel_copy_sync_dtor(source, persistent);
+			return;
+		}
+
 		OBJ_RELEASE(source);
 		return;
 	}
 
+	/*
+	 * For persistent copies, source->ce may be a dangling pointer if the
+	 * source thread has exited (e.g. objects in exception traces). Use
+	 * exact pointer comparison instead of instanceof_function() which
+	 * would dereference the potentially-dangling CE.
+	 */
+	if (source->ce == php_parallel_sync_ce) {
+		php_parallel_copy_sync_dtor(source, persistent);
+		return;
+	}
+
 	if (GC_DELREF(source) == 0) {
-		if (source->ce->default_properties_count) {
-			zval *property = source->properties_table, *end = property + source->ce->default_properties_count;
+		/*
+		 * source->handle stores default_properties_count, saved at
+		 * persistent copy time to avoid dereferencing source->ce here.
+		 */
+		if (source->handle) {
+			zval *property = source->properties_table, *end = property + source->handle;
 
 			while (property < end) {
 				PARALLEL_ZVAL_DTOR(property);

--- a/tests/base/073-bootstrap.inc
+++ b/tests/base/073-bootstrap.inc
@@ -1,0 +1,12 @@
+<?php
+class PlainUserClass {
+    public string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+
+function throw_with_object_in_trace(PlainUserClass $obj) {
+    throw new RuntimeException("error from thread");
+}

--- a/tests/base/073.phpt
+++ b/tests/base/073.phpt
@@ -1,0 +1,63 @@
+--TEST--
+persistent copy of object with user CE must not segfault after thread exit
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+/*
+ * When a thread throws an exception whose trace contains a plain user object
+ * (a class without create_object), the exception is persistently copied.
+ * The persistent copy must not keep the thread-local zend_class_entry pointer,
+ * because it becomes dangling after the thread exits.
+ *
+ * Without the fix, php_parallel_copy_object_dtor() calls
+ * instanceof_function() on the dangling CE and segfaults during shutdown.
+ *
+ * We use Events with a Future to mirror the amphp pattern that triggers the
+ * crash: during shutdown, Events destroys the Future which calls
+ * php_parallel_exceptions_destroy() on the persistent exception data.
+ */
+$runtime = new \parallel\Runtime(sprintf("%s/073-bootstrap.inc", __DIR__));
+
+$future = $runtime->run(function(){
+    $obj = new PlainUserClass("test");
+    throw_with_object_in_trace($obj);
+});
+
+/* Wait for the thread to finish */
+try {
+    $future->value();
+} catch (\Throwable $e) {
+    echo $e->getMessage() . "\n";
+}
+
+/*
+ * Kill the runtime to ensure the thread is fully shut down and its
+ * class entries are freed. The $future still holds persistently copied
+ * exception data referencing the (now-freed) thread-local CE.
+ */
+$runtime->kill();
+
+/*
+ * Add the future to Events so its cleanup happens via Events::remove()
+ * during shutdown — this is the path that triggers the segfault in the
+ * original amphp use case.
+ */
+$events = new \parallel\Events();
+$events->addFuture("task", $future);
+
+/* Force some allocations to increase chance of CE memory being reused */
+for ($i = 0; $i < 1000; $i++) {
+    ${"v$i"} = str_repeat("x", 256);
+}
+
+echo "OK\n";
+/* Segfault would occur here during shutdown when Events destroys the Future */
+?>
+--EXPECT--
+error from thread
+OK


### PR DESCRIPTION
When a thread throws an exception whose trace contains a plain user object (a class without `create_object`), the exception is persistently copied via `php_parallel_exceptions_save()`. The persistent copy retains the thread-local `zend_class_entry` pointer in `dest->ce`.

After the thread exits, this CE pointer becomes dangling. When the persistent copy is later destroyed (e.g. during shutdown via `Events` destroying a `Future`), `php_parallel_copy_object_dtor()` would:

1. Call `instanceof_function(source->ce, php_parallel_sync_ce)`, which dereferences the dangling CE pointer -> segfault.
2. Access `source->ce->default_properties_count` to iterate `properties_table` -> segfault.

Fix by making the persistent dtor path safe without dereferencing CE:

- Use exact pointer comparison (`source->ce == php_parallel_sync_ce`) instead of `instanceof_function()` for the persistent path. This is safe because `parallel\Sync` is an internal CE whose address is stable.
- Store `default_properties_count` in `dest->handle` at persistent copy time (handle is unused for persistent copies since they are not in the object store). The dtor reads `source->handle` instead of `source->ce->default_properties_count`.

The ctor (`php_parallel_copy_object_persistent`) is unchanged - it still preserves the original CE for objects without `create_object`, which is needed for the persistent->thread copy path (task parameters) where the source thread is alive and the CE is valid.