### PR TITLE
Fix use-after-free in exception trace with user objects

### DIFF
--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -165,6 +165,37 @@ void php_parallel_exceptions_save(zval *saved, zend_object *exception)
 	PARALLEL_ZVAL_COPY(&ex->line, line, 1);
 	PARALLEL_ZVAL_COPY(&ex->message, message, 1);
 	PARALLEL_ZVAL_COPY(&ex->code, code, 1);
+
+	/* Sanitize objects in trace args before persistent copy.
+	   Objects hold ce pointers to thread-local class entries which become
+	   dangling once the thread shuts down, causing use-after-free when the
+	   exception is destroyed in another thread. Replace objects with their
+	   class name string to preserve debug info safely. */
+	if (Z_TYPE_P(trace) == IS_ARRAY) {
+		zval *frame;
+		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(trace), frame)
+		{
+			if (Z_TYPE_P(frame) == IS_ARRAY) {
+				zval *args = zend_hash_str_find(Z_ARRVAL_P(frame), "args", sizeof("args") - 1);
+				if (args && Z_TYPE_P(args) == IS_ARRAY) {
+					zval *arg;
+					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(args), arg)
+					{
+						if (Z_TYPE_P(arg) == IS_OBJECT) {
+							zend_string *name = Z_OBJCE_P(arg)->name;
+							zend_string *repr = zend_string_concat3("Object(", sizeof("Object(") - 1, ZSTR_VAL(name),
+							                                        ZSTR_LEN(name), ")", sizeof(")") - 1);
+							zval_ptr_dtor(arg);
+							ZVAL_STR(arg, repr);
+						}
+					}
+					ZEND_HASH_FOREACH_END();
+				}
+			}
+		}
+		ZEND_HASH_FOREACH_END();
+	}
+
 	PARALLEL_ZVAL_COPY(&ex->trace, trace, 1);
 	PARALLEL_ZVAL_COPY(&ex->previous, &previous, 1);
 

--- a/tests/base/037.phpt
+++ b/tests/base/037.phpt
@@ -12,7 +12,7 @@ $parallel = new \parallel\Runtime(sprintf("%s/bootstrap.inc", __DIR__));
 
 $future = $parallel->run(function(){
 	$foo = new Foo();
-	
+
 	return $foo->bar([42],new stdClass);
 });
 
@@ -21,7 +21,7 @@ var_dump($future->value());
 --EXPECTF--
 Fatal error: Uncaught RuntimeException: message in %s:12
 Stack trace:
-#0 %s(19): Qux->method(Array, Object(stdClass))
-#1 %s(7): Foo->bar(Array, Object(stdClass))
+#0 %s(19): Qux->method(Array, 'Object(stdClass...')
+#1 %s(7): Foo->bar(Array, 'Object(stdClass...')
 %A
 

--- a/tests/base/073-bootstrap.inc
+++ b/tests/base/073-bootstrap.inc
@@ -1,0 +1,12 @@
+<?php
+class PlainUserClass {
+    public string $name;
+
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+}
+
+function throw_with_object_in_trace(PlainUserClass $obj) {
+    throw new RuntimeException("error from thread");
+}

--- a/tests/base/073.phpt
+++ b/tests/base/073.phpt
@@ -1,0 +1,45 @@
+--TEST--
+persistent copy of object with user CE must not segfault after thread exit
+--DESCRIPTION--
+When a thread throws an exception whose trace contains a plain user object
+(a class without `create_object`), the exception is persistently copied.
+The persistent copy must not keep the thread-local `zend_class_entry` pointer,
+because it becomes dangling after the thread exits. Without the fix,
+`php_parallel_copy_object_dtor()` calls `instanceof_function()` on the
+dangling CE and segfaults during shutdown.
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+    echo 'skip';
+}
+?>
+--FILE--
+<?php
+$runtime = new \parallel\Runtime(sprintf("%s/073-bootstrap.inc", __DIR__));
+
+$future = $runtime->run(function () {
+    $obj = new PlainUserClass("test");
+    throw_with_object_in_trace($obj);
+});
+
+try {
+    $future->value();
+} catch (\Throwable $e) {
+    echo $e->getMessage() . "\n";
+}
+
+/*
+ * Kill the runtime to ensure the thread is fully shut down and its
+ * class entries are freed. The $future still holds persistently copied
+ * exception data referencing the (now-freed) thread-local CE.
+ */
+$runtime->kill();
+
+/* Segfault would occur here */
+unset($future);
+
+echo "OK\n";
+?>
+--EXPECT--
+error from thread
+OK


### PR DESCRIPTION
See #371 

> When a thread throws an exception whose trace contains a plain user object (a class without create_object), the exception is persistently copied via php_parallel_exceptions_save(). The persistent copy retains the thread-local zend_class_entry pointer in dest->ce.

The exception should not hold a pointer to an object in another thread.