### PR TITLE
Add ThreadSanitizer CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,12 +17,15 @@ jobs:
 
     - name: Install clang-format
       run: |
+        . /etc/os-release
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+        echo "deb https://apt.llvm.org/$VERSION_CODENAME/ llvm-toolchain-$VERSION_CODENAME-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y clang-format
+        sudo apt-get install -y clang-format-20
 
     - name: Run clang-format
       run: |
         # Find all C files and run clang-format check
         # -dry-run outputs violations without changing files
         # -Werror makes warnings (violations) exit with non-zero status
-        find src -name '*.c' -o -name '*.h' | xargs clang-format -style=file --dry-run --Werror
+        find src -name '*.c' -o -name '*.h' | xargs clang-format-20 -style=file --dry-run --Werror

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         php:
           - major: 8
@@ -32,8 +33,8 @@ jobs:
             rc: ''
           - major: 8
             minor: 5
-            patch: 0
-            rc: RC2
+            patch: 8
+            rc: ''
         flags:
           - name: asan
             debug: disable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,6 @@ jobs:
     permissions:
       packages: write
     strategy:
-      fail-fast: false
       matrix:
         php:
           - major: 8
@@ -56,14 +55,12 @@ jobs:
             asan: disable
             tsan: disable
             gcov: disable
-          - name: tsan
-            debug: disable
-            asan: disable
-            tsan: enable
-            gcov: disable
         exclude:
           - php: {major: 8, minor: 0}
             flags: {name: asan}
+        include:
+          - php: {major: 8, minor: 5, patch: 8, rc: ''}
+            flags: {name: tsan, debug: disable, asan: disable, tsan: enable, gcov: disable}
 
     steps:
       - name: Prepare build variables

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,18 +38,27 @@ jobs:
           - name: asan
             debug: disable
             asan: enable
+            tsan: disable
             gcov: disable
           - name: dbg
             debug: enable
             asan: disable
+            tsan: disable
             gcov: disable
           - name: gcov
             debug: disable
             asan: disable
+            tsan: disable
             gcov: enable
           - name: release
             debug: disable
             asan: disable
+            tsan: disable
+            gcov: disable
+          - name: tsan
+            debug: disable
+            asan: disable
+            tsan: enable
             gcov: disable
         exclude:
           - php: {major: 8, minor: 0}
@@ -84,6 +93,7 @@ jobs:
             "PHP_SRC_TYPE=dist"
             "PHP_SRC_DEBUG=${{ matrix.flags.debug }}"
             "PHP_SRC_ASAN=${{ matrix.flags.asan }}"
+            "PHP_SRC_TSAN=${{ matrix.flags.tsan }}"
             "PHP_SRC_GCOV=${{ matrix.flags.gcov }}"
             "PHP_VERSION_MAJOR=${{ matrix.php.major }}"
             "PHP_VERSION_MINOR=${{ matrix.php.minor }}"
@@ -98,7 +108,12 @@ jobs:
 
       # https://docs.docker.com/build/ci/github-actions/test-before-push/
       - name: Test Docker Image
-        run: docker run --rm ${{ steps.build-vars.outputs.repository }}:latest php --version
+        run: |
+          if [ "${{ matrix.flags.name }}" = tsan ]; then
+            docker run --rm --security-opt seccomp=unconfined ${{ steps.build-vars.outputs.repository }}:latest php --version
+          else
+            docker run --rm ${{ steps.build-vars.outputs.repository }}:latest php --version
+          fi
 
       - name: Push Docker Image
         run: docker push --all-tags ${{ steps.build-vars.outputs.repository }}

