### PR TITLE
Document source conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,19 @@ To ease reproduction of test cases, development, and CI, parallel has adopted do
 
 parallel requires a ZTS build of PHP which is built as a separate environment upon which the testing environment relies.
 
+Source Conventions
+==================
+
+The source tree deliberately uses a regular module layout. Keep new and modified code consistent with these conventions:
+
+  - Keep each C module in matching `src/<module>.c` and `src/<module>.h` files, including small private headers used only for declarations.
+  - Keep module-specific include guards in both files: `HAVE_PARALLEL_<MODULE>` for C files and `HAVE_PARALLEL_<MODULE>_H` for headers.
+  - Prefix internal symbols with `php_parallel_` and lifecycle identifiers with `PARALLEL_`.
+  - Define lifecycle hooks in pairs: `MINIT` with `MSHUTDOWN`, and `RINIT` with `RSHUTDOWN`. Keep the matching hook even when it is empty, and declare the pair in the module header.
+  - Keep initialization hierarchical: `parallel.c` initializes top-level modules, and each module initializes its own submodules. Preserve lifecycle ordering unless a dependency requires changing it.
+  - Use the `php_parallel_copy_string*` helpers for strings entering persistent or shared state. Allocate reusable internal keys and labels once as persistent interned strings during `MINIT`, rather than allocating them at each use.
+  - Preserve the standard license banner and format C sources and headers with the repository's `.clang-format` configuration.
+
 PHP Services
 ============
 


### PR DESCRIPTION
## Summary
- Document the matching C/header module layout and source include guards.
- Record lifecycle pairing, hierarchy, and ordering conventions.
- Document persistent/shared string interning, symbol naming, license, and formatting conventions.

## Testing
- `git diff --check`
- Verified all 19 C modules have matching headers and source/header include guards.
- Verified all 17 lifecycle modules define `MINIT`/`MSHUTDOWN` and `RINIT`/`RSHUTDOWN` symmetrically when either phase is present.
