### PR TITLE
Narrow the Windows VEH to undefined-function calls only

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -442,6 +442,12 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 {
 	php_parallel_future_t *future = php_parallel_scheduler_future;
 
+	/* Set once the future has been signalled READY by an error path below, so
+	 * the trailing READY signal is skipped. Signalling twice is a use-after-free
+	 * race: the first signal releases the consumer, which may free the future
+	 * (and its monitor) before the second php_parallel_monitor_set() runs. */
+	volatile bool          ready = false;
+
 	runtime->crashed = 0;
 	runtime->missing = NULL;
 	runtime->file = NULL;
@@ -462,7 +468,9 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 					} else {
 						php_parallel_exceptions_save(frame->return_value, EG(exception));
 
-						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
+
+						ready = true;
 					}
 				} else {
 					zend_throw_exception_internal(NULL);
@@ -499,6 +507,8 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 					}
 					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
 					php_parallel_monitor_unlock(future->monitor);
+
+					ready = true;
 				}
 
 				// This runtime crashed, as such we can not give any guarantees
@@ -533,7 +543,7 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 	}
 	zend_end_try();
 
-	if (future) {
+	if (future && !ready) {
 		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
 	}
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -33,49 +33,13 @@ TSRM_TLS php_parallel_future_t  *php_parallel_scheduler_future = NULL;
 
 void (*zend_interrupt_handler)(zend_execute_data *) = NULL;
 
-#ifdef _WIN32
-void       *php_parallel_veh_handle = NULL;
-
-LONG WINAPI php_parallel_veh_handler(PEXCEPTION_POINTERS exceptionInfo)
-{
-	if (exceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
-		if (php_parallel_scheduler_context) {
-			php_parallel_scheduler_context->crashed = 1;
-
-			if (EG(current_execute_data)) {
-				if (EG(current_execute_data)->opline) {
-					const zend_op *opline = EG(current_execute_data)->opline;
-
-					php_parallel_scheduler_context->line = opline->lineno;
-					if (opline->opcode == ZEND_INIT_FCALL) {
-						zval *name = RT_CONSTANT(opline, opline->op2);
-
-						if (Z_TYPE_P(name) == IS_STRING) {
-							if (!zend_hash_exists(EG(function_table), Z_STR_P(name))) {
-								php_parallel_scheduler_context->missing = Z_STR_P(name);
-							}
-						}
-					}
-				}
-				if (EG(current_execute_data)->func && EG(current_execute_data)->func->op_array.filename) {
-					php_parallel_scheduler_context->file = EG(current_execute_data)->func->op_array.filename;
-				}
-			}
-			zend_bailout();
-		}
-	}
-	return EXCEPTION_CONTINUE_SEARCH;
-}
-#else
-struct sigaction php_parallel_old_sigsegv_action;
-
 /* The only crash we deliberately convert into a catchable error: a parallel
  * worker faulting on a call to a function that does not exist in the worker's
  * function table (e.g. not provided via a bootstrap file). On success it
  * records the diagnostics on the runtime and returns true so the caller can
  * zend_bailout(). Every other crash is a genuine bug and must reach the
- * previous handler, so this returns false and stashes nothing. */
-static bool      php_parallel_scheduler_recover_missing_function(void)
+ * previously installed handler, so this returns false and stashes nothing. */
+static bool php_parallel_scheduler_recover_missing_function(void)
 {
 	php_parallel_runtime_t *runtime = php_parallel_scheduler_context;
 
@@ -106,7 +70,26 @@ static bool      php_parallel_scheduler_recover_missing_function(void)
 	return true;
 }
 
-static void php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context)
+#ifdef _WIN32
+void       *php_parallel_veh_handle = NULL;
+
+LONG WINAPI php_parallel_veh_handler(PEXCEPTION_POINTERS exceptionInfo)
+{
+	if (exceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+		// Only convert into a catchable error when a parallel worker crashed
+		// calling an undefined function. Any other access violation is a genuine
+		// bug: forward it to the previously installed handler (and crash cleanly
+		// if nothing handles it) rather than masking it.
+		if (php_parallel_scheduler_recover_missing_function()) {
+			zend_bailout();
+		}
+	}
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+#else
+struct sigaction php_parallel_old_sigsegv_action;
+
+static void      php_parallel_sigsegv_handler(int sig, siginfo_t *info, void *context)
 {
 	// Only convert into a catchable error when a parallel worker crashed
 	// calling an undefined function. Any other crash is a genuine bug and must


### PR DESCRIPTION
Stacked on #381 (base = `florian/fix-future-monitor-uaf-race`). Retarget to `develop` once #381 lands.

Follow-up to #378, which narrowed the **POSIX** SIGSEGV handler. This applies the same policy to the **Windows** vectored exception handler (VEH).

### What changed
The VEH introduced in #355 caught **every** access violation on a parallel worker and converted it into a catchable `IllegalInstruction` via an unconditional `zend_bailout()`. Now it only does that for the one case it was built for: a worker faulting on a `ZEND_INIT_FCALL` to a function missing from its function table (no bootstrap file). Any other access violation returns `EXCEPTION_CONTINUE_SEARCH`, i.e. it is forwarded to the previously installed handler and crashes cleanly if nothing handles it — the Windows equivalent of chaining to the previous `SIGSEGV` handler on POSIX.

Detection is shared between both handlers via `php_parallel_scheduler_recover_missing_function()`.

### Why this is now safe
Narrowing the VEH previously unmasked a latent worker-thread teardown access violation in `tests/functional/007.phpt`. That was a real use-after-free race on `future->monitor`, fixed in #381 — so with this stacked on top, `007` passes for the right reason instead of being masked by the catch-all.

### Testing
- Linux suite green (148/148).
- Undefined-function path still covered: `init_fcall_fix_001/002/003`.