--- a/.github/workflows/frankenphp.yml
+++ b/.github/workflows/frankenphp.yml
@@ -1,0 +1,19 @@
+name: FrankenPHP
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - master
+      - develop
+      - release
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Output bailout recovery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Test aborted output
+        run: docker/frankenphp.test

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,35 @@
+name: ThreadSanitizer
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - master
+      - develop
+      - release
+  schedule:
+    - cron: "30 4 * * *"
+
+env:
+  PHP_BUILD: tsan
+  PHP_VERSION: "8.5"
+  PHP_VERSION_MAJOR: "8"
+  PHP_VERSION_MINOR: "5"
+  PHP_VERSION_PATCH: "0"
+  PHP_VERSION_RC: ""
+  PHP_SRC_TSAN: enable
+  TSAN_OPTIONS: halt_on_error=1:exitcode=1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: TSan, PHP v8.5, vanilla
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build PHP
+        run: docker compose build php
+      - name: Build parallel
+        run: docker compose build parallel
+      - name: Test parallel
+        run: docker compose run --rm -e TSAN_OPTIONS parallel docker/parallel.test

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -11,25 +11,26 @@ on:
     - cron: "30 4 * * *"
 
 env:
-  PHP_BUILD: tsan
-  PHP_VERSION: "8.5"
-  PHP_VERSION_MAJOR: "8"
-  PHP_VERSION_MINOR: "5"
-  PHP_VERSION_PATCH: "0"
-  PHP_VERSION_RC: ""
-  PHP_SRC_TSAN: enable
   TSAN_OPTIONS: halt_on_error=1:exitcode=1
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     runs-on: ubuntu-latest
-    name: TSan, PHP v8.5, vanilla
+    name: TSan, PHP v${{ matrix.version }}, vanilla
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Build PHP
-        run: docker compose build php
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build parallel
-        run: docker compose build parallel
+        run: PHP_BUILD=tsan PHP_VERSION=${{ matrix.version }} docker compose build parallel
       - name: Test parallel
-        run: docker compose run --rm -e TSAN_OPTIONS parallel docker/parallel.test
+        run: PHP_BUILD=tsan PHP_VERSION=${{ matrix.version }} docker compose run --rm -e TSAN_OPTIONS parallel docker/parallel.test

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -11,16 +11,14 @@ on:
     - cron: "30 4 * * *"
 
 env:
+  PHP_BUILD: tsan
+  PHP_VERSION: "8.5"
   TSAN_OPTIONS: halt_on_error=1:exitcode=1
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     runs-on: ubuntu-latest
-    name: TSan, PHP v${{ matrix.version }}, vanilla
+    name: TSan, PHP v8.5, vanilla
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -31,6 +29,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build parallel
-        run: PHP_BUILD=tsan PHP_VERSION=${{ matrix.version }} docker compose build parallel
+        run: docker compose build parallel
       - name: Test parallel
-        run: PHP_BUILD=tsan PHP_VERSION=${{ matrix.version }} docker compose run --rm -e TSAN_OPTIONS parallel docker/parallel.test
+        run: docker compose run --rm -e TSAN_OPTIONS parallel docker/parallel.test

