### PR TITLE
Fix future cleanup use-after-free

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -425,11 +425,9 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 {
 	php_parallel_future_t *future = php_parallel_scheduler_future;
 
-	/* Set once the future has been signalled READY by an error path below, so
-	 * the trailing READY signal is skipped. Signalling twice is a use-after-free
-	 * race: the first signal releases the consumer, which may free the future
-	 * (and its monitor) before the second php_parallel_monitor_set() runs. */
-	volatile bool          ready = false;
+	/* READY allows the consumer to destroy the future, so publish it only after
+	 * the worker's final access through frame->return_value. */
+	volatile int32_t       future_state = PHP_PARALLEL_READY;
 
 	runtime->crashed = 0;
 	runtime->missing = NULL;
@@ -451,9 +449,7 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 					} else {
 						php_parallel_exceptions_save(frame->return_value, EG(exception));
 
-						php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
-
-						ready = true;
+						future_state |= PHP_PARALLEL_ERROR;
 					}
 				} else {
 					zend_throw_exception_internal(NULL);
@@ -488,10 +484,9 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 						php_parallel_exceptions_save(frame->return_value, exception);
 						OBJ_RELEASE(exception);
 					}
-					php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY | PHP_PARALLEL_ERROR);
 					php_parallel_monitor_unlock(future->monitor);
 
-					ready = true;
+					future_state |= PHP_PARALLEL_ERROR;
 				}
 
 				// This runtime crashed, as such we can not give any guarantees
@@ -526,8 +521,8 @@ static void php_parallel_scheduler_run(php_parallel_runtime_t *runtime, zend_exe
 	}
 	zend_end_try();
 
-	if (future && !ready) {
-		php_parallel_monitor_set(future->monitor, PHP_PARALLEL_READY);
+	if (future) {
+		php_parallel_monitor_set(future->monitor, future_state);
 	}
 
 	php_parallel_scheduler_future = NULL;


### PR DESCRIPTION
## Summary
- defer publishing the future's `READY` state until the worker has finished accessing `frame->return_value`
- publish `READY` and `ERROR` together once after task cleanup
- preserve the success and crash behavior while preventing the consumer from freeing the future during worker cleanup

## Context
This fixes the heap-use-after-free reported by [the failing PHP 8.3 ASan job](https://github.com/krakjoe/parallel/actions/runs/30074193741/job/89421284754) in [`tests/functional/007.phpt`](https://github.com/krakjoe/parallel/blob/develop/tests/functional/007.phpt). The worker signalled `READY|ERROR` before its final access through `frame->return_value`, allowing request shutdown to destroy the future while the worker still referenced its embedded value.

## Testing
- PHP 8.5 release suite: 147/147 passed
- `tests/functional/007.phpt`: passed
- formatting and `git diff --check`: passed
- PHP 8.3 ASan could not run locally because Docker exhausted memory under amd64 emulation; draft PR CI will verify it
