### PR TITLE
Fix PHP 8.4 task exit handling

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -110,9 +110,30 @@ static void      php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *co
 }
 #endif
 
-static zend_always_inline int php_parallel_scheduler_list_delete(void *lhs, void *rhs) { return lhs == rhs; }
+static zend_always_inline int  php_parallel_scheduler_list_delete(void *lhs, void *rhs) { return lhs == rhs; }
 
-static void                   php_parallel_schedule_free_function(zend_function *function)
+static zend_always_inline bool php_parallel_scheduler_exit_exception(void)
+{
+#if PHP_VERSION_ID >= 80400
+	zend_object *exception = EG(exception);
+
+	/* PHP 8.4 models exit as an internal exception that must not be copied as a task error. */
+	return exception && (zend_is_unwind_exit(exception) || zend_is_graceful_exit(exception));
+#else
+	return false;
+#endif
+}
+
+static zend_always_inline void php_parallel_scheduler_kill_future(php_parallel_future_t *future)
+{
+	php_parallel_monitor_lock(future->monitor);
+	if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
+		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_KILLED);
+	}
+	php_parallel_monitor_unlock(future->monitor);
+}
+
+static void php_parallel_schedule_free_function(zend_function *function)
 {
 	if (function->op_array.static_variables) {
 		php_parallel_copy_hash_dtor(function->op_array.static_variables, 1);
@@ -416,9 +437,15 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 
 			if (UNEXPECTED(EG(exception))) {
 				if (future) {
-					php_parallel_exceptions_save(frame->return_value, EG(exception));
+					if (php_parallel_scheduler_exit_exception()) {
+						zend_clear_exception();
 
-					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+						php_parallel_scheduler_kill_future(future);
+					} else {
+						php_parallel_exceptions_save(frame->return_value, EG(exception));
+
+						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+					}
 				} else {
 					zend_throw_exception_internal(NULL);
 				}
@@ -465,11 +492,7 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 				php_parallel_monitor_set(runtime->monitor, PHP_PARALLEL_DONE | PHP_PARALLEL_KILLED);
 				php_parallel_monitor_unlock(runtime->monitor);
 			} else if (future) {
-				php_parallel_monitor_lock(future->monitor);
-				if (!php_parallel_monitor_check(future->monitor, PHP_PARALLEL_CANCELLED)) {
-					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_KILLED);
-				}
-				php_parallel_monitor_unlock(future->monitor);
+				php_parallel_scheduler_kill_future(future);
 			}
 		}
 		zend_end_try();

--- a/tests/base/074-autoload.inc
+++ b/tests/base/074-autoload.inc
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+final class Issue375ClassLoader
+{
+    public function loadClass($class)
+    {
+    }
+}
+
+return true;

--- a/tests/base/074-fn.inc
+++ b/tests/base/074-fn.inc
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace Name\Space;
+
+use function function_exists;

--- a/tests/base/074.phpt
+++ b/tests/base/074.phpt
@@ -1,0 +1,77 @@
+--TEST--
+parallel Runtime continues after task exit with included class and namespace imports
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	die("skip parallel not loaded");
+}
+if (PHP_VERSION_ID < 80400) {
+    die("skip php 8.4 required");
+}
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+use parallel\Runtime;
+
+error_reporting(E_ALL);
+
+class Flow
+{
+    protected(set) Runtime $runtime;
+    protected array $futures = [];
+
+    public function __construct(private string $log)
+    {
+        $this->runtime = new Runtime;
+    }
+
+    public function exec(Closure $callback): self
+    {
+        $wrapTask = static function (Closure $task, string $log): void {
+            file_put_contents($log, "task exit\n", FILE_APPEND);
+            exit;
+        };
+
+        $this->futures[] = $this->runtime->run($wrapTask, [$callback, $this->log]);
+
+        return $this;
+    }
+
+    public function wait(): void
+    {
+        foreach ($this->futures as $future) {
+            try {
+                $future->value();
+            } catch (Throwable) {
+            }
+        }
+    }
+}
+
+$log = tempnam(sys_get_temp_dir(), 'parallel-074-');
+$flow = new Flow($log);
+
+$boot = $flow->runtime->run(static function (): void {
+    require_once __DIR__ . '/074-autoload.inc';
+    require_once __DIR__ . '/074-fn.inc';
+    echo "boot\n";
+});
+$boot->value();
+
+$flow->exec(static function (): void {});
+$flow->exec(static function (): void {});
+$flow->exec(static function (): void {});
+
+$flow->wait();
+
+echo "task exits=" . substr_count(file_get_contents($log), "task exit\n") . "\n";
+@unlink($log);
+
+exit("main flow end\n");
+?>
+--EXPECT--
+boot
+task exits=3
+main flow end


### PR DESCRIPTION
Fixes a PHP 8.4 regression where a task that calls `exit` after worker-side includes could prevent a `parallel\Runtime` from continuing to drain queued tasks.

On PHP 8.4 and newer, `exit`/`die` reaches the task scheduler as PHP’s internal `UnwindExit`/`GracefulExit` exception. The scheduler was treating that object as a normal task exception and passing it to `php_parallel_exceptions_save()`, which expects normal `Error`/`Throwable` properties. This shuts down the runtime and as such will not execute scheduled tasks.

This change detects the internal exit objects before the normal exception-copy path, clears them, marks only the current future as killed, and lets the worker continue processing queued work.

Fixes #375 