### PR TITLE
Fix: Update `coverallsapp/github-action` from `master` to `v2.3.6`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker compose run parallel-${{matrix.build}}-${{matrix.version}} docker/parallel.test
       - name: Send Coverage
         if: ${{ matrix.build == 'gcov' }}
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ github.workspace }}/coverage.info
@@ -61,7 +61,7 @@ jobs:
         run: docker compose run parallel-${{matrix.build}}-${{matrix.version}} docker/parallel.test -d opcache.enable_cli=1 -d opcache.jit=disable
       - name: Build Coveralls
         if: ${{ matrix.build == 'gcov' }}
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ github.workspace }}/coverage.info
@@ -83,7 +83,7 @@ jobs:
         run: docker compose run parallel-${{matrix.build}}-${{matrix.version}} docker/parallel.test -d opcache.enable_cli=1 -d opcache.jit=function -d opcache.jit_buffer_size=32M
       - name: Build Coveralls
         if: ${{ matrix.build == 'gcov' }}
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ github.workspace }}/coverage.info
@@ -95,7 +95,7 @@ jobs:
     needs: [vanilla, opcache, jit]
     steps:
     - name: Finish Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2.3.6
       with:
-        github-token: ${{ secrets.github_token }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true


### PR DESCRIPTION
Using a pinned stable version `v2.3.6` for `coverallsapp/github-action` again.
Also fixed case inconsistency: `secrets.github_token` -> `secrets.GITHUB_TOKEN`