### PR TITLE
fix: support packed arrays on PHP 8.6

### DIFF
--- a/src/copy.c
+++ b/src/copy.c
@@ -220,7 +220,7 @@ static zend_always_inline HashTable *php_parallel_copy_hash_persistent_inline(
 		return ht;
 	}
 
-#ifdef HT_PACKED_SIZE
+#if PHP_VERSION_ID >= 80200
 	// if array is packed, copy it as packed
 	if (HT_IS_PACKED(ht)) {
 		HT_SET_DATA_ADDR(ht, php_parallel_copy_memory_func(HT_GET_DATA_ADDR(source),
@@ -301,7 +301,7 @@ static zend_always_inline HashTable *php_parallel_copy_hash_thread(HashTable *so
 
 	HT_SET_DATA_ADDR(ht, emalloc(HT_SIZE(ht)));
 	memcpy(HT_GET_DATA_ADDR(ht), HT_GET_DATA_ADDR(source), HT_HASH_SIZE(ht->nTableMask));
-#ifdef HT_PACKED_SIZE
+#if PHP_VERSION_ID >= 80200
 	if (HT_IS_PACKED(ht)) {
 		zval *p = ht->arPacked, *q = source->arPacked, *p_end = p + ht->nNumUsed;
 		for (; p < p_end; p++, q++) {
@@ -388,7 +388,7 @@ void php_parallel_copy_hash_dtor(HashTable *table, bool persistent)
 #endif
 		}
 
-#ifdef HT_PACKED_SIZE
+#if PHP_VERSION_ID >= 80200
 		if (HT_IS_PACKED(table)) {
 			zval *p = table->arPacked, *end = p + table->nNumUsed;
 			while (p < end) {

--- a/tests/base/075.phpt
+++ b/tests/base/075.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Copy packed array return value
+--SKIPIF--
+<?php
+if (!extension_loaded('parallel')) {
+	echo 'skip';
+}
+?>
+--FILE--
+<?php
+var_dump((new parallel\Runtime())->run(static fn() => [1.1, 2.2, 3.3, 4])->value());
+?>
+--EXPECT--
+array(4) {
+  [0]=>
+  float(1.1)
+  [1]=>
+  float(2.2)
+  [2]=>
+  float(3.3)
+  [3]=>
+  int(4)
+}


### PR DESCRIPTION
## What and why

PHP 8.6 changed `HT_PACKED_SIZE` from a macro to an inline function in https://github.com/php/php-src/pull/22305. `parallel` used `#ifdef HT_PACKED_SIZE` around its packed-array copy and destruction paths, so those paths were silently compiled out on PHP 8.6. Packed zvals were then interpreted as `Bucket` structures, causing invalid string-key pointers and segmentation faults when transferring packed arrays between runtimes.

## Implementation

Replace the three `#ifdef HT_PACKED_SIZE` checks with `#if PHP_VERSION_ID >= 80200` around persistent copying, thread-local copying, and destruction of packed arrays. PHP 8.0 and 8.1 use the older `HashTable` representation without `arPacked`, PHP 8.2 through 8.5 expose the packed-array API as macros, while PHP 8.6 exposes it as inline functions.

Add a regression that returns a packed array containing floats and an integer from a runtime.