### PR TITLE
fix: improve PHP compatibility for parameter parsing and struct offsets

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -345,7 +345,7 @@ PHP_MINIT_FUNCTION(PARALLEL_CHANNEL)
 
 	memcpy(&php_parallel_channel_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_channel_handlers.offset = XtOffsetOf(php_parallel_channel_t, std);
+	php_parallel_channel_handlers.offset = offsetof(php_parallel_channel_t, std);
 	php_parallel_channel_handlers.free_obj = php_parallel_channel_destroy;
 	php_parallel_channel_handlers.compare = php_parallel_channel_compare;
 	php_parallel_channel_handlers.get_debug_info = php_parallel_channel_debug;

--- a/src/channel.h
+++ b/src/channel.h
@@ -30,7 +30,7 @@ extern zend_object_handlers                       php_parallel_channel_handlers;
 
 static zend_always_inline php_parallel_channel_t *php_parallel_channel_fetch(zend_object *o)
 {
-	return (php_parallel_channel_t *)(((char *)o) - XtOffsetOf(php_parallel_channel_t, std));
+	return (php_parallel_channel_t *)(((char *)o) - offsetof(php_parallel_channel_t, std));
 }
 
 static zend_always_inline php_parallel_channel_t *php_parallel_channel_from(zval *z)

--- a/src/events.c
+++ b/src/events.c
@@ -284,7 +284,7 @@ PHP_MINIT_FUNCTION(PARALLEL_EVENTS)
 
 	memcpy(&php_parallel_events_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_events_handlers.offset = XtOffsetOf(php_parallel_events_t, std);
+	php_parallel_events_handlers.offset = offsetof(php_parallel_events_t, std);
 	php_parallel_events_handlers.free_obj = php_parallel_events_destroy;
 
 	INIT_NS_CLASS_ENTRY(ce, "parallel", "Events", php_parallel_events_methods);

--- a/src/events.h
+++ b/src/events.h
@@ -40,7 +40,7 @@ typedef struct _php_parallel_events_state_t {
 
 static zend_always_inline php_parallel_events_t *php_parallel_events_fetch(zend_object *o)
 {
-	return (php_parallel_events_t *)(((char *)o) - XtOffsetOf(php_parallel_events_t, std));
+	return (php_parallel_events_t *)(((char *)o) - offsetof(php_parallel_events_t, std));
 }
 
 static zend_always_inline php_parallel_events_t *php_parallel_events_from(zval *z)

--- a/src/future.c
+++ b/src/future.c
@@ -261,7 +261,7 @@ PHP_MINIT_FUNCTION(PARALLEL_FUTURE)
 
 	memcpy(&php_parallel_future_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_future_handlers.offset = XtOffsetOf(php_parallel_future_t, std);
+	php_parallel_future_handlers.offset = offsetof(php_parallel_future_t, std);
 	php_parallel_future_handlers.free_obj = php_parallel_future_destroy;
 	php_parallel_future_handlers.get_debug_info = php_parallel_future_debug;
 

--- a/src/future.h
+++ b/src/future.h
@@ -34,7 +34,7 @@ typedef struct _php_parallel_future_t {
 
 static zend_always_inline php_parallel_future_t *php_parallel_future_fetch(zend_object *o)
 {
-	return (php_parallel_future_t *)(((char *)o) - XtOffsetOf(php_parallel_future_t, std));
+	return (php_parallel_future_t *)(((char *)o) - offsetof(php_parallel_future_t, std));
 }
 
 static zend_always_inline php_parallel_future_t *php_parallel_future_from(zval *z)

--- a/src/input.c
+++ b/src/input.c
@@ -30,7 +30,7 @@ typedef struct _php_parallel_events_input_t {
 
 static zend_always_inline php_parallel_events_input_t *php_parallel_events_input_fetch(zend_object *o)
 {
-	return (php_parallel_events_input_t *)(((char *)o) - XtOffsetOf(php_parallel_events_input_t, std));
+	return (php_parallel_events_input_t *)(((char *)o) - offsetof(php_parallel_events_input_t, std));
 }
 
 static zend_always_inline php_parallel_events_input_t *php_parallel_events_input_from(zval *z)
@@ -178,7 +178,7 @@ PHP_MINIT_FUNCTION(PARALLEL_EVENTS_INPUT)
 
 	memcpy(&php_parallel_events_input_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_events_input_handlers.offset = XtOffsetOf(php_parallel_events_input_t, std);
+	php_parallel_events_input_handlers.offset = offsetof(php_parallel_events_input_t, std);
 	php_parallel_events_input_handlers.free_obj = php_parallel_events_input_destroy;
 
 	INIT_NS_CLASS_ENTRY(ce, "parallel\\Events", "Input", php_parallel_events_input_methods);

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -62,7 +62,7 @@ typedef union _php_parallel_platform_align_test {
 #include "dependencies.h"
 
 #define PARALLEL_PARAMETERS_NONE(r)                                                                                    \
-	ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 0, 0)                                                      \
+	ZEND_PARSE_PARAMETERS_START(0, 0)  							                                                       \
 	ZEND_PARSE_PARAMETERS_END()
 
 static zend_always_inline bool php_parallel_mutex_init(pthread_mutex_t *mutex, bool recursive)

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -62,7 +62,7 @@ typedef union _php_parallel_platform_align_test {
 #include "dependencies.h"
 
 #define PARALLEL_PARAMETERS_NONE(r)                                                                                    \
-	ZEND_PARSE_PARAMETERS_START(0, 0)  							                                                       \
+	ZEND_PARSE_PARAMETERS_START(0, 0)                                                                                  \
 	ZEND_PARSE_PARAMETERS_END()
 
 static zend_always_inline bool php_parallel_mutex_init(pthread_mutex_t *mutex, bool recursive)

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -146,7 +146,7 @@ PHP_MINIT_FUNCTION(PARALLEL_RUNTIME)
 
 	memcpy(&php_parallel_runtime_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_runtime_handlers.offset = XtOffsetOf(php_parallel_runtime_t, std);
+	php_parallel_runtime_handlers.offset = offsetof(php_parallel_runtime_t, std);
 	php_parallel_runtime_handlers.free_obj = php_parallel_runtime_destroy;
 
 	INIT_NS_CLASS_ENTRY(ce, "parallel", "Runtime", php_parallel_runtime_methods);

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -45,7 +45,7 @@ typedef struct _php_parallel_runtime_t {
 
 static zend_always_inline php_parallel_runtime_t *php_parallel_runtime_fetch(zend_object *o)
 {
-	return (php_parallel_runtime_t *)(((char *)o) - XtOffsetOf(php_parallel_runtime_t, std));
+	return (php_parallel_runtime_t *)(((char *)o) - offsetof(php_parallel_runtime_t, std));
 }
 
 static zend_always_inline php_parallel_runtime_t *php_parallel_runtime_from(zval *z)

--- a/src/sync.c
+++ b/src/sync.c
@@ -283,7 +283,7 @@ PHP_MINIT_FUNCTION(PARALLEL_SYNC)
 
 	memcpy(&php_parallel_sync_handlers, php_parallel_standard_handlers(), sizeof(zend_object_handlers));
 
-	php_parallel_sync_handlers.offset = XtOffsetOf(php_parallel_sync_object_t, std);
+	php_parallel_sync_handlers.offset = offsetof(php_parallel_sync_object_t, std);
 	php_parallel_sync_handlers.free_obj = php_parallel_sync_object_destroy;
 	php_parallel_sync_handlers.get_debug_info = php_parallel_sync_object_debug;
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -34,7 +34,7 @@ typedef struct _php_parallel_sync_object_t {
 
 static zend_always_inline php_parallel_sync_object_t *php_parallel_sync_object_fetch(zend_object *o)
 {
-	return (php_parallel_sync_object_t *)(((char *)o) - XtOffsetOf(php_parallel_sync_object_t, std));
+	return (php_parallel_sync_object_t *)(((char *)o) - offsetof(php_parallel_sync_object_t, std));
 }
 
 static zend_always_inline php_parallel_sync_object_t *php_parallel_sync_object_from(zval *z)


### PR DESCRIPTION
fix: improve PHP compatibility for parameter parsing and struct offsets

* Replaced `ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, ...)`
  with `ZEND_PARSE_PARAMETERS_START(...)` for compatibility with PHP 8.6
* Updated `XtOffsetOf` to standard `offsetof` for better portability and modern C compliance
