### PR TITLE
Fix use-after-free race on `future->monitor` in error paths

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -442,6 +442,12 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 {
 	php_parallel_future_t *future = php_parallel_scheduler_future;
 
+	/* Set once the future has been signalled READY by an error path below, so
+	 * the trailing READY signal is skipped. Signalling twice is a use-after-free
+	 * race: the first signal releases the consumer, which may free the future
+	 * (and its monitor) before the second php_parallel_monitor_set() runs. */
+	volatile bool          ready = false;
+
 	runtime->crashed = 0;
 	runtime->missing = NULL;
 	runtime->file = NULL;
@@ -462,7 +468,9 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 					} else {
 						php_parallel_exceptions_save(frame->return_value, EG(exception));
 
-						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_ERROR);
+						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
+
+						ready = true;
 					}
 				} else {
 					zend_throw_exception_internal(NULL);
@@ -499,6 +507,8 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 					}
 					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
 					php_parallel_monitor_unlock(future->monitor);
+
+					ready = true;
 				}
 
 				// This runtime crashed, as such we can not give any guarantees
@@ -533,7 +543,7 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 	}
 	zend_end_try();
 
-	if (future) {
+	if (future && !ready) {
 		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
 	}
 


### PR DESCRIPTION
Root cause of the Windows worker-thread teardown access violation found via the diagnostic in #380.

### The bug
When a task threw a normal exception (or crashed into the `IllegalInstruction` path), the worker signalled the future **twice** in `php_parallel_scheduler_run()`:
1. `PHP_PARALLEL_ERROR` (resp. `READY|ERROR`) when saving the task error, then
2. an unconditional trailing `php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY)` at the end of the function.

`Future::value()` waits on `READY|FAILURE|ERROR`, so the **first** signal already releases the consumer. The consumer can then tear the future down — freeing `future->monitor` — before the worker reaches the **second** signal, which then dereferences a dangling monitor inside `pthread_cond_signal` → use-after-free.

On Windows this is a hard `0xC0000005` (caught here via a diagnostic backtrace):
```
php_parallel_thread            scheduler.c
 └ php_parallel_scheduler_run  -> monitor_set(future->monitor, PHP_PARALLEL_READY)
    └ php_parallel_monitor_set  monitor.c:93  pthread_cond_signal(&monitor->condition)
       └ <pthreads dll>  -> deref garbage (0x10000000A) -> AV
```
It surfaced in `tests/functional/007.phpt` (bootstrap set inside a task). On Linux the freed memory stayed readable, so it went unnoticed; on Windows it was masked by the catch-all VEH from #355.

### The fix
The error paths now signal `READY|ERROR` exactly **once** and skip the trailing `READY` (guarded by a `ready` flag). Once that single `monitor_set` returns, the worker never touches the future again, closing the window. Setting `READY` in the error path also keeps the future destructor (which waits for `READY`) from blocking when `value()` is never called.

The **success** and **kill** paths are unchanged: they have no early wake and still rely on the trailing `READY`.

### Testing
- Linux suite green (148/148).
- Windows CI on this PR should show `functional/007` passing for the right reason (no AV).

### Related
- Unblocks #379 (narrowing the Windows VEH) — `007` will then pass instead of being masked.
- Supersedes the investigation in #380 (diagnostic, to be closed).