### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -27,7 +27,7 @@ jobs:
     name: ASAN, PHP v${{matrix.version}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -27,9 +27,9 @@ jobs:
     name: ASAN, PHP v${{matrix.version}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install clang-format
       run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install clang-format
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,13 +63,13 @@ jobs:
           echo "version=${{ matrix.php.major }}.${{ matrix.php.minor }}.${{ matrix.php.patch }}${{ matrix.php.rc }}" >> $GITHUB_OUTPUT
 
       - name: Repository checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -77,7 +77,7 @@ jobs:
 
       # https://docs.docker.com/build/ci/github-actions/cache/
       - name: Build and export Docker Image
-        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           load: true
           build-args: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
     name: Linux, PHP v${{matrix.version}}, ${{matrix.build}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,9 +30,9 @@ jobs:
     name: Linux, PHP v${{matrix.version}}, ${{matrix.build}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -30,7 +30,7 @@ jobs:
     name: UBSAN, PHP v${{matrix.version}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -30,9 +30,9 @@ jobs:
     name: UBSAN, PHP v${{matrix.version}}, ${{matrix.mode.name}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get the extension matrix
         id: extension-matrix
         uses: php/php-windows-builder/extension-matrix@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 #v1.8.1
@@ -37,7 +37,7 @@ jobs:
       matrix: ${{fromJson(needs.get-extension-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build the extension
         uses: php/php-windows-builder/extension@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 #v1.8.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,10 +21,10 @@ jobs:
       matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Get the extension matrix
         id: extension-matrix
-        uses: php/php-windows-builder/extension-matrix@c89baa7d20ae73f2a022556132c3d6f4b56a89b8 #v1.5.1
+        uses: php/php-windows-builder/extension-matrix@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 #v1.8.1
         with:
           php-version-list: '8.0, 8.1, 8.2, 8.3, 8.4, 8.5'
           arch-list: 'x64, x86'
@@ -37,9 +37,9 @@ jobs:
       matrix: ${{fromJson(needs.get-extension-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Build the extension
-        uses: php/php-windows-builder/extension@c89baa7d20ae73f2a022556132c3d6f4b56a89b8 #v1.5.1
+        uses: php/php-windows-builder/extension@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 #v1.8.1
         with:
           php-version: ${{ matrix.php-version }}
           arch: ${{ matrix.arch }}
@@ -56,7 +56,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     steps:
       - name: Upload artifact to the release
-        uses: php/php-windows-builder/release@c89baa7d20ae73f2a022556132c3d6f4b56a89b8 #v1.5.1
+        uses: php/php-windows-builder/release@e03e5d39879adaeb61ed2225f0f4eae7db8c1df8 #v1.8.1
         with:
           release: ${{ github.event.release.tag_name }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Upgrade actions/checkout to v7
- Upgrade Docker actions to their latest Node.js 24 releases
- Upgrade php/php-windows-builder to v1.8.1
- Keep coverallsapp/github-action at its current latest release, v2.3.6

## Testing

- `actionlint`
- `git diff --check`