--- a/config.m4
+++ b/config.m4
@@ -12,6 +12,9 @@ PHP_ARG_ENABLE(parallel-address-sanitizer, whether to enable address sanitizer f
 PHP_ARG_ENABLE(parallel-undefined-sanitizer, whether to enable undefined behavior sanitizer flags for parallel,
 [  --enable-parallel-undefined-sanitizer Enable undefined behavior sanitizer flags for parallel], no, no)
 
+PHP_ARG_ENABLE(parallel-thread-sanitizer, whether to enable thread sanitizer flags for parallel,
+[  --enable-parallel-thread-sanitizer Enable thread sanitizer flags for parallel], no, no)
+
 PHP_ARG_ENABLE(parallel-gcov, whether to enable gcov for parallel,
 [  --enable-parallel-gcov              Enable gcov for parallel], no, no)
 
@@ -65,6 +68,11 @@ if test "$PHP_PARALLEL" != "no"; then
     AX_CHECK_COMPILE_FLAG(-fno-omit-frame-pointer,          EXTRA_CFLAGS="$EXTRA_CFLAGS -fno-omit-frame-pointer")
   fi
 
+  if test "$PHP_PARALLEL_THREAD_SANITIZER" != "no"; then
+    AX_CHECK_COMPILE_FLAG(-fsanitize=thread,                EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=thread")
+    AX_CHECK_COMPILE_FLAG(-fno-omit-frame-pointer,          EXTRA_CFLAGS="$EXTRA_CFLAGS -fno-omit-frame-pointer")
+  fi
+
   if test "$PHP_PARALLEL_GCOV" != "no"; then
     AX_CHECK_COMPILE_FLAG(-fprofile-arcs,           EXTRA_CFLAGS="$EXTRA_CFLAGS -fprofile-arcs")
     AX_CHECK_COMPILE_FLAG(-ftest-coverage,          EXTRA_CFLAGS="$EXTRA_CFLAGS -ftest-coverage")
@@ -75,7 +83,7 @@ if test "$PHP_PARALLEL" != "no"; then
   PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
   PHP_ADD_INCLUDE($ext_srcdir)
 
-  if test "$PHP_PARALLEL_GCOV" != "no" || test "$PHP_PARALLEL_UNDEFINED_SANITIZER" != "no"; then
+  if test "$PHP_PARALLEL_GCOV" != "no" || test "$PHP_PARALLEL_UNDEFINED_SANITIZER" != "no" || test "$PHP_PARALLEL_THREAD_SANITIZER" != "no"; then
     PHP_SUBST(EXTRA_CFLAGS)
   fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,12 @@ services:
         PHP_SRC_TYPE: ${PHP_SOURCE:-dist}
         PHP_SRC_DEBUG: ${PHP_SRC_DEBUG:-disable}
         PHP_SRC_ASAN: ${PHP_SRC_ASAN:-disable}
+        PHP_SRC_TSAN: ${PHP_SRC_TSAN:-disable}
         PHP_SRC_GCOV: ${PHP_SRC_GCOV:-disable}
         PHP_VERSION_MAJOR: ${PHP_VERSION_MAJOR:-8}
         PHP_VERSION_MINOR: ${PHP_VERSION_MINOR:-5}
         PHP_VERSION_PATCH: ${PHP_VERSION_PATCH:-0}
-        PHP_VERSION_RC: ${PHP_VERSION_RC:-RC2}
+        PHP_VERSION_RC: ${PHP_VERSION_RC-RC2}
 
   parallel:
     <<: *common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         PHP_VERSION_MAJOR: ${PHP_VERSION_MAJOR:-8}
         PHP_VERSION_MINOR: ${PHP_VERSION_MINOR:-5}
         PHP_VERSION_PATCH: ${PHP_VERSION_PATCH:-0}
-        PHP_VERSION_RC: ${PHP_VERSION_RC-RC2}
+        PHP_VERSION_RC: ${PHP_VERSION_RC:-RC2}
 
   parallel:
     <<: *common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
         PHP_SRC_GCOV: ${PHP_SRC_GCOV:-disable}
         PHP_VERSION_MAJOR: ${PHP_VERSION_MAJOR:-8}
         PHP_VERSION_MINOR: ${PHP_VERSION_MINOR:-5}
-        PHP_VERSION_PATCH: ${PHP_VERSION_PATCH:-0}
-        PHP_VERSION_RC: ${PHP_VERSION_RC:-RC2}
+        PHP_VERSION_PATCH: ${PHP_VERSION_PATCH:-8}
+        PHP_VERSION_RC: ${PHP_VERSION_RC:-}
 
   parallel:
     <<: *common

--- a/docker/frankenphp.dockerfile
+++ b/docker/frankenphp.dockerfile
@@ -1,0 +1,16 @@
+FROM dunglas/frankenphp:1.12.6-php8.5-bookworm AS build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends $PHPIZE_DEPS
+
+COPY config.m4 Makefile.frag php_parallel.c php_parallel.h /usr/src/parallel/
+COPY src/*.c src/*.h /usr/src/parallel/src/
+WORKDIR /usr/src/parallel
+RUN phpize \
+ && ./configure --enable-parallel \
+ && make -j"$(nproc)" \
+ && make install
+
+FROM dunglas/frankenphp:1.12.6-php8.5-bookworm
+COPY --from=build /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+RUN docker-php-ext-enable parallel

--- a/docker/frankenphp.test
+++ b/docker/frankenphp.test
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+image=parallel-frankenphp:test
+name="parallel-frankenphp-test-$$"
+fixture=$(mktemp -d "$PWD/.frankenphp-test.XXXXXX")
+
+cleanup() {
+	docker rm -f "$name" >/dev/null 2>&1 || true
+	rm -rf "$fixture"
+}
+trap cleanup EXIT
+
+mkdir "$fixture/public"
+cat >"$fixture/public/index.php" <<'PHP'
+<?php
+if (!extension_loaded("parallel")) {
+    http_response_code(500);
+    exit("parallel not loaded\n");
+}
+sleep(1);
+echo "hello\n";
+PHP
+cat >"$fixture/Caddyfile" <<'CADDY'
+{
+	auto_https off
+	frankenphp {
+		num_threads 8
+	}
+}
+
+:8080 {
+	root * /test/public
+	php_server
+}
+CADDY
+
+docker build -f docker/frankenphp.dockerfile -t "$image" .
+docker run -d --rm --name "$name" -p 127.0.0.1::8080 \
+	-v "$fixture:/test:ro" "$image" frankenphp run --config /test/Caddyfile >/dev/null
+port=$(docker port "$name" 8080/tcp | awk -F: '{print $NF}')
+
+for _ in {1..30}; do
+	if curl -fsS --max-time 2 "http://127.0.0.1:$port/" >/dev/null 2>&1; then
+		ready=1
+		break
+	fi
+	sleep 0.1
+done
+
+if [ "${ready:-}" != 1 ]; then
+	docker logs "$name"
+	exit 1
+fi
+
+python3 - "$port" <<'PY'
+import socket
+import struct
+import sys
+import time
+
+sockets = []
+for _ in range(8):
+    connection = socket.create_connection(("127.0.0.1", int(sys.argv[1])))
+    connection.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+    sockets.append(connection)
+
+time.sleep(0.2)
+for connection in sockets:
+    connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+    connection.close()
+PY
+
+sleep 2
+response=$(curl -fsS --max-time 3 "http://127.0.0.1:$port/") || {
+	docker logs "$name"
+	exit 1
+}
+test "$response" = hello

--- a/docker/parallel.dockerfile
+++ b/docker/parallel.dockerfile
@@ -13,7 +13,7 @@ ADD . /opt/parallel
 
 WORKDIR /opt/parallel
 
-RUN php -v
+RUN test "$PHP_SRC_TYPE" = tsan || php -v
 
 RUN phpize --clean
 
@@ -23,9 +23,13 @@ RUN mkdir -p /opt/build/parallel
 
 WORKDIR /opt/build/parallel
 
-RUN /opt/parallel/configure --enable-parallel \
+RUN if test "$PHP_SRC_TYPE" = tsan; then \
+        export CC=clang-20 CXX=clang++-20; \
+    fi && \
+    /opt/parallel/configure --enable-parallel \
     --$(test "$PHP_SRC_TYPE" = asan && echo enable || echo disable)-parallel-address-sanitizer \
     --$(test "$PHP_SRC_TYPE" = ubsan && echo enable || echo disable)-parallel-undefined-sanitizer \
+    --$(test "$PHP_SRC_TYPE" = tsan && echo enable || echo disable)-parallel-thread-sanitizer \
     --$(test "$PHP_SRC_TYPE" = gcov && echo enable || echo disable)-parallel-gcov >/dev/null
 
 RUN make -j >/dev/null
@@ -35,6 +39,6 @@ RUN make install >/dev/null
 RUN echo "extension=parallel.so" > \
         /opt/etc/php.d/parallel.ini
 
-RUN php -m
+RUN test "$PHP_SRC_TYPE" = tsan || php -m
 
 WORKDIR /opt/parallel

--- a/docker/php.dockerfile
+++ b/docker/php.dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /opt/etc/php.d
 
 ENV PATH=/opt/bin:$PATH
 
-RUN if [ "$PHP_SRC_TSAN" != enable ] && [ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]; then \
+RUN if [ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]; then \
         echo "zend_extension=opcache.so" > /opt/etc/php.d/opcache.ini; \
     fi
 

--- a/docker/php.dockerfile
+++ b/docker/php.dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /opt/etc/php.d
 
 ENV PATH=/opt/bin:$PATH
 
-RUN if [ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]; then \
+RUN if [ "$PHP_SRC_TSAN" != enable ] && [ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]; then \
         echo "zend_extension=opcache.so" > /opt/etc/php.d/opcache.ini; \
     fi
 

--- a/docker/php.dockerfile
+++ b/docker/php.dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ARG PHP_SRC_TYPE
 ARG PHP_SRC_DEBUG
 ARG PHP_SRC_ASAN
+ARG PHP_SRC_TSAN
 ARG PHP_SRC_GCOV
 ARG PHP_VERSION_MAJOR
 ARG PHP_VERSION_MINOR
@@ -12,6 +13,13 @@ ARG PHP_VERSION_RC
 RUN apt-get update
 
 RUN apt-get -y install bash git wget build-essential autoconf pkg-config bison re2c
+
+RUN if test "$PHP_SRC_TSAN" = enable; then \
+        wget -qO /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key && \
+        echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm.list && \
+        apt-get update && \
+        apt-get -y install clang-20 llvm-20; \
+    fi
 
 RUN mkdir -p /opt/src
 RUN mkdir -p /opt/bin
@@ -25,7 +33,10 @@ WORKDIR /opt/src/php-src
 
 RUN ./buildconf --force >/dev/null
 
-RUN ./configure --disable-all \
+RUN if [ "$PHP_SRC_TSAN" = enable ]; then \
+        export CC=clang-20 CXX=clang++-20; \
+    fi && \
+    ./configure --disable-all \
                 --disable-cgi \
                 --disable-phpdbg \
                 --$PHP_SRC_DEBUG-debug \
@@ -37,9 +48,17 @@ RUN ./configure --disable-all \
                 --with-config-file-scan-dir=/opt/etc/php.d \
                 --with-config-file-path=/opt/etc
 
-RUN make -j >/dev/null
+RUN if test "$PHP_SRC_TSAN" = enable; then \
+        make -j EXTRA_CFLAGS="-O1 -g -fsanitize=thread -fno-omit-frame-pointer" >/dev/null; \
+    else \
+        make -j >/dev/null; \
+    fi
 
-RUN make install
+RUN if test "$PHP_SRC_TSAN" = enable; then \
+        make install EXTRA_CFLAGS="-O1 -g -fsanitize=thread -fno-omit-frame-pointer"; \
+    else \
+        make install; \
+    fi
 
 RUN cp php.ini-development /opt/etc/php.ini
 
@@ -51,8 +70,8 @@ RUN if [ "$PHP_VERSION_MAJOR" -eq 8 ] && [ "$PHP_VERSION_MINOR" -lt 5 ]; then \
         echo "zend_extension=opcache.so" > /opt/etc/php.d/opcache.ini; \
     fi
 
-RUN php -v
+RUN test "$PHP_SRC_TSAN" = enable || php -v
 
-RUN php --ini
+RUN test "$PHP_SRC_TSAN" = enable || php --ini
 
 WORKDIR /opt

--- a/src/check.c
+++ b/src/check.c
@@ -83,9 +83,9 @@ static zend_always_inline const char *php_parallel_check_opcode_name(zend_uchar 
 
 static zend_always_inline bool php_parallel_check_type(zend_type type)
 { /* {{{ */
-	zend_string *name;
-	zend_type   *single;
-	zend_class_entry *class;
+	zend_string              *name;
+	zend_type                *single;
+	zend_class_entry         *class;
 	php_parallel_check_type_t check, *checked;
 
 	if (ZEND_TYPE_HAS_LIST(type)) {

--- a/src/check.c
+++ b/src/check.c
@@ -83,9 +83,9 @@ static zend_always_inline const char *php_parallel_check_opcode_name(zend_uchar 
 
 static zend_always_inline bool php_parallel_check_type(zend_type type)
 { /* {{{ */
-	zend_string              *name;
-	zend_type                *single;
-	zend_class_entry         *class;
+	zend_string *name;
+	zend_type   *single;
+	zend_class_entry *class;
 	php_parallel_check_type_t check, *checked;
 
 	if (ZEND_TYPE_HAS_LIST(type)) {

--- a/src/copy.c
+++ b/src/copy.c
@@ -122,7 +122,7 @@ zend_class_entry *php_parallel_copy_scope(zend_class_entry *class)
 		}
 	}
 
-	if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong)class))) {
+	if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong) class))) {
 		return scope;
 	}
 
@@ -147,7 +147,7 @@ zend_class_entry *php_parallel_copy_scope(zend_class_entry *class)
 		return php_parallel_copy_type_unavailable_ce;
 	}
 
-	return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong)class, scope);
+	return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong) class, scope);
 }
 
 static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, bool persistent)

--- a/src/copy.c
+++ b/src/copy.c
@@ -122,7 +122,7 @@ zend_class_entry *php_parallel_copy_scope(zend_class_entry *class)
 		}
 	}
 
-	if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong) class))) {
+	if ((scope = zend_hash_index_find_ptr(&PCG(scope), (zend_ulong)class))) {
 		return scope;
 	}
 
@@ -147,7 +147,7 @@ zend_class_entry *php_parallel_copy_scope(zend_class_entry *class)
 		return php_parallel_copy_type_unavailable_ce;
 	}
 
-	return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong) class, scope);
+	return zend_hash_index_update_ptr(&PCG(scope), (zend_ulong)class, scope);
 }
 
 static zend_always_inline zend_long php_parallel_copy_resource_ctor(zend_resource *source, bool persistent)

--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -21,7 +21,7 @@
 #include "parallel.h"
 
 struct _php_parallel_exception_t {
-	zval                        class;
+	zval class;
 	zval                        file;
 	zval                        line;
 	zval                        code;

--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -21,7 +21,7 @@
 #include "parallel.h"
 
 struct _php_parallel_exception_t {
-	zval class;
+	zval                        class;
 	zval                        file;
 	zval                        line;
 	zval                        code;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -34,7 +34,13 @@ int     php_parallel_monitor_lock(php_parallel_monitor_t *monitor) { return pthr
 
 int32_t php_parallel_monitor_check(php_parallel_monitor_t *monitor, int32_t state)
 {
-	return (monitor->state & (state));
+	int32_t result;
+
+	pthread_mutex_lock(&monitor->mutex);
+	result = monitor->state & state;
+	pthread_mutex_unlock(&monitor->mutex);
+
+	return result;
 }
 
 int     php_parallel_monitor_unlock(php_parallel_monitor_t *monitor) { return pthread_mutex_unlock(&monitor->mutex); }

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -22,9 +22,9 @@
 #include <stdint.h>
 
 typedef struct _php_parallel_monitor_t {
-	pthread_mutex_t  mutex;
-	pthread_cond_t   condition;
-	int32_t          state;
+	pthread_mutex_t mutex;
+	pthread_cond_t  condition;
+	int32_t         state;
 } php_parallel_monitor_t;
 
 #define PHP_PARALLEL_READY (1 << 0)

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -24,7 +24,7 @@
 typedef struct _php_parallel_monitor_t {
 	pthread_mutex_t  mutex;
 	pthread_cond_t   condition;
-	volatile int32_t state;
+	int32_t          state;
 } php_parallel_monitor_t;
 
 #define PHP_PARALLEL_READY (1 << 0)

--- a/src/parallel.c
+++ b/src/parallel.c
@@ -40,13 +40,18 @@ static php_sapi_deactivate_t php_sapi_deactivate_function;
 static php_sapi_output_t     php_sapi_output_function;
 
 static pthread_mutex_t       php_parallel_output_mutex = PTHREAD_MUTEX_INITIALIZER;
+static TSRM_TLS bool         php_parallel_output_locked = false;
 
 static size_t                php_parallel_output_function(const char *str, size_t len)
 {
 	size_t result;
 
 	pthread_mutex_lock(&php_parallel_output_mutex);
+	php_parallel_output_locked = true;
+
 	result = php_sapi_output_function(str, len);
+
+	php_parallel_output_locked = false;
 	pthread_mutex_unlock(&php_parallel_output_mutex);
 
 	return result;
@@ -228,10 +233,10 @@ PHP_RSHUTDOWN_FUNCTION(PARALLEL_CORE)
 
 	PHP_RSHUTDOWN(PARALLEL_COPY)(INIT_FUNC_ARGS_PASSTHRU);
 
-	// In case of a `zend_bailout()` this mutex could still be locked, so we
-	// unlock it just in case.
-	// See https://github.com/krakjoe/parallel/issues/313 for more details
-	if (UNEXPECTED(CG(unclean_shutdown) == 1)) {
+	// A `zend_bailout()` from the SAPI writer skips the normal unlock.
+	// See https://github.com/krakjoe/parallel/issues/313 for more details.
+	if (UNEXPECTED(CG(unclean_shutdown) == 1 && php_parallel_output_locked)) {
+		php_parallel_output_locked = false;
 		pthread_mutex_unlock(&php_parallel_output_mutex);
 	}
 


### PR DESCRIPTION
## Summary
- Publish a reusable PHP 8.5.8 base image built with Clang 20 ThreadSanitizer instrumentation from the existing Docker matrix.
- Build the current `parallel.so` from each pull request against that image and run a dedicated vanilla TSan job that fails on sanitizer reports.
- Synchronize monitor state reads and restrict emergency SAPI output mutex recovery to the thread that owns the mutex.
- Add a FrankenPHP regression test for client disconnects during SAPI output.
- Pin formatting CI to Clang Format 20 so local and upstream formatting agree.\n- Keep the existing GCC-based builds unchanged.

## PHP version scope
TSan intentionally runs only on PHP 8.5. PHP 8.4 and older load extensions with `RTLD_DEEPBIND`, which is incompatible with the sanitizer runtime. PHP 8.5 stopped using `RTLD_DEEPBIND` for the CLI when `dlmopen()` is available, allowing TSan to instrument PHP and `parallel.so` without carrying a patched PHP build.

## Verification
- Published `ghcr.io/krakjoe/php-tsan-8.5:8.5.8` and confirmed the image starts successfully under TSan.
- Passed all 147 release tests on PHP 8.5.8.
- Passed all 147 local TSan tests without diagnostics.
- Reproduced the original FrankenPHP deadlock by removing bailout recovery, then confirmed the ownership-aware recovery remains responsive after eight aborted requests.

## Addressed findings
`php_parallel_monitor_check()` previously read `php_parallel_monitor_t::state` without synchronization while writers held the monitor mutex. The state is now consistently protected by the recursive monitor mutex instead of relying on `volatile`.

The SAPI bailout recovery previously unlocked `php_parallel_output_mutex` after every unclean shutdown, including cancellation bailouts where the current thread did not own the mutex. Thread-local ownership now limits recovery to bailouts that interrupted the SAPI writer while preserving the FrankenPHP client-disconnect behavior from #313